### PR TITLE
fix yum gpgenabled check to allow spaces around =

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -823,8 +823,8 @@
         FOUND=0
         FileExists /etc/yum.conf
         if [ ${FILE_FOUND} -eq 1 ]; then
-           SearchItem "^gpgenabled=1$" "/etc/yum.conf"; if [ ${ITEM_FOUND} -eq 1 ]; then FOUND=1; fi
-           SearchItem "^gpgcheck=1$" "/etc/yum.conf"; if [ ${ITEM_FOUND} -eq 1 ]; then FOUND=1; fi
+           SearchItem "^gpgenabled\s*=\s*1$" "/etc/yum.conf"; if [ ${ITEM_FOUND} -eq 1 ]; then FOUND=1; fi
+           SearchItem "^gpgcheck\s*=\s*1$" "/etc/yum.conf"; if [ ${ITEM_FOUND} -eq 1 ]; then FOUND=1; fi
            if [ ${FOUND} -eq 1 ]; then
                LogText "Result: GPG check is enabled"
                Display --indent 2 --text "- Checking GPG checks (yum.conf)" --result "${STATUS_OK}" --color GREEN


### PR DESCRIPTION
Issue #245 

yum.conf allows an arbitrary number of spaces to surround the equals assignment.