### PR TITLE
AUTH-9262 - restructure + pwquality

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -454,50 +454,64 @@
         FOUND=0
         FOUND_CRACKLIB=0
         FOUND_PASSWDQC=0
+        FOUND_PWQUALITY=0
 
         # Cracklib
-        LogText "Searching cracklib PAM module"
+        LogText "Searching PAM password testing modules (cracklib, passwdqc, pwquality)"
         for I in ${PAM_FILE_LOCATIONS}; do
+
             if [ -f ${I}/pam_cracklib.so ]; then
                 FOUND_CRACKLIB=1
+                FOUND=1
                 LogText "Result: found pam_cracklib.so (crack library PAM) in ${I}"
             fi
+
+            if [ -f ${I}/pam_passwdqc.so ]; then
+                FOUND_PASSWDQC=1
+                FOUND=1
+                LogText "Result: found pam_passwdqc.so (passwd quality control PAM) in ${I}"
+            fi
+
+            if [ -f ${I}/pam_pwquality.so ]; then
+                FOUND_PWQUALITY=1
+                FOUND=1
+                LogText "Result: found pam_pwquality.so (password quality control PAM) in ${I}"
+            fi
         done
+        
+        # Cracklib
         if [ ${FOUND_CRACKLIB} -eq 1 ]; then
             LogText "Result: pam_cracklib.so found"
             Report "pam_cracklib=1"
-            AddHP 3 3
-            FOUND=1
           else
             LogText "Result: pam_cracklib.so NOT found (crack library PAM)"
-            AddHP 1 3
         fi
 
         # Passwd quality control
-        LogText "Searching passwdqc PAM module"
-        for I in ${PAM_FILE_LOCATIONS}; do
-            if [ -f ${I}/pam_passwdqc.so ]; then
-                FOUND_PASSWDQC=1
-                LogText "Result: found pam_passwdqc.so (passwd quality control PAM) in ${I}"
-            fi
-        done
         if [ ${FOUND_PASSWDQC} -eq 1 ]; then
             LogText "Result: pam_passwdqc.so found"
             Report "pam_passwdqc=1"
-            AddHP 3 3
-            FOUND=1
           else
             LogText "Result: pam_passwdqc.so NOT found (passwd quality control PAM)"
-            AddHP 1 3
+        fi
+
+        # pwquality 
+        if [ ${FOUND_PWQUALITY} -eq 1 ]; then
+            LogText "Result: pam_pwquality.so found"
+            Report "pam_pwquality=1"
+          else
+            LogText "Result: pam_pwquality.so NOT found (pwquality control PAM)"
         fi
 
         if [ ${FOUND} -eq 0 ]; then
             Display --indent 2 --text "- Checking PAM password strength tools" --result "SUGGESTION" --color YELLOW
             LogText "Result: no PAM modules for password strength testing found"
             ReportSuggestion ${TEST_NO} "Install a PAM module for password strength testing like pam_cracklib or pam_passwdqc"
+            AddHP 0 3
           else
             Display --indent 2 --text "- Checking PAM password strength tools" --result OK --color GREEN
             LogText "Result: found at least one PAM module for password strength testing"
+            AddHP 3 3
         fi
     fi
 #


### PR DESCRIPTION
Added pwquality (default in some Ubuntu variants) to accepted password-quality modules - addresses issue #118.

Restructured tests so that full points (3/3) are granted if any of these libraries are installed (particularly because passwdqc and cracklib are incompatible).