### PR TITLE
Update tests_boot_services

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -269,11 +269,12 @@
             FIND2=`grep 'password --encrypted' ${GRUBCONFFILE} | grep -v '^#'`
             FIND3=`grep 'set superusers' ${GRUBCONFFILE} | grep -v '^#'`
             FIND4=`grep 'password_pbkdf2' ${GRUBCONFFILE} | grep -v '^#'`
+            
             # GRUB1: MD5 or SHA1
             if [ ! "${FIND}" = "" -o ! "${FIND2}" = "" ]; then
                 FOUND=1
               # GRUB2: Superusers and password should be defined
-              elif [ ! "${FIND3}" = "" -a ! "${FIND4}" = "" ]; then
+              elif [ ! "${FIND3}" = "" -a ! "${FIND4}" = "" -o ! "${FIND5}" = ""  ]; then
                 FOUND=1
             fi
             if [ ${FOUND} -eq 1 ]; then


### PR DESCRIPTION
To properly detect Grub2 password protection on Ubuntu 14.04LTS