### PR TITLE
Check if file is symlink or not

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -647,13 +647,20 @@
         CHECKFILES="/etc/rc /etc/rc.local /etc/rc.d/rc.sysinit"
         for I in ${CHECKFILES}; do
             if [ -f ${I} ]; then
-                LogText "Test: Checking ${I} file for writable bit"
-                if IsWorldWritable ${I}; then
-                    ReportWarning ${TEST_NO} "H" "Found writable startup script ${I}"
+                ShowSymlinkPath "${I}"
+                if [ ${FOUNDPATH} -eq 1 ]; then
+                    CHECKFILE="$SYMLINK"
+                    LogText "Result: found the path behind this symlink (${CHECKFILE} --> ${I})"
+                else
+                    CHECKFILE="$I"
+                fi
+                LogText "Test: Checking ${CHECKFILE} file for writable bit"
+                if IsWorldWritable ${CHECKFILE}; then
+                    ReportWarning ${TEST_NO} "H" "Found writable startup script ${CHECKFILE}"
                     FOUND=1
-                    LogText "Result: warning, file ${I} is world writable"
+                    LogText "Result: warning, file ${CHECKFILE} is world writable"
                   else
-                    LogText "Result: good, file ${I} not world writable"
+                    LogText "Result: good, file ${CHECKFILE} not world writable"
                 fi
             fi
         done


### PR DESCRIPTION
On CentOS 7, the file /etc/rc.local is a symlink to /etc/rc.d/rc.local.
In that case, the script raises an error. The symlink is world readable, which is not the case of the real file.

```
# stat /etc/rc.local
  File: ‘/etc/rc.local’ -> ‘rc.d/rc.local’
  Size: 13              Blocks: 0          IO Block: 4096   symbolic link
Device: fd01h/64769d    Inode: 88540       Links: 1
Access: (0777/lrwxrwxrwx)  Uid: (    0/    root)   Gid: (    0/    root)
Context: system_u:object_r:etc_t:s0
Access: 2016-05-02 11:20:18.794261132 +0200
Modify: 2016-04-01 11:56:54.061649752 +0200
Change: 2016-04-01 11:56:54.061649752 +0200
 Birth: -
```
