### PR TITLE
Fix STRG-1840 (Check for disabled USB storage)

### DIFF
--- a/include/tests_storage
+++ b/include/tests_storage
@@ -33,7 +33,7 @@
         if [ -d /etc/modprobe.d ]; then
             FIND=`ls /etc/modprobe.d/* 2> /dev/null`
             if [ ! "${FIND}" = "" ]; then
-                FIND=`grep -r "install usb-storage /bin/(false|true)" /etc/modprobe.d/* | grep "usb-storage" | grep -v "#"`
+                FIND=`grep -r "install usb-storage /bin/\(false\|true\)" /etc/modprobe.d/* | grep "usb-storage" | grep -v "#"`
                 FIND2=`egrep -r "^blacklist (usb_storage|usb-storage)" /etc/modprobe.d/*`
                 if [ ! "${FIND}" = "" -o ! "${FIND2}" = "" ]; then
                     FOUND=1
@@ -44,7 +44,7 @@
             fi
         fi
         if [ -f /etc/modprobe.conf ]; then
-            FIND=`grep "install usb-storage /bin/(false|true)" /etc/modprobe.conf | grep "usb-storage" | grep -v "#"`
+            FIND=`grep "install usb-storage /bin/\(false\|true\)" /etc/modprobe.conf | grep "usb-storage" | grep -v "#"`
             if [ ! "${FIND}" = "" ]; then
                 FOUND=1
                 logtext "Result: found usb-storage driver in disabled state"


### PR DESCRIPTION
By default, grep uses basic regular expressions (BRE). BRE needs '(', '|', and ')' escaped.