### PR TITLE
Fix sed syntax for ServerAlias removal

### DIFF
--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -156,7 +156,7 @@
                     fi
                 done
                 # Search Server aliases
-                for J in `${GREPBINARY} "ServerAlias" ${I} | ${GREPBINARY} -v "^#" | sed "s/.* ServerAlias//g" | sed "s/#.*//g"`; do
+                for J in `${GREPBINARY} "ServerAlias" ${I} | ${GREPBINARY} -v "^#" | sed "s/\s*ServerAlias //g" | sed "s/#.*//g"`; do
                     if [ ! -z ${J} ]; then
                         tVHOSTS="${tVHOSTS} ${J}"
                         cVHOSTS=$((cVHOSTS + 1))


### PR DESCRIPTION
When a Apache config directive is in use, it has whitespace(s) or nothing at all prepended. Assuming that it always has a space before it doesn't have to match.

I thought I'd submitted this PR already, but it seemed not to have happened, strangely enough ... 