### PR TITLE
Fix false positive matches with unsafe ports on SQD-3624

### DIFF
--- a/include/tests_squid
+++ b/include/tests_squid
@@ -265,7 +265,7 @@
             #SQUID_DAEMON_UNSAFE_PORTS_LIST
             for I in ${SQUID_DAEMON_UNSAFE_PORTS_LIST}; do
                 logtext "Test: Checking port ${I} in Safe_ports list"
-                FIND2=`grep "^acl Safe_ports port ${I}" ${SQUID_DAEMON_CONFIG}`
+                FIND2=`grep -w "^acl Safe_ports port ${I}" ${SQUID_DAEMON_CONFIG}`
                 if [ "${FIND2}" = "" ]; then
                     Display --indent 6 --text "- Checking ACL 'Safe_ports' (port ${I})" --result "NOT FOUND" --color GREEN
                     AddHP 1 1


### PR DESCRIPTION
The grep statement needs to be modified to prevent tagging port values that contains a value in `SQUID_DAEMON_UNSAFE_PORTS_LIST` but aren't actually equal to the listed port value