### PR TITLE
Combine "sort | uniq" to "sort -u"

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -69,7 +69,7 @@
         fi
         # Check password file
         if [ -f ${PASSWD_FILE} ]; then
-            FIND=`cat ${PASSWD_FILE} | grep -v '^#' | cut -d ':' -f3 | uniq -d`
+            FIND=`cat ${PASSWD_FILE} | grep -v '^#' | cut -d ':' -f3 | sort | uniq -d`
             if [ "${FIND}" = "" ]; then
                 Display --indent 2 --text "- Checking for non-unique UIDs" --result OK --color GREEN
                 logtext "Result: all accounts found in ${PASSWD_FILE} are unique"

--- a/include/tests_homedirs
+++ b/include/tests_homedirs
@@ -34,7 +34,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Read sixth field of /etc/passwd
         logtext "Test: query /etc/passwd to obtain home directories"
-        FIND=`${AWKBINARY} -F: '{ if ($1 !~ "#") print $6 }' /etc/passwd | sort | uniq`
+        FIND=`${AWKBINARY} -F: '{ if ($1 !~ "#") print $6 }' /etc/passwd | sort -u`
         for I in ${FIND}; do
             if [ -d ${I} ]; then
                 logtext "Result: found home directory: ${I} (directory exists)"

--- a/include/tests_logging
+++ b/include/tests_logging
@@ -254,7 +254,7 @@
     Register --test-no LOGG-2148 --weight L --preqs-met ${PREQS_MET} --network NO --description "Checking logrotated files"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: Checking which files are rotated with logrotate and if they exist"
-        FIND=`${LOGROTATEBINARY} -d -v /etc/logrotate.conf 2>&1 | egrep "considering log|skipping" | grep -v '*' | sort | uniq | awk '{ if ($2!="log") { print "File:"$2":does_not_exist" } else { print "File:"$3":exists" } }'`
+        FIND=`${LOGROTATEBINARY} -d -v /etc/logrotate.conf 2>&1 | egrep "considering log|skipping" | grep -v '*' | sort -u | awk '{ if ($2!="log") { print "File:"$2":does_not_exist" } else { print "File:"$3":exists" } }'`
         if [ "${FIND}" = "" ]; then
             logtext "Result: nothing found"
           else
@@ -273,7 +273,7 @@
     Register --test-no LOGG-2150 --weight L --preqs-met ${PREQS_MET} --network NO --description "Checking directories in logrotate configuration"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: Checking which directories can be found in logrotate configuration"
-        FIND=`${LOGROTATEBINARY} -d -v /etc/logrotate.conf 2>&1 | egrep "considering log|skipping" | grep -v '*' | sort | uniq | awk '{ if ($2=="log") { print $3 } }' | sed 's@/[^/]*$@@g' | sort | uniq`
+        FIND=`${LOGROTATEBINARY} -d -v /etc/logrotate.conf 2>&1 | egrep "considering log|skipping" | grep -v '*' | sort -u | awk '{ if ($2=="log") { print $3 } }' | sed 's@/[^/]*$@@g' | sort -u`
         if [ "${FIND}" = "" ]; then
             logtext "Result: nothing found"
           else
@@ -380,7 +380,7 @@
     Register --test-no LOGG-2162 --preqs-met ${PREQS_MET} --weight L --network NO --description "Checking directories in /etc/newsyslog.conf"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: parsing directories from /etc/newsyslog.conf file"
-        FIND=`cat /etc/newsyslog.conf | sort | uniq | grep "^/" | awk '{ print $1 }' | sed 's/\/*[a-zA-Z_.-]*$//g' | sort | uniq`
+        FIND=`cat /etc/newsyslog.conf | sort -u | grep "^/" | awk '{ print $1 }' | sed 's/\/*[a-zA-Z_.-]*$//g' | sort -u`
         for I in ${FIND}; do
             if [ -d ${I} ]; then
                 logtext "Result: Directory ${I} found and exists"
@@ -400,7 +400,7 @@
     Register --test-no LOGG-2164 --preqs-met ${PREQS_MET} --weight L --network NO --description "Checking files specified /etc/newsyslog.conf"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: parsing files from /etc/newsyslog.conf file"
-        FIND=`cat /etc/newsyslog.conf | sort | uniq | grep "^/" | awk '{ print $1 }'`
+        FIND=`cat /etc/newsyslog.conf | sort -u | grep "^/" | awk '{ print $1 }'`
         for I in ${FIND}; do
             if [ -f ${I} ]; then
                 logtext "Result: File ${I} found and exists"
