### PR TITLE
Fix FILE-6344 bug

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -308,7 +308,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Proc should be mounted with 'hidepid=2' or 'hidepid=1' at least
         LogText "Test: check proc mount with incorrect mount options"
-        FIND=$(mount | ${EGREPBINARY} "^proc" |  ${EGREPBINARY} -o "hidepid=[0-9]")
+        FIND=$(mount | ${EGREPBINARY} "^/proc" |  ${EGREPBINARY} -o "hidepid=[0-9]")
         if [ "${FIND}" = "hidepid=2" ]; then
             Display --indent 2 --text "- Testing proc mount" --result "${STATUS_OK}" --color GREEN
             LogText "Result: proc mount mounted with hidepid=2"


### PR DESCRIPTION
The result of mount command returns like
/proc on /proc type proc (rw,hidepid=2)

Witch means the regular expression should be '^/proc' not '^proc' or you can grep nothing. :P