### PR TITLE
Small PIDfile fixes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 ------------------------------------------
 
   Alexander Lobodzinski
+  Bodine Wilson
   Brian Ginsbach
   C.J. Adams-Collier, US
   Charlie Heselton, US

--- a/lynis
+++ b/lynis
@@ -290,8 +290,22 @@
 #
 #################################################################################
 #
-    # Check if there is already a PID file (incorrect termination of previous instance)
-    if [ -f lynis.pid -o -f /var/run/lynis.pid ]; then
+
+    # Decide where to write our PID file. For unprivileged users this will be in their home directory, or /tmp if their
+    # home directory isn't set. For root it will be /var/run, or the current workign directory if /var/run doesn't exist.
+    MYHOMEDIR=`echo ~`
+    if [ "${MYHOMEDIR}" = "" ]; then MYHOMEDIR="/tmp"; fi
+
+    if [ ${PRIVILEGED} -eq 0 ]; then
+        PIDFILE="${MYHOMEDIR}/lynis.pid"
+    elif [ -d /var/run ]; then
+        PIDFILE="/var/run/lynis.pid"
+    else
+        PIDFILE="./lynis.pid"
+    fi
+
+    # Check if there is already a PID file in any of the locations (incorrect termination of previous instance)
+    if [ -f "${MYHOMEDIR}/lynis.pid" -o -f "./lynis.pid" -o -f "/var/run/lynis.pid" ]; then
         echo ""
         echo "      ${WARNING}Warning${NORMAL}: ${WHITE}PID file exists, probably another Lynis process is running.${NORMAL}"
         echo "      ------------------------------------------------------------------------------"
@@ -305,26 +319,18 @@
         echo "      ${YELLOW}Note: ${WHITE}Cancelling the program can leave temporary files behind${NORMAL}"
         echo ""
         wait_for_keypress
-        # Deleting temporary files
+        # Deleting any stale PID files that might exist.
         # Note: Display function does not work yet at this point
-        if [ -f lynis.pid ]; then rm -f lynis.pid; fi
-        if [ -f /var/run/lynis.pid ]; then rm -f /var/run/lynis.pid; fi
+        if [ -f "${MYHOMEDIR}/lynis.pid" ]; then rm -f "${MYHOMEDIR}/lynis.pid"; fi
+        if [ -f "./lynis.pid" ]; then rm -f "./lynis.pid"; fi
+        if [ -f "/var/run/lynis.pid" ]; then rm -f "/var/run/lynis.pid"; fi
     fi
 
-    # Create new PID file (use work directory if /var/run is not available)
-    if [ ${PRIVILEGED} -eq 0 ]; then
-          # Store it in home directory of user
-          MYHOMEDIR=`echo ~`
-          if [ "${MYHOMEDIR}" = "" ]; then HOMEDIR="/tmp"; fi
-          PIDFILE="${MYHOMEDIR}/lynis.pid"
-      elif [ -d /var/run ]; then
-          PIDFILE="/var/run/lynis.pid"
-      else
-          PIDFILE="lynis.pid"
-    fi
+    # Create new PID file writable only by owner. Decrease the window for symlink attacks.
+    (umask 077; rm -f ${PIDFILE} ; touch ${PIDFILE})
     OURPID=`echo $$`
     echo ${OURPID} > ${PIDFILE}
-    chmod 600 ${PIDFILE}
+
 #
 #################################################################################
 #


### PR DESCRIPTION
After finding that the MYHOMEDIR is empty, the base version of lynis sets HOMEDIR to /tmp (line 318). This appears to be a typo since $HOMEDIR is not referenced anywhere and the empty $MYHOMEDIR is used in line 319. This has the undesirable effect of writing a PIDFILE in the root directory.

Fixing this typo is great, but it creates a possible symlink attack. Line 332 writes the lynis process ID to the pidfile. If an attacker creates a symlink at /tmp/lynis.pid on a system without an immutable /tmp directory (and without a /var/run directory), executing lynis will clobber the target of that symlink, overwriting file contents with the process ID of the running lynis process.

This is a corner case. Nonetheless, I've largely mitigated this vulnerability by removing PIDFILE immediately before creating it with the appropriate permissions set. Without the portable ability to atomically create a PIDFILE, this is as safe as it gets.

Additionally, the base version only cleans up PID files in /var/run or the current working directory. I've expanded this to include PID files stored in the user's HOME directory as well.