### PR TITLE
improve non-interactive use of zypper

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -285,7 +285,7 @@
         N=0
         PACKAGE_AUDIT_TOOL_FOUND=1
         PACKAGE_AUDIT_TOOL="zypper"
-        FIND=`${ZYPPERBINARY} se -i | awk '{ if ($1=="i") { print $3 } }'`
+        FIND=`${ZYPPERBINARY} se -t package -i | awk '{ if ($1=="i") { print $3 } }'`
         if [ ! "${FIND}" = "" ]; then
             for I in ${FIND}; do
                 N=$((N + 1))

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -285,7 +285,7 @@
         N=0
         PACKAGE_AUDIT_TOOL_FOUND=1
         PACKAGE_AUDIT_TOOL="zypper"
-        FIND=`${ZYPPERBINARY} se -t package -i | awk '{ if ($1=="i") { print $3 } }'`
+        FIND=`${ZYPPERBINARY} se -n -t package -i | awk '{ if ($1=="i") { print $3 } }'`
         if [ ! "${FIND}" = "" ]; then
             for I in ${FIND}; do
                 N=$((N + 1))
@@ -306,7 +306,7 @@
     if [ ! "${ZYPPERBINARY}" = "" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7330 --preqs-met ${PREQS_MET} --weight L --network NO --description "Querying Zypper for vulnerable packages"
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=`${ZYPPERBINARY} pchk | grep "(0 security patches)"`
+        FIND=`${ZYPPERBINARY} -n pchk | grep "(0 security patches)"`
             if [ ! "${FIND}" = "" ]; then
                 LogText "Result: No security updates found with Zypper"
                 Display --indent 2 --text "- Using Zypper to find vulnerable packages" --result NONE --color GREEN
@@ -315,7 +315,7 @@
                 LogText "Result: Zypper found one or more installed packages which are vulnerable."
                 ReportWarning ${TEST_NO} "H" "Found one or more vulnerable packages installed"
                 # Unfortunately zypper does not properly give back which package it is. Usually best guess is last word on the line
-                FIND=`${ZYPPERBINARY} lp | ${AWKBINARY} '{ if ($5=="security" || $7=="security") { print $NF }}' | sed 's/:$//' | grep -v "^$" | sort -u`
+                FIND=`${ZYPPERBINARY} -n lp | ${AWKBINARY} '{ if ($5=="security" || $7=="security") { print $NF }}' | sed 's/:$//' | grep -v "^$" | sort -u`
                 LogText "List of vulnerable packages/version:"
                 for I in ${FIND}; do
                     VULNERABLE_PACKAGES_FOUND=1


### PR DESCRIPTION
Improve non-interactive behavior of zypper.

* Always run with -n (non-interactive) to prevent questions that block execution of lynis
* for PKGS-7328 only list packages