### PR TITLE
Added MacOS-specific check for ClamXav

### DIFF
--- a/include/tests_malware
+++ b/include/tests_malware
@@ -196,33 +196,6 @@
 #
 #################################################################################
 #
-# ClamXav (Mac OS X Specific)
-#
-#################################################################################
-#
-#    Test        : MALW-3299
-#    Description : Check for ClamXav
-#
-#################################################################################
-    Register --test-no MALW-3299 --weight L --network NO --description "Check for ClamXav"
-    if [ ${SKIPTEST} -eq 0 ]; then
-        if [ "${OS}" -eq "MacOS" ]; then
-            CLAMSCANBINARY=`ls /Applications/ClamXav.app/Contents/Resources/ScanningEngine/bin`
-            if [ ! "${CLAMSCANBINARY}" = "" ]; then
-                logtext "Result: Found ClamXav clamscan installed"
-                Display --indent 2 --text "- Checking presence of ClamXav AV scanner" --result
-                MALWARE_SCANNER_INSTALLED=1
-                AddHP 3 3
-            else
-                logtext "Result: ClamXav malware scanner not found"
-                Display --indent 2 --text "- Checking presence of ClamXav AV scanner" --result
-                AddHP 0 3
-            fi
-        fi
-    fi
-
-#################################################################################
-#
 # Other projects: maldetect (rfxn)
 #
 #################################################################################


### PR DESCRIPTION
Atomic changes.  ;-)

I wiped out the other Lynis-1 repository, and re-forked from source repo.  This pull-request adds the MacOS check for ClamXav to include/tests_malware.
