### PR TITLE
More reliable and often faster check to determine virtualization.

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -590,6 +590,19 @@
         # 0 = no, 1 = yes, 2 = unknown
         ISVIRTUALMACHINE=2; VMTYPE="unknown"; VMFULLTYPE="Unknown"
 
+        # Trying facter
+        if [ -x /usr/bin/facter ]; then
+            case "`facter is_virtual`" in
+            "true")
+                VMTYPE=`facter virtual`
+                logtext "Result: found virtual machine (type: ${VMTYPE})"
+                report "vm=1"
+                report "vmtype=${VMTYPE}"
+                return ;;
+            "false") return ;;
+            esac
+        fi
+
         SHORT=""
 
         # Trying systemd
@@ -600,6 +613,13 @@
                 SHORT="${FIND}"
             fi
         fi
+
+        # # dmidecode
+        # if [ "${SHORT}" = "" ]; then
+        #     if [ -x /usr/sbin/dmidecode ]; then
+        #         SHORT=`dmidecode -s system-product-name`
+        #     fi
+        # fi
 
         # lshw
         if [ "${SHORT}" = "" ]; then


### PR DESCRIPTION
Lynis contains a check to determine whether the server is virtualized or not. On a bare metal machine, lshw can take over 10 seconds. Especially if you run `lynis update info` to check if you have the latest Lynis installed, this is undesirable. 
Much faster than `lshw` would be `dmidecode -s system-product-name`, but I'm not sure if the output could be 100% reliable be interpreted. If the system has facter installed (part of Puppet), then this will be a much more reliable and faster way to check virtualization.