### PR TITLE
Authentication fixes for OpenBSD

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -62,7 +62,7 @@
     Register --test-no AUTH-9208 --weight L --network NO --description "Check non-unique accounts in passwd file"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: Checking for non-unique accounts"
-        if  [ "${OS}" = "DragonFly" -o "${OS}" = "FreeBSD" -o "${OS}" = "NetBSD" ]; then
+        if  [ "${OS}" = "DragonFly" -o "${OS}" = "FreeBSD" -o "${OS}" = "NetBSD" -o "${OS}" = "OpenBSD" ]; then
             PASSWD_FILE="/etc/master.passwd"
           else
             PASSWD_FILE="/etc/passwd"
@@ -273,7 +273,7 @@
     #               MacOS: need to be improved (just reading passwd file is not enough)
     #               OpenBSD/NetBSD: unknown
     #               Arch Linux / CentOS / Ubuntu: 1000+
-    Register --test-no AUTH-9234 --os Linux --weight L --network NO --description "Query user accounts"
+    Register --test-no AUTH-9234 --weight L --network NO --description "Query user accounts"
     if [ ${SKIPTEST} -eq 0 ]; then
         logtext "Test: Read system users (including root user) from /etc/passwd"
         FIND=""
@@ -287,6 +287,11 @@
             "Linux")
                 logtext "Linux real users output (ID = 0, or 500+, but not 65534):"
                 FIND=`awk -F: '($3 >= 1000) && ($3 != 65534) || ($3 == 0) { print $1","$3 }' /etc/passwd`
+            ;;
+
+            "OpenBSD")
+                logtext "OpenBSD real users output (ID = 0, or 1000-60000, but not 32767):"
+                FIND=`awk -F: '($3 >= 1000) && ($3 <= 60000) && ($3 != 32767) || ($3 == 0) { print $1","$3 }' /etc/passwd`
             ;;
 
             "Solaris")

--- a/include/tests_nameservices
+++ b/include/tests_nameservices
@@ -505,7 +505,13 @@
             logtext "Result: ypbind is running"
             Display --indent 2 --text "- Checking ypbind status" --result "FOUND" --color GREEN
             YPBIND_RUNNING=1
-            ReportSuggestion "Disable the usage of NIS/NIS+ and use an alternative like LDAP or Kerberos instead"
+	    IsRunning ypldap
+	    if [ ${RUNNING} -eq 1 ]; then
+		logtext "Result: ypldap is running"
+		Display --indent 2 --text "- Checking ypldap status" --result "FOUND" --color GREEN
+	    else
+                ReportSuggestion "Disable the usage of NIS/NIS+ and use an alternative like LDAP or Kerberos instead"
+	    fi
           else
             logtext "Result: ypbind is not active"
             Display --indent 2 --text "- Checking ypbind status" --result "NOT FOUND" --color WHITE


### PR DESCRIPTION
AUTH-9208: OpenBSD has /etc/master.passwd of course

AUTH-9234: OpenBSD real user ids run from 1000-60000 without 32767 by default; enable this test for non-Linux in the first place
