### PR TITLE
expect value of sysctl:kernel.kptr_restrict to be 2

### DIFF
--- a/default.prf
+++ b/default.prf
@@ -163,7 +163,7 @@ sysctl:kernel.core_uses_pid:1:1:XXX:
 sysctl:kernel.ctrl-alt-del:0:1:XXX:
 sysctl:kernel.exec-shield-randomize:1:1:XXX:
 sysctl:kernel.exec-shield:1:1:XXX:
-sysctl:kernel.kptr_restrict:1:1:Restrict access to kernel symbols:
+sysctl:kernel.kptr_restrict:2:1:Restrict access to kernel symbols:
 sysctl:kernel.sysrq:0:1:Disable magic SysRQ:
 sysctl:kernel.use-nx:0:1:XXX:
 


### PR DESCRIPTION
  from https://lwn.net/Articles/420403/:

>   The %pK format specifier is designed to hide exposed kernel
>   pointers, specifically via /proc interfaces.  Exposing these
>   pointers provides an easy target for kernel write vulnerabilities,
>   since they reveal the locations of writable structures containing
>   easily triggerable function pointers.  The behavior of %pK depends
>   on the kptr_restrict sysctl. […] If kptr_restrict is set to 2,
>   kernel pointers using %pK are printed as 0's regardless of
>   privileges.