@@ -437,7 +437,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: checking open log files with lsof"
         if [ ! "${LSOFBINARY}" = "" ]; then
-            FIND=`${LSOFBINARY} -n 2>&1 | grep "log$" | egrep -v "WARNING|Output information" | awk '{ if ($5=="REG") { print $9 } }' | sort | uniq | grep -v "^$"`
+            FIND=`${LSOFBINARY} -n 2>&1 | grep "log$" | egrep -v "WARNING|Output information" | awk '{ if ($5=="REG") { print $9 } }' | sort -u | grep -v "^$"`
             for I in ${FIND}; do
                 logtext "Found logfile: ${I}"
                 report "open_logfile[]=${I}"
@@ -458,7 +458,7 @@
     Register --test-no LOGG-2190 --preqs-met ${PREQS_MET} --weight L --network NO --description "Checking deleted files in file table"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: checking deleted files but are still in use"
-        FIND=`${LSOFBINARY} -n +L 1 2>&1 | egrep -v "WARNING|Output information" | awk '{ if ($5=="REG") { print $10 } }' | grep -v "^$" | sort | uniq`
+        FIND=`${LSOFBINARY} -n +L 1 2>&1 | egrep -v "WARNING|Output information" | awk '{ if ($5=="REG") { print $10 } }' | grep -v "^$" | sort -u`
         if [ ! "${FIND}" = "" ]; then
             logtext "Result: found one or more files which are deleted, but still in use"
             for I in ${FIND}; do

--- a/include/tests_nameservices
+++ b/include/tests_nameservices
@@ -588,7 +588,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: check duplicate line in /etc/hosts"
         if [ -f /etc/hosts ]; then
-            sFIND=`cat /etc/hosts | egrep -v '^(#|$)' | uniq -d`
+            sFIND=`cat /etc/hosts | egrep -v '^(#|$)' | sort | uniq -d`
             if [ "${sFIND}" = "" ]; then
                 logtext "Result: OK, no duplicate lines found"
                 Display --indent 4 --text "- Checking /etc/hosts (duplicates)" --result OK --color GREEN

--- a/include/tests_networking
+++ b/include/tests_networking
@@ -151,11 +151,11 @@
                 FIND=`lscfg -vl ent* | fgrep "Network Address" | cut -d"." -f14 | awk '{ ctr=1; i=1; while (ctr <= 6) { d[ctr++]=substr($0,i,2);i=i+2 } printf("%s:%s:%s:%s:%s:%s\n",d[1],d[2],d[3],d[4],d[5],d[6]) }'`
                 ;;
             DragonFly|FreeBSD)
-                FIND=`${IFCONFIGBINARY} -a | ${AWKBINARY} '{ if ($1=="ether") print $2 }' | sort | uniq`
+                FIND=`${IFCONFIGBINARY} -a | ${AWKBINARY} '{ if ($1=="ether") print $2 }' | sort -u`
                 ;;
             Linux)
                 if [ ! "${IFCONFIGBINARY}" = "" ]; then
-                    FIND=`${IFCONFIGBINARY} -a | ${GREPBINARY} "HWaddr" | awk '{ if ($4=="HWaddr") print $5 }' | sort | uniq`
+                    FIND=`${IFCONFIGBINARY} -a | ${GREPBINARY} "HWaddr" | awk '{ if ($4=="HWaddr") print $5 }' | sort -u`
                   else
                     if [ ! "${IPBINARY}" = "" ]; then
                         logtext "Test: Using ip binary to gather hardware addresses"
@@ -166,16 +166,16 @@
                 fi
                 ;;
             MacOS)
-                FIND=`${IFCONFIGBINARY} -a | awk '{ if ($1=="lladdr" || $1=="ether") print $2 }' | sort | uniq`
+                FIND=`${IFCONFIGBINARY} -a | awk '{ if ($1=="lladdr" || $1=="ether") print $2 }' | sort -u`
                 ;;
             NetBSD)
-                FIND=`${IFCONFIGBINARY} -a | awk '{ if ($1=="address:") print $2 }' | sort | uniq`
+                FIND=`${IFCONFIGBINARY} -a | awk '{ if ($1=="address:") print $2 }' | sort -u`
                 ;;
             OpenBSD)
-                FIND=`${IFCONFIGBINARY} -A | awk '{ if ($1=="lladdr") print $2 }' | sort | uniq`
+                FIND=`${IFCONFIGBINARY} -A | awk '{ if ($1=="lladdr") print $2 }' | sort -u`
                 ;;
             Solaris)
