### PR TITLE
Make AddHP identify non-optimal HP in logfile entries

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -71,7 +71,11 @@
         HPADD=$1; HPADDMAX=$2
         HPPOINTS=`expr ${HPPOINTS} + ${HPADD}`
         HPTOTAL=`expr ${HPTOTAL} + ${HPADDMAX}`
-        LogText "Hardening: assigned ${HPADD} hardening points (max for this item: ${HPADDMAX}), current: ${HPPOINTS}, total: ${HPTOTAL}"
+        if [ ${HPADD} -eq ${HPADDMAX} ]; then
+            LogText "Hardening: assigned ${HPADD} hardening points (max for this item: ${HPADDMAX}), current: ${HPPOINTS}, total: ${HPTOTAL}"
+        else
+            LogText "Hardening: assigned ${HPADD} hardening points (max for this item: ${HPADDMAX}), current: ${HPPOINTS}, total: ${HPTOTAL} [*]"
+        fi
       }
 
 


### PR DESCRIPTION
Helps resolve #128.

I thought doing it this way would minimise the impact on anyone who already parses the log file somehow.