### PR TITLE
Hide fail2ban open+deleted file warning, when grsec is installed

### DIFF
--- a/include/tests_logging
+++ b/include/tests_logging
@@ -474,8 +474,15 @@
     if [ ! "${LSOFBINARY}" = "" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no LOGG-2190 --preqs-met ${PREQS_MET} --weight L --network NO --description "Checking deleted files in file table"
     if [ ${SKIPTEST} -eq 0 ]; then
-        LogText "Test: checking deleted files but are still in use"
-        FIND=`${LSOFBINARY} -n +L 1 2>&1 | egrep -v "WARNING|Output information" | awk '{ if ($5=="REG") { print $10 } }' | grep -v "^$" | sort -u`
+        LogText "Test: checking deleted files that are still in use"
+        
+        if [ -e /dev/grsec ]; then
+            # grsecurity causes Fail2Ban to hold onto deleted in-use files in /var/tmp
+            FIND=`${LSOFBINARY} -n +L 1 2>&1 | egrep -v "WARNING|Output information|fail2ban" | awk '{ if ($5=="REG") { print $10 } }' | grep -v "^$" | sort -u`
+        else
+            FIND=`${LSOFBINARY} -n +L 1 2>&1 | egrep -v "WARNING|Output information" | awk '{ if ($5=="REG") { print $10 } }' | grep -v "^$" | sort -u`
+        fi
+
         if [ ! "${FIND}" = "" ]; then
             LogText "Result: found one or more files which are deleted, but still in use"
             for I in ${FIND}; do


### PR DESCRIPTION
One of the features in grsecurity also prevents Fail2Ban from creating a temp file under /var/tmp.  I've been unable to pinpoint the line in fail2ban which causes the issue, but have confirmed it's related to grsecurity.

Note: disabling the PaX MPROTECT function on /usr/bin/python will also resolve this issue, but it's better to keep MPROTECT on.