### PR TITLE
OWNER?ID fails on FreeBSD

### DIFF
--- a/lynis
+++ b/lynis
@@ -86,8 +86,8 @@
     PERMS2=`ls -l ${INCLUDEDIR}/functions | cut -c 2-10`
     OWNER=`ls -l ${INCLUDEDIR}/consts | awk -F" " '{ print $3 }'`
     OWNER2=`ls -l ${INCLUDEDIR}/functions | awk -F" " '{ print $3 }'`
-    OWNERID=`ls -n ${INCLUDEDIR}/consts | awk -F" " '{ print $3 }'`
-    OWNER2ID=`ls -n ${INCLUDEDIR}/functions | awk -F" " '{ print $3 }'`
+    OWNERID=`ls -ln ${INCLUDEDIR}/consts | awk -F" " '{ print $3 }'`
+    OWNER2ID=`ls -ln ${INCLUDEDIR}/functions | awk -F" " '{ print $3 }'`
 
     ISSUE=0
     SHOWPERMERROR=0


### PR DESCRIPTION
On FreeBSD, the -n flag to 'ls' only works in combination with -l.
So the following code returns *nothing*;

    # ls -n include/consts | awk -F" " '{ print $3 }'

However, if we change it to ‘ln -ln’, it works;

    # ls -ln include/consts | awk -F" " '{ print $3 }'
    0