### PR TITLE
Simple [ -z {$VAR} catches unset variables only in bash.  Need to add…

### DIFF
--- a/lynis
+++ b/lynis
@@ -503,8 +503,8 @@ ${NORMAL}
     Report "os_fullname=${OS_FULLNAME}"
     Report "os_version=${OS_VERSION}"
     if [ "${OS}" = "Linux" ]; then Report "linux_version=${LINUX_VERSION}"; fi
-    if [ ! -z "${OS_KERNELVERSION}" ]; then Report "os_kernel_version=${OS_KERNELVERSION}"; fi
-    if [ ! -z "${OS_KERNELVERSION_FULL}" ]; then Report "os_kernel_version_full=${OS_KERNELVERSION_FULL}"; fi
+    if [ ! -z "${OS_KERNELVERSION+x}" ]; then Report "os_kernel_version=${OS_KERNELVERSION}"; fi
+    if [ ! -z "${OS_KERNELVERSION_FULL+x}" ]; then Report "os_kernel_version_full=${OS_KERNELVERSION_FULL}"; fi
 
     Report "hostname=${HOSTNAME}"
 


### PR DESCRIPTION
… +word to correctly work on non-bash shells.

Just seeing that a lot of -z tests have crept in - you may want to look at those as well...