### PR TITLE
i18n: wrong indentation of result column

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -508,8 +508,10 @@
             fi
 
             if [ ${SHOW} -eq 1 ]; then
-                # Display (counting with -m instead of -c, to support language locale)
-                LINESIZE=`echo "${TEXT}" | wc -m | tr -d ' '`
+                # Display:
+                # - counting with -m instead of -c, to support language locale
+                # - wc needs LANG to deal with multi-bytes characters but LANG has been unset in include/consts...
+                LINESIZE=`export LC_ALL= ; export LANG="${DISPLAY_LANG}";echo "${TEXT}" | wc -m | tr -d ' '`
                 if [ ${SHOWDEBUG} -eq 1 ]; then DEBUGTEXT=" [${PURPLE}DEBUG${NORMAL}]"; else DEBUGTEXT=""; fi
                 if [ ${INDENT} -gt 0 ]; then SPACES=$((62 - INDENT - LINESIZE)); fi
                 if [ ${SPACES} -lt 0 ]; then SPACES=0; fi

--- a/lynis
+++ b/lynis
@@ -49,6 +49,9 @@
     # Version number of report files (when format changes in future)
     REPORT_version_major="1"; REPORT_version_minor="0"
     REPORT_version="${REPORT_version_major}.${REPORT_version_minor}"
+
+    DISPLAY_LANG=$LANG   # requiered by function Display to deal with multi-bytes characters.
+
 #
 #################################################################################
 #


### PR DESCRIPTION
Display function uses wc to calc the number of spaces between label and result; wc requires LANG value to deal with multi-bytes characters, e.g. accentuated ones in french with utf-8.
But atm LANG is unset inside include/consts. Then 'wc -m' returns the number of bytes, not the number of unicode code points, i.e. "characters". On the concerned raws, the result is misaligned (too closed of the label).