### PR TITLE
Comparison error when Docker is present, but the daemon is not running (or unset).

### DIFF
--- a/include/tests_containers
+++ b/include/tests_containers
@@ -119,6 +119,9 @@
         # Check total of containers
         logtext "Test: checking total amount of Docker containers"
         DOCKER_CONTAINERS_TOTAL=`${DOCKERBINARY} info 2> /dev/null | grep "^Containers: " | awk '{ print $2 }'`
+        if [ ${DOCKER_CONTAINERS_TOTAL} -z ]; then
+            DOCKER_CONTAINERS_TOTAL=0
+        fi
         logtext "Result: docker info shows ${DOCKER_CONTAINERS_TOTAL} containers"
         DOCKER_CONTAINERS_TOTAL2=`${DOCKERBINARY} ps -a 2> /dev/null | grep -v "CONTAINER" | wc -l`
         logtext "Result: docker ps -a shows ${DOCKER_CONTAINERS_TOTAL2} containers"
@@ -131,7 +134,7 @@
         fi
 
         # Check running instances
-        DOCKER_CONTAINERS_RUNNING=`${DOCKERBINARY} ps | grep -v "CONTAINER" | wc -l`
+        DOCKER_CONTAINERS_RUNNING=`${DOCKERBINARY} ps 2> /dev/null | grep -v "CONTAINER" | wc -l`
         Display --indent 8 --text "- Running containers" --result "${DOCKER_CONTAINERS_RUNNING}" --color GREEN
         if [ ${DOCKER_CONTAINERS_RUNNING} -gt 0 ]; then
             logtext "Result: ${DOCKER_CONTAINERS_RUNNING} containers are currently active"


### PR DESCRIPTION
When running the Container tests;

If the Docker binary is present but when the Docker daemon is not running, or DOCKER_HOST unset, the Container tests logs two error-messages, as shown below: 

```
[+] Containers
------------------------------------
        - Docker info output (warnings)                       [ NONE ]
      - Containers
        - Total containers                                    [ UNKNOWN ]
time="2015-07-24T23:30:13+02:00" level=fatal msg="Cannot connect to the Docker daemon. Is 'docker -d' running on this host?"
        - Running containers                                  [        0 ]
./include/tests_containers: line 145: [: -gt: unary operator expected

[+] Custom Tests
------------------------------------
  - Running custom tests...                                   [ NONE ]

```


With this pull request an extra test for the DOCKER_CONTAINERS_TOTAL variable is added (set DOCKER_CONTAINERS_TOTAL to the int 0, if string zero), which clears the integer -gt test.

Secondly, STDERR redirection to /dev/null is added for the command that sets DOCKER_CONTAINERS_RUNNING, to eliminate the "Cannot connect to the Docker daemon" error.
