### PR TITLE
SSH-7408: Added UsePrivilegeSeparation and LogLevel; modified report wording

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -97,7 +97,9 @@
                 IgnoreRhosts:YES,,NO\
                 UseDNS:YES,,NO\
                 X11Forwarding:NO,,YES\
-                PrintLastLog:YES,,NO"
+                PrintLastLog:YES,,NO\
+                UsePrivilegeSeparation:SANDBOX,YES,NO\
+                LogLevel:VERBOSE,INFO,"
 
         for I in ${SSHOPS}; do
             OPTIONNAME=`echo ${I} | cut -d ':' -f1`
@@ -116,12 +118,12 @@
                     Display --indent 4 --text "- SSH option: ${OPTIONNAME}" --result OK --color GREEN
                     AddHP 3 3
                 elif [ "${FOUNDVALUE}" = "${MEDIUMSCOREDVALUE}" ]; then
-                    logtext "Result: SSH option ${OPTIONNAME} is configured totally wrong"
-                    ReportSuggestion ${TEST_NO} "Consider hardening of SSH configuration" "${OPTIONNAME}" "-"
+                    logtext "Result: SSH option ${OPTIONNAME} is configured reasonably"
+                    ReportSuggestion ${TEST_NO} "Consider hardening SSH configuration" "${OPTIONNAME}" "-"
                     Display --indent 4 --text "- SSH option: ${OPTIONNAME}" --result "MEDIUM" --color YELLOW
                     AddHP 1 3
                 elif [ "${FOUNDVALUE}" = "${WRONGVALUE}" ]; then
-                    logtext "Result: SSH option ${OPTIONNAME} is configured totally wrong"
+                    logtext "Result: SSH option ${OPTIONNAME} is in a weak configuration and should be fixed"
                     #ReportWarning ${TEST_NO} "M" "Unsafe configured SSH option: ${OPTIONNAME}"
                     ReportSuggestion ${TEST_NO} "Consider hardening SSH configuration" "${OPTIONNAME}" "-"
                     Display --indent 4 --text "- SSH option: ${OPTIONNAME}" --result WARNING --color RED


### PR DESCRIPTION
### UsePrivilegeSeparation sandbox 

Sandbox is a more restrictive privilege separation method, introduced in 2011 in: http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/sshd/Makefile?rev=1.73&content-type=text/x-cvsweb-$

From man sshd_config: "If UsePrivilegeSeparation is set to “sandbox” then the pre-authentication unprivileged process is **subject to additional restrictions**."

### LogLevel VERBOSE

In some versions of sshd (depending on the version), a LogLevel of INFO doesn't log some combination of:
 - Source IP address
 - Key fingerprint used for authentication
 - Successful authentication attempts

Increasing LogLevel to VERBOSE ensures that this information is included in all recent versions of sshd.

(ref: https://en.wikibooks.org/wiki/OpenSSH/Logging#Server_Logs and https://feeding.cloud.geek.nz/posts/hardening-ssh-servers/)