### PR TITLE
Modifications on test_logging and test_shells

### DIFF
--- a/include/tests_logging
+++ b/include/tests_logging
@@ -274,7 +274,7 @@
     Register --test-no LOGG-2150 --weight L --preqs-met ${PREQS_MET} --network NO --description "Checking directories in logrotate configuration"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: Checking which directories can be found in logrotate configuration"
-        FIND=`${LOGROTATEBINARY} -d -v /etc/logrotate.conf 2>&1 | egrep "considering log|skipping" | grep -v '*' | sort | uniq | awk '{ if ($2=="log") { print $3 } }' | sed 's/\/*[a-zA-Z_.-]*$//g' | sort | uniq`
+        FIND=`${LOGROTATEBINARY} -d -v /etc/logrotate.conf 2>&1 | egrep "considering log|skipping" | grep -v '*' | sort | uniq | awk '{ if ($2=="log") { print $3 } }' | sed 's@/[^/]*$@@g' | sort | uniq`
         if [ "${FIND}" = "" ]; then
             logtext "Result: nothing found"
           else

--- a/include/tests_shells
+++ b/include/tests_shells
@@ -226,32 +226,86 @@
 #
 #################################################################################
 #
-
     # Test        : SHLL-6240
     # Description : Check default umask
-#    Register --test-no SHLL-6240 --weight L --network NO --description "Check default umask"
-#    if [ ${SKIPTEST} -eq 0 ]; then
-#        logtext "Test: Checking /etc/profile"
-#	if [ -f /etc/profile ]; then
-#    	    FIND=`grep "^umask" | awk '{ print $2 }'`
-#    	    if [ "${FIND}" = "" ]; then
-#		logtext "Result: xxx"
-#  		Display --indent 2 --text "- Checking default umask" --result OK --color GREEN
-#              else
-#		logtext "Result: xxx"
-#    		Display --indent 2 --text "- Checking default umask" --result WARNING --color RED
-#		#ReportWarning ${TEST_NO} "M" "xxx"
-#		#ReportSuggestion ${TEST_NO} "xxx"
-#	    fi
-#	fi
-#    fi
+    Register --test-no SHLL-6240 --weight L --network NO --description "Check default umask"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        logtext "Test: Checking /etc/profile ..."
+	if [ -f /etc/profile ]; then
+            FIND=`grep "^umask" /etc/profile | awk '{ print $2 }'`
+            if [ "${FIND}" = "" ]; then
+                logtext "Result: not found"
+                Display --indent 2 --text "- Checking default umask in /etc/profile ... " --result OK --color GREEN
+              else
+                case ${FIND} in
+                        022|0022|027|0027|077|0077)
+                                umresult=OK
+                                umcolor=GREEN
+                                ;;
+                        *)
+                                umresult=WARNING
+                                umcolor=RED
+                                ;;
+                esac				
+                logtext "Result: ${FIND}"
+                Display --indent 2 --text "- Checking default umask /etc/profile ... " --result ${umresult} --color ${umcolor}
+            fi
+        fi
+    fi
 #
 #################################################################################
 #
     # Test        : SHLL-6250
     # Description : Check /etc/bash.bashrc
-#    Register --test-no SHLL-6250 --weight L --network NO --description "Check default umask"
-#    if [ ${SKIPTEST} -eq 0 ]; then
+    Register --test-no SHLL-6250 --weight L --network NO --description "Check default umask"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        logtext "Test: Checking /etc/bash.bashrc and /etc/bashrc ..."
+        if [ -f /etc/bash.bashrc ]; then
+            FIND=`grep "^umask" /etc/bash.bashrc | awk '{ print $2 }'`
+            if [ "${FIND}" = "" ]; then
+                logtext "Result: not found"
+                Display --indent 2 --text "- Checking default umask in /etc/bash.bashrc ... " --result OK --color GREEN
+              else
+                case ${FIND} in
+                        022|0022|027|0027|077|0077)
+                                umresult=OK
+                                umcolor=GREEN
+                                ;;
+                        *)
+                                umresult=WARNING
+                                umcolor=RED
+                                ;;
+                esac
+                logtext "Result: ${FIND}"
+                Display --indent 2 --text "- Checking default umask in /etc/bash.bashrc ... " --result ${umresult} --color ${umcolor}
+                #ReportWarning ${TEST_NO} "M" "xxx"
+                #ReportSuggestion ${TEST_NO} "xxx"
+            fi
+        fi
+		        if [ -f /etc/bashrc ]; then
+            FIND=`grep "^umask" /etc/bashrc | awk '{ print $2 }'`
+            if [ "${FIND}" = "" ]; then
+                logtext "Result: not found"
+                Display --indent 2 --text "- Checking default umask in /etc/bashrc ... " --result OK --color GREEN
+              else
+                case ${FIND} in
+                        022|0022|027|0027|077|0077)
+                                umresult=OK
+                                umcolor=GREEN
+                                ;;
+                        *)
+                                umresult=WARNING
+                                umcolor=RED
+                                ;;
+                esac
+                logtext "Result: ${FIND}"
+                Display --indent 2 --text "- Checking default umask in /etc/bashrc ... " --result ${umresult} --color ${umcolor}
+                #ReportWarning ${TEST_NO} "M" "xxx"
+                #ReportSuggestion ${TEST_NO} "xxx"
+            fi
+        fi
+    fi
+
 #
 #################################################################################
 #


### PR DESCRIPTION
Modification on test_logging in order to check correctly subdirectories in /var/log containing a number in subdirectory's name (LOGG-2150).

Modification on test_shells to check 'umask' values in '/etc/profile' and '/etc/bash.bashrc' (SHLL-6240 and SHLL-6250)