### PR TITLE
Check for arpon as ARP monitoring software

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -27,6 +27,7 @@
     NUMBERACTIVENS=0                                # Number of active nameservers
     DHCP_CLIENT_RUNNING=0                           # DHCP client availability
     ARPWATCH_RUNNING=0                              # ARP-cache based attack monitoring software
+    ARPON_RUNNING=0                                 # ARP-cache based attack monitoring software
 #
 #################################################################################
 #
@@ -605,13 +606,26 @@
     # Description : Checking for ARP spoofing and related monitoring software
     Register --test-no NETW-3032 --os Linux --weight L --network NO --category security --description "Checking for ARP monitoring software"
     if [ ${SKIPTEST} -eq 0 ]; then
+        FOUND=0
+        
+        # arpwatch
         IsRunning arpwatch
         if [ ${RUNNING} -eq 1 ]; then
+            FOUND=1
             ARPWATCH_RUNNING=1
             Display --indent 2 --text "- Checking for ARP monitoring software" --result "${STATUS_RUNNING}" --color GREEN
-          else
+        fi
+        
+        # arpon
+        IsRunning arpon
+        if [ ${RUNNING} -eq 1 ]; then
+            FOUND=1
+            ARPON_RUNNING=1
+            Display --indent 2 --text "- Checking for ARP monitoring software" --result "${STATUS_RUNNING}" --color GREEN
+        fi
+        if [ ${FOUND} -eq 0 ]; then
             Display --indent 2 --text "- Checking for ARP monitoring software" --result "${STATUS_NOT_FOUND}" --color YELLOW
-            ReportSuggestion ${TEST_NO} "Consider running ARP monitoring software (arpwatch)"
+            ReportSuggestion ${TEST_NO} "Consider running ARP monitoring software (arpwatch,arpon)"
         fi
     fi
 #


### PR DESCRIPTION
In test **NETW-3032** check for [_ArpON_](https://en.wikipedia.org/wiki/ArpON) as ARP monitoring software. 
Tested with:
 
- Ubuntu 16.04
- arpon 2.7.2

This fixes #266 issue.