-                FIND=`${IFCONFIGBINARY} -a | awk '{ if ($1=="ether") print $2 }' | sort | uniq`
+                FIND=`${IFCONFIGBINARY} -a | awk '{ if ($1=="ether") print $2 }' | sort -u`
                 ;;
             *)
                 # Having a system currently unsupported? Share your details to determine MAC information
@@ -265,7 +265,7 @@
         case ${OS} in
             DragonFly|FreeBSD)
                 if [ ! "${SOCKSTATBINARY}" = "" ]; then
-                    FIND=`${SOCKSTATBINARY} | awk '{ if ($7 ~ /\*:\*/) print $5"|"$6"|"$2"|" }' | sort | uniq`
+                    FIND=`${SOCKSTATBINARY} | awk '{ if ($7 ~ /\*:\*/) print $5"|"$6"|"$2"|" }' | sort -u`
                     # To strip off IP's: sed 's/|.*:/|/'
                   else
                     FIND=""
@@ -304,7 +304,7 @@
 
             NetBSD)
                 if [ ! "${SOCKSTATBINARY}" = "" ]; then
-                    FIND=`${SOCKSTATBINARY} | awk '{ if ($7 ~ /\*.\*/) print $5"|"$6"|"$2"|" }' | sort | uniq`
+                    FIND=`${SOCKSTATBINARY} | awk '{ if ($7 ~ /\*.\*/) print $5"|"$6"|"$2"|" }' | sort -u`
                   else
                     FIND=""
                 fi
@@ -431,7 +431,7 @@
     # Description : Netstat/socktstat compare (FreeBSD)
     #	    echo -n "        - Comparing output sockstat and netstat"
     #	    logtext "Comparing output of sockstat and netstat"
-    #	    NETSTATOUTPUT=`netstat -an | grep -v 'TIME_WAIT' | grep -v 'ESTABLISHED' | grep -v 'SYN_SENT' | grep -v 'CLOSE_WAIT' | grep -v 'LAST_ACK' | grep -v 'SYN_RECV' | grep -v 'CLOSING' | cut -c 1-44 | grep '*.' | cut -c 24-32 | tr -d ' ' | tr -d '\t' | grep -v '*' | sort | uniq`
+    #	    NETSTATOUTPUT=`netstat -an | grep -v 'TIME_WAIT' | grep -v 'ESTABLISHED' | grep -v 'SYN_SENT' | grep -v 'CLOSE_WAIT' | grep -v 'LAST_ACK' | grep -v 'SYN_RECV' | grep -v 'CLOSING' | cut -c 1-44 | grep '*.' | cut -c 24-32 | tr -d ' ' | tr -d '\t' | grep -v '*' | sort -u`
     #
     #	    if [ "${SOCKSTATOUTPUT}" = "${NETSTATOUTPUT}" ]; then
     #	        ShowResult OK

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -224,7 +224,7 @@
         COUNT=0
         # Check configuration options (options start with a capital)
         logtext "Test: searching configured options in ${PACMANCONF}"
-        FIND=`grep "^[A-Z]" ${PACMANCONF} | sort | uniq | sed 's/ /:space:/g'`
+        FIND=`grep "^[A-Z]" ${PACMANCONF} | sort -u | sed 's/ /:space:/g'`
         for I in ${FIND}; do
             PMOPTION=`echo ${I} | sed 's/:space:/ /g' | ${AWKBINARY} -F= '{ print $1 }'`
             PMVALUE=`echo ${I} | sed 's/:space:/ /g' | ${AWKBINARY} -F= '{ print $2 }'`
@@ -282,7 +282,7 @@
                 logtext "Result: Zypper found one or more installed packages which are vulnerable."
                 ReportWarning ${TEST_NO} "H" "Found one or more vulnerable packages installed"
                 # Unfortunately zypper does not properly give back which package it is. Usually best guess is last word on the line
-                FIND=`${ZYPPERBINARY} lp | ${AWKBINARY} '{ if ($5=="security" || $7=="security") { print $NF }}' | sed 's/:$//' | grep -v "^$" | sort | uniq`
+                FIND=`${ZYPPERBINARY} lp | ${AWKBINARY} '{ if ($5=="security" || $7=="security") { print $NF }}' | sed 's/:$//' | grep -v "^$" | sort -u`
                 logtext "List of vulnerable packages/version:"
                 for I in ${FIND}; do
                     report "vulnerable_package[]=${I}"
@@ -477,7 +477,7 @@
                     logtext "Result: pkg_admin audit found one or more installed packages which are vulnerable."
                     ReportWarning ${TEST_NO} "M" "Found one or more vulnerable packages."
                     logtext "List of vulnerable packages/version:"
