### PR TITLE
Make IsVirtualMachine detect centos6.8 on openstack

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1336,6 +1336,7 @@
                     vmware)             ISVIRTUALMACHINE=1; VMTYPE="vmware";          VMFULLTYPE="VMware product"                          ;;
                     xen)                ISVIRTUALMACHINE=1; VMTYPE="xen";             VMFULLTYPE="XEN"                                     ;;
                     zvm)                ISVIRTUALMACHINE=1; VMTYPE="zvm";             VMFULLTYPE="IBM z/VM"                                ;;
+                    openstack)          ISVIRTUALMACHINE=1; VMTYPE="nova";            VMFULLTYPE="Openstack Nova"                                ;;
                     *)                  LogText "Result: Unknown virtualization type, so most likely system is physical"                   ;;
                 esac
         fi


### PR DESCRIPTION
These function made mistake in centos 6.8 virtual machine. Only dmicecode work
on these environment and it return Openstack Nova. A openstack case is needed
in codes that check $SHORT codes.