### PR TITLE
Remove the support of some filesystems

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -644,6 +644,43 @@
 #
 #################################################################################
 #
+    # Test        : FILE-6430
+    # Description : Disable Mounting of some Filesystems : cramfs hfs hfsplus squashfs udf freevxfs jffs2
+
+    Register --test-no FILE-6430 --weight L --network NO --description "Disable Mounting of some filesystems"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        if [ ! "${LSMODBINARY}" = "" -a -f /proc/modules ]; then
+            Display --indent 2 --text "- Disable Mounting of some filesystems"
+            LIST_FS_NOT_SUPPORTED="cramfs hfs hfsplus squashfs udf freevxfs jffs2"
+            for FS in ${LIST_FS_NOT_SUPPORTED}; do
+                Display --indent 4 --text "- Disable Mounting of $FS Filesystems"
+                LogText "Test: Checking if $FS is not present in loaded modules"
+                # Check if FS is present in lsmod output
+                FIND=`${LSMODBINARY} | grep $FS | wc -l`
+                if [ "${FIND}" = "0" ]; then
+                    LogText "Module $FS not loaded in the kernel"
+                    Display --indent 6 --text "- Module $FS not loaded in the kernel" --result OK --color GREEN
+                else
+                    LogText "Module $FS loaded in the kernel"
+                    Display --indent 6 --text "- Module $FS loaded in the kernel" --result "REMOVE NEEDED" --color YELLOW
+                fi
+                # Check if FS is present in modprobe output
+                FIND=`${MODPROBEBINARY} -v -n $FS 2>/dev/null | tail -1`
+                if echo $FIND | ${EGREPBINARY} -q "insmod .*${FS}.ko"; then
+                    Display --indent 6 --text "- Module $FS present in the kernel" --result "REMOVE NEEDED" --color YELLOW
+                else
+                    Display --indent 6 --text "- Module $FS not present in the kernel" --result OK --color GREEN
+                    ReportSuggestion ${TEST_NO} "The modprobe.d should contains a file with the entry 'install $FS /bin/true'"
+                fi
+            done
+        else
+            LogText "Test skipped lsmod binary not found or /proc/modules can not be opened"
+        fi
+    fi
+
+#
+#################################################################################
+#
 
 WaitForKeyPress
 


### PR DESCRIPTION
[removed links]

Some chapters ask to remove the support of some filesystems : cramfs hfs hfsplus squashfs udf freevxfs jffs2

Tested on Red Hat 7.2 and CentOS 7.2