### PR TITLE
Update check for sulogin under systemd.

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -702,7 +702,7 @@
          if [ -f /usr/lib/systemd/system/rescue.service ]; then
              logtext "Result: file /usr/lib/systemd/system/rescue.service"
              logtext "Test: checking presence sulogin for single user mode"
-             FIND=`egrep "^ExecStart=-(/usr)?/sbin/sulogin" /usr/lib/systemd/system/rescue.service`
+             FIND=`egrep "^ExecStart=-(/bin/sh -c \")?(/usr)?/(s)?bin/sulogin" /usr/lib/systemd/system/rescue.service`
              if [ ! "${FIND}" = "" ]; then
                  FOUND=1
                  logtext "Result: found sulogin, so single user is protected"


### PR DESCRIPTION
The default rescue.service unit file was updated
in the systemd repo on Jan 23, 2015
to allow for sulogin location variability.