### PR TITLE
Update KRNL-5788 for grsecurity

### DIFF
--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -343,11 +343,22 @@
         if [ -x /usr/bin/apt-cache ]; then
             LogText "Result: found /usr/bin/apt-cache"
             LogText "Test: checking readlink location of /vmlinuz"
-            FINDKERNFILE=`readlink -f /vmlinuz`
-            LogText "Output: readlink reported file ${FINDKERNFILE}"
-            LogText "Test: checking package from dpkg -S"
-            FINDKERNEL=`dpkg -S ${FINDKERNFILE} 2> /dev/null | awk -F : '{print $1}'`
-            LogText "Output: dpkg -S reported package ${FINDKERNEL}"
+            if [ -f /vmlinuz ]; then
+                FINDKERNFILE=`readlink -f /vmlinuz`
+                LogText "Output: readlink reported file ${FINDKERNFILE}"
+                LogText "Test: checking package from dpkg -S"
+                FINDKERNEL=`dpkg -S ${FINDKERNFILE} 2> /dev/null | awk -F : '{print $1}'`
+                LogText "Output: dpkg -S reported package ${FINDKERNEL}"
+            else
+                if [ -e /dev/grsec ]; then
+                    FINDKERNEL=linux-image-`uname -r`
+                    LogText "/vmlinuz missing due to grsecurity; assuming ${FINDKERNEL}"
+                else
+                    LogText "This system is missing /vmlinuz.  Unable to check whether kernel is up-to-date."
+                    ReportException "${TEST_NO}:00|Missing /vmlinuz"
+                    ReportSuggestion ${TEST_NO} "Discover why /vmlinuz is missing. Consider manually re-linking."
+                fi
+            fi
             LogText "Test: Using apt-cache policy to determine if there is an update available"
             FINDINST=`apt-cache policy ${FINDKERNEL} | egrep 'Installed' | cut -d ':' -f2 | tr -d ' '`
             FINDCAND=`apt-cache policy ${FINDKERNEL} | egrep 'Candidate' | cut -d ':' -f2 | tr -d ' '`

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -370,11 +370,17 @@
                 ReportException "${TEST_NO}:01"
                 LogText "Exception: apt-cache policy did not return an installed kernel version"
                 ReportSuggestion ${TEST_NO} "Check the output of apt-cache policy manually to determine why output is empty"
-              else
+            else
                 if [ "${FINDINST}" = "${FINDCAND}" ]; then
-                    Display --indent 2 --text "- Checking for available kernel update" --result OK --color GREEN
-                    LogText "Result: no kernel update available"
-                  else
+                    if [ -e /dev/grsec ]; then
+                        Display --indent 2 --text "- Checking for available kernel update" --result GRSEC --color GREEN
+                        LogText "Result: Grsecurity is installed; unable to determine if there's a newer kernel available"
+                        ReportSuggestion ${TEST_NO} "Manually check to confirm you're using a recent kernel and grsecurity patch"
+                    else
+                        Display --indent 2 --text "- Checking for available kernel update" --result OK --color GREEN
+                        LogText "Result: no kernel update available"
+                    fi
+                else
                     Display --indent 2 --text "- Checking for available kernel update" --result "UPDATE AVAILABLE" --color YELLOW
                     LogText "Result: kernel update available according 'apt-cache policy'."
                     ReportSuggestion ${TEST_NO} "Determine priority for available kernel update"


### PR DESCRIPTION
KRNL-5788 had some issues with grsecurity.  Specifically:
 - /vmlinuz missing caused the test to fail.  #175 
 - Threw a misleading error message re apt-cache.  #176 

This patch:
 - Responds appropriately to missing /vmlinuz, but only when grsecurity is installed
 - If /vmlinuz is missing, and grsec is NOT installed, throws a ReportException
 - Suggests the auditor manually check to confirm a recent kernel+grsec is running

@mboelen - Have tested on **one system only**.  I'd appreciate further testing before merging.  :-)