### PR TITLE
Added ini dir of EL6

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -38,7 +38,8 @@
                 /usr/local/etc/php.ini /usr/local/lib/php.ini \
                 /usr/pkg/etc/php.ini"
 
-    PHPINIDIRS="/etc/php5/conf.d"
+    PHPINIDIRS="/etc/php5/conf.d \
+                /etc/php.d"
 #
 #################################################################################
 #


### PR DESCRIPTION
On my EL6 systems PHP uses an ini directory of /etc/php.d, added this to the php test.