### PR TITLE
/usr/sbin/httpd on OpenBSD is builtin non-Apache webserver, do not ru…

### DIFF
--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -50,9 +50,13 @@
     # Test        : HTTP-6622
     # Description : Test for Apache installation
     # Notes       : Do not run on NetBSD, -v is unknown option for httpd binary
+    #		    On OpenBSD do not run /usr/sbin/httpd with -v: builtin non-Apache
     if [ ! "${OS}" = "NetBSD" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no HTTP-6622 --preqs-met ${PREQS_MET} --weight L --network NO --description "Checking Apache presence"
     if [ ${SKIPTEST} -eq 0 ]; then
+	if [ "${OS}" = "OpenBSD" -a "${HTTPDBINARY}" = "/usr/sbin/httpd" ]; then
+	    HTTPDBINARY=""
+	fi
         if [ "${HTTPDBINARY}" = "" ]; then
             Display --indent 2 --text "- Checking Apache" --result "NOT FOUND" --color WHITE
           else


### PR DESCRIPTION
…n with -v

If Apache is installed it is detected in /usr/local/sbin/httpd nevertheless


You can use my name in the contributions :-)
