### PR TITLE
Remote syslog server not detected for syslog-ng

### DIFF
--- a/include/tests_logging
+++ b/include/tests_logging
@@ -343,7 +343,7 @@
         fi
         if [ -f ${SYSLOGD_CONF} ]; then
             logtext "Test: check if logs are also logged to a remote logging host"
-            FIND=`egrep "@[a-zA-Z0-9]" ${SYSLOGD_CONF} | grep -v "^#" | grep -v "[a-zA-Z0-9]@"`
+            FIND=`egrep "@[a-zA-Z0-9]|destination\s.+(udp|tcp).+\sport" ${SYSLOGD_CONF} | grep -v "^#" | grep -v "[a-zA-Z0-9]@"`
             if [ ! "${FIND}" = "" ]; then
                 logtext "Result: remote logging enabled"
                 AddHP 5 5


### PR DESCRIPTION
LOGG-2154: syslog-ng config file has a different syntax