### PR TITLE
Pass information about locate prereqs to Register.

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -538,7 +538,7 @@
     #                       or /var/cache/locate/locatedb
     #               FreeBSD /var/db/locate.database
     if [ ! "${LOCATEBINARY}" = "" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
-    Register --test-no FILE-6410 --os Linux --weight L --network NO --description "Checking Locate database"
+    Register --test-no FILE-6410 --preqs-met ${PREQS_MET} --os Linux --weight L --network NO --description "Checking Locate database"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: Checking locate database"
         FOUND=0


### PR DESCRIPTION
Prevent the locate test from running spuriously when locate is not present.