### PR TITLE
Escape Special Character on Function "Display"

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -307,7 +307,7 @@
                 if [ ${INDENT} -gt 0 ]; then SPACES=`expr 62 - ${INDENT} - ${LINESIZE}`; fi
                 if [ ${CRONJOB} -eq 0 ]; then
                     # Check if we already have already discovered a proper echo command tool. It not, set it default to 'echo'.
-                    if [ "${ECHOCMD}" = "" ]; then ECHOCMD="echo"; fi
+                    if [ "${ECHOCMD}" = "" ]; then ECHOCMD="echo -e"; fi
                     ${ECHOCMD} "\033[${INDENT}C${TEXT}\033[${SPACES}C${RESULTPART}"
                   else
                     echo "${TEXT}${RESULTPART}"


### PR DESCRIPTION
When `echo` command is used without switch `-e` which interpret escape characters, the text supposed to be colored is printed as plain text.

I've only tested this on my Arch-Linux. 
![error](https://cloud.githubusercontent.com/assets/4489002/14044124/ce2b7f78-f29d-11e5-8840-83b6216f51df.png)
![fixerr](https://cloud.githubusercontent.com/assets/4489002/14044127/e1dac01a-f29d-11e5-81c7-b3e81e608748.png)

