### PR TITLE
Bugfix: nginx SSL detection worked on Linux only (only GNU sed unders…

### DIFF
--- a/include/tests_hardening
+++ b/include/tests_hardening
@@ -96,7 +96,7 @@
     # Description : Check for installed malware scanners
     Register --test-no HRDN-7230 --weight L --network NO --description "Check for malware scanner"
     if [ ${SKIPTEST} -eq 0 ]; then
-        logtext "Test: Check if one or more compilers can be found on the system"
+        logtext "Test: Check if a malware scanner is installed"
         if [ ${MALWARE_SCANNER_INSTALLED} -eq 1 ]; then
             logtext "Result: found at least one malware scanner"
             Display --indent 4 --text "- Installed malware scanner" --result "FOUND" --color GREEN

--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -422,7 +422,7 @@
         # Remove temp file
         if [ ! "${TMPFILE}" = "" ]; then if [ -f ${TMPFILE} ]; then rm -f ${TMPFILE}; fi; fi
         N=0
-        cat ${NGINX_CONF_LOCATION} | sed -e 's/^[ \t]*//' | grep -v "^#" | grep -v "^$" | sed 's/[\t]/ /g' | sed 's/  / /g' | sed 's/  / /g' >> ${TMPFILE}
+        cat ${NGINX_CONF_LOCATION} | sed -e 's/^[ 	]*//' | grep -v "^#" | grep -v "^$" | sed 's/[	]/ /g' | sed 's/  / /g' | sed 's/  / /g' >> ${TMPFILE}
         # Search for included configuration files (may include directories and wild cards)
         FIND=`grep "include" ${NGINX_CONF_LOCATION} | ${AWKBINARY} '{ if ($1=="include") { print $2 }}' | sed 's/;$//g'`
         for I in ${FIND}; do
@@ -435,7 +435,7 @@
                   report "nginx_sub_conf_file=${J}"
                   FileIsReadable ${J}
                   if [ ${CANREAD} -eq 1 ]; then
-                      FIND3=`cat ${J} | sed -e 's/^[ \t]*//' | grep -v "^#" | grep -v "^$" | sed 's/[\t]/ /g' | sed 's/  / /g' | sed 's/  / /g' >> ${TMPFILE}`
+                      FIND3=`cat ${J} | sed -e 's/^[ 	]*//' | grep -v "^#" | grep -v "^$" | sed 's/[	]/ /g' | sed 's/  / /g' | sed 's/  / /g' >> ${TMPFILE}`
                     else
                       ReportException "${TEST_NO}:1" "Can not parse file ${J}, as it is not readable"
                   fi


### PR DESCRIPTION
…tands \t on the command line)

For non-GNU sed the \t has to be replaced with a real tab character.  Code previously failed on OpenBSD and MacOS, now works there (and still on Linux).