### PR TITLE
fix: Test names are different

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1793,13 +1793,13 @@
 
         # Skip test if it's configured in profile (old style)
         if [ ${SKIPTEST} -eq 0 ]; then
-            FIND=`echo "${TEST_SKIP_ALWAYS}" | grep "${TEST_NO}" | tr '[:upper:]' '[:lower:]'`
+            FIND=`echo "${TEST_SKIP_ALWAYS}" | grep "${TEST_NO}" | tr '[:lower:]' '[:upper:]'`
             if [ ! "${FIND}" = "" ]; then SKIPTEST=1; SKIPREASON="Skipped by configuration"; fi
         fi
 
         # Check if this test is on the list to skip
         if [ ${SKIPTEST} -eq 0 ]; then
-            VALUE=`echo ${TEST_NO} | tr '[:upper:]' '[:lower:]'`
+            VALUE=`echo ${TEST_NO} | tr '[:lower:]' '[:upper:]'`
             for I in ${SKIP_TESTS}; do
                 if [ "${I}" = "${VALUE}" ]; then SKIPTEST=1; SKIPREASON="Skipped by configuration (skip-test)"; fi
             done


### PR DESCRIPTION
After changes in 9aa5736 the test names are different. This results in something like BOOT-5122 = boot-5122 and skipped test aren't skipped anymore. Changed from lower to upper, to match display commit.