### PR TITLE
Skip NTP checks from within a FreeBSD jail

### DIFF
--- a/include/tests_time
+++ b/include/tests_time
@@ -45,6 +45,9 @@
         # Skip NTP tests if we are in a DomU xen instance YYY
         FIND=$(cat /sys/hypervisor/type)
         if [ "${FIND}" = "xen" ]; then PREQS_MET="NO"; else PREQS_MET="YES"; fi
+    elif [ -f /sbin/sysctl ] && [ "`/sbin/sysctl -n security.jail.jailed 2>/dev/null || echo 0`" -eq 1 ]; then
+        # Skip NTP tests if we're in a FreeBSD jail
+        PREQS_MET="NO"
     else
         PREQS_MET="YES"
     fi


### PR DESCRIPTION
As jails get their time from the host and do not have their own clocks, it's not useful to run a time synchronization program from within the jail.