-                    for I in `/usr/sbin/pkg_admin audit | awk '{ print $2 }' | sort | uniq`; do
+                    for I in `/usr/sbin/pkg_admin audit | awk '{ print $2 }' | sort -u`; do
                         report "vulnerable_package[]=${I}"
                         logtext "Vulnerable package: ${I}"
                         # Decrease hardening points for every found vulnerable package
@@ -516,7 +516,7 @@
                 #ReportWarning ${TEST_NO} "M" "Found one or more vulnerable packages."
                 #ReportSuggestion ${TEST_NO} "Update your system with portupgrade or other tools"
                 #logtext "List of vulnerable packages/version:"
-                #for I in `/usr/sbin/pkg audit -F | grep "Affected package" | cut -d ' ' -f3 | sort | uniq`; do
+                #for I in `/usr/sbin/pkg audit -F | grep "Affected package" | cut -d ' ' -f3 | sort -u`; do
                 #    report "vulnerable_package[]=${I}"
                 #    logtext "Vulnerable package: ${I}"
                 #    # Decrease hardening points for every found vulnerable package
@@ -548,7 +548,7 @@
                 ReportWarning ${TEST_NO} "M" "Found one or more vulnerable packages."
                 ReportSuggestion ${TEST_NO} "Update your system with portupgrade or other tools"
                 logtext "List of vulnerable packages/version:"
-                for I in `/usr/local/sbin/portaudit | grep "Affected package" | cut -d ' ' -f3 | sort | uniq`; do
+                for I in `/usr/local/sbin/portaudit | grep "Affected package" | cut -d ' ' -f3 | sort -u`; do
                     report "vulnerable_package[]=${I}"
                     logtext "Vulnerable package: ${I}"
                     # Decrease hardening points for every found vulnerable package
@@ -821,7 +821,7 @@
 
         # Trying also with apt-get directly (does not always work, as updates are distributed on both -security and -updates)
         # Show packages which would be upgraded and match 'security' in repository name
-        FIND=`/usr/bin/apt-get --dry-run --show-upgraded upgrade 2> /dev/null | grep '-security' | grep "^Inst" | cut -d ' ' -f2 | sort | uniq`
+        FIND=`/usr/bin/apt-get --dry-run --show-upgraded upgrade 2> /dev/null | grep '-security' | grep "^Inst" | cut -d ' ' -f2 | sort -u`
         if [ ! "${FIND}" = "" ]; then
             #Display --indent 2 --text "- Checking vulnerable packages" --result WARNING --color RED
             VULNERABLE_PACKAGES_FOUND=1

--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -132,7 +132,7 @@
 
         # Sort unsorted list, save it in temp file and then remove unsorted list
         if [ -f ${TMPFILE2} ]; then
-            sort ${TMPFILE2} | uniq >> ${TMPFILE}
+            sort -u ${TMPFILE2} >> ${TMPFILE}
             rm -f ${TMPFILE2}
         fi
         cVHOSTS=0; tVHOSTS=""
@@ -442,7 +442,7 @@
         done
 
         # Sort all discovered configuration lines and store unique ones. Also strip out the mime types configured in nginx
-        SORTFILE=`cat ${TMPFILE} | sort | uniq | sed 's/ /:space:/g' | egrep -v "(application|audio|image|text|video)/" | egrep -v "({|})"`
+        SORTFILE=`cat ${TMPFILE} | sort -u | sed 's/ /:space:/g' | egrep -v "(application|audio|image|text|video)/" | egrep -v "({|})"`
         for I in ${SORTFILE}; do
             I=`echo ${I} | sed 's/:space:/ /g'`
             report "nginx_config_option=${I}";
@@ -667,7 +667,7 @@
             logtext "Test: Checking ${I}"
             if [ -d ${I} ]; then
                 logtext "Result: Directory ${I} exists, so will be used as search path"
-                FIND=`find ${I} -type f -exec grep access_log \{\} \; | grep -v "#" | awk '{ if($1=="access_log") { print $2 } }' | sed 's/;$//g' | sort | uniq`
+                FIND=`find ${I} -type f -exec grep access_log \{\} \; | grep -v "#" | awk '{ if($1=="access_log") { print $2 } }' | sed 's/;$//g' | sort -u`
                 if [ "${FIND}" = "" ]; then
                     logtext "Result: no log files found"
                   else


### PR DESCRIPTION
Combine "sort | uniq" into "sort -u" to reduce the number of processes used for running Lynis.
The busybox version of sort also supports the -u option.