### PR TITLE
Update tests_boot_services

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -269,6 +269,7 @@
             FIND2=`grep 'password --encrypted' ${GRUBCONFFILE} | grep -v '^#'`
             FIND3=`grep 'set superusers' ${GRUBCONFFILE} | grep -v '^#'`
             FIND4=`grep 'password_pbkdf2' ${GRUBCONFFILE} | grep -v '^#'`
+            FIND5=`grep 'grub.pbkdf2' ${GRUBCONFFILE} | grep -v '^#'`
             # GRUB1: MD5 or SHA1
             if [ ! "${FIND}" = "" -o ! "${FIND2}" = "" ]; then
                 FOUND=1


### PR DESCRIPTION
Added detection of password for Grub2 in Ubuntu 14.04 LTS. Previous version doesn't detect it.