### PR TITLE
Fixed GRSECFOUND and WaitForKeyPress

### DIFF
--- a/include/tests_logging
+++ b/include/tests_logging
@@ -477,7 +477,7 @@
         LogText "Test: checking deleted files that are still in use"
 
         LSOF_GREP="WARNING|Output information"
-        if [ ${GRSECFOUND} -eq 1 ]; then
+        if [ -e /dev/grsec ]; then
             # grsecurity causes Fail2Ban to hold onto deleted in-use files in /var/tmp
             LSOF_GREP="${LSOF_GREP}|fail2ban"
         fi

--- a/include/tests_logging
+++ b/include/tests_logging
@@ -507,7 +507,7 @@
 Report "log_rotation_config_found=${LOGROTATE_CONFIG_FOUND}"
 Report "log_rotation_tool=${LOGROTATE_TOOL}"
 
-WaitForKeypress
+WaitForKeyPress
 
 #
 #================================================================================


### PR DESCRIPTION
1)  WaitForKeyPress function called with incorrect capitalisation (failed)
2)  GRSECFOUND isn't set at this point in operation; reverted to checking for /dev/grsec