### PR TITLE
Small issue during the display of $OPTIONS

### DIFF
--- a/include/helper_show
+++ b/include/helper_show
@@ -121,7 +121,7 @@ if [ $# -gt 0 ]; then
 
         "license")              echo "${PROGRAM_LICENSE}" ;;
         "man")                  echo "Use ./lynis --man or man lynis" ;;
-        "options")              echo "${OPTIONS}" ;;
+        "options")              echo -en "${OPTIONS}" ;;
         "pidfile")              echo "${PIDFILE}" ;;
         "profile" | "profiles") for I in ${PROFILES}; do echo ${I}; done ;;
         "plugindir")            echo "${PLUGINDIR}" ;;


### PR DESCRIPTION
"bash lynis show options" should display  :

--auditor
--check-all (-c)
--config
--cronjob (--cron)
--debug
--developer
--help (-h)
--info
--license-key --log-file
--manpage_(--man)
--no-colors --no-log
--pentest
--profile
--plugins-dir
--quiet (-q)
--quick (-Q)
--report-file
--reverse-colors
--tests
--tests-category
--upload
--verbose
--version (-V)
--view-categories


instead of 

--auditor\n--check-all (-c)\n--config\n--cronjob (--cron)\n--debug\n--developer\n--help (-h)\n--info\n--license-key --log-file\n--manpage_(--man)\n--no-colors --no-log\n--pentest\n--profile\n--plugins-dir\n--quiet (-q)\n--quick (-Q)\n--report-file\n--reverse-colors\n--tests\n--tests-category\n--upload\n--verbose\n--version (-V)\n--view-categories

?