### PR TITLE
Add support for Rudder configuration management

### DIFF
--- a/include/tests_tooling
+++ b/include/tests_tooling
@@ -57,7 +57,7 @@
             Report "automation_tool_running[]=cf-agent"
             Display --indent 4 --text "Found: Cfengine (cfagent)" --result "${STATUS_FOUND}" --color GREEN
         fi
-        OTHER_CFENGINE_LOCATIONS="/var/cfengine/bin"
+        OTHER_CFENGINE_LOCATIONS="/var/cfengine/bin /var/rudder/cfengine-community/bin"
         for I in ${OTHER_CFENGINE_LOCATIONS}; do
             if [ -d ${I} ]; then
                 if [ -f ${I}/cf-agent ]; then


### PR DESCRIPTION
Rudder (http://www.rudder-project.org) is a config management tool with automatic reporting / dynamic policy adjustment.
The "dynamic" bit happens using FusionInventory.
The config management part uses CFEngine under the hood.
I don't know if hw/os inventory tools also matter in the Lynis report, if yes, I can look into that too.

This patch extends the path searched to detect a running CFEngine agent (and fileserver daemon)
Since the agent is the same, this should immediately detect it.