### PR TITLE
UseDNS = No is a safer configuration

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -126,7 +126,7 @@
                 Protocol:2,,1:=\
                 StrictModes:YES,,NO:=\
                 TCPKeepAlive:NO,,YES:=\
-                UseDNS:YES,,NO:=\
+                UseDNS:NO,,YES:=\
                 UsePrivilegeSeparation:SANDBOX,YES,NO:=\
                 VerifyReverseMapping:YES,,NO:=\
                 X11Forwarding:NO,,YES:="


### PR DESCRIPTION
See Issue #197.  

References:
 - https://bugs.launchpad.net/ubuntu/+source/openssh/+bug/424371/comments/11
 - https://unix.stackexchange.com/questions/56941/what-is-the-point-of-sshd-usedns-option
 - https://security.googleblog.com/2016/02/cve-2015-7547-glibc-getaddrinfo-stack.html