### PR TITLE
Minor tweak to glsa-check to show '0' when all tests are compliant

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -816,7 +816,7 @@
             logtext "Result: found /usr/bin/glsa-check"
             logtext "Test: checking if there are any vulnerable packages"
             # glsa-check reports the GLSA date/ID string, not the vulnerable package.
-            FIND=`/usr/bin/glsa-check -t all 2>&1 | grep -v "This system is affected by the following GLSAs:" | wc -l`
+            FIND=`/usr/bin/glsa-check -t all 2>&1 | grep -v "This system is affected by the following GLSAs:" | grep -v "This system is not affected by any of the listed GLSAs" | wc -l`
             if [ "${FIND}" = "" ]; then
                 logtext "Result: unexpected result: wc should report 0 if no vulnerable packages found."
                 ReportSuggestion ${TEST_NO} "Check if system is up-to-date, security updates check (glsa-check) gives and unexpected result"


### PR DESCRIPTION
As the subject says....

Currently the test expects all responses to include text that indicates GLSAs exist.  This just adds text exclusion when NO GLSAs are present.

Tested on both vulnerable and non-vulnerable gentoo systems.  Reports when GLSAs are applicable, as expected, on vulnerable systems.  Also report that no GLSas are applicable for systems that are clean.
