### PR TITLE
Fix description of CheckFilePermissions

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -166,7 +166,7 @@
 
     ################################################################################
     # Name        : CheckFilePermissions()
-    # Description : Adds a system to a group, which can be used for categorizing
+    # Description : Check file permissions
     #
     # Input       : full path to file or directory
     # Returns     : PERMS (FILE_NOT_FOUND | OK | BAD)

--- a/include/functions
+++ b/include/functions
@@ -1152,7 +1152,7 @@
 
     ################################################################################
     # Name        : IsVirtualMachine()
-    # Description : Check if a specific item exists in the report
+    # Description : Determine whether it is a virtual machine
     # Returns     : ISVIRTUALMACHINE (0-2)
     #               VMTYPE
     #               VMFULLTYPE


### PR DESCRIPTION
"Adds a system to a group, which can be used for categorizing" should belong to 
AddSystemGroup but not CheckFilePermissions