### PR TITLE
[MALW-3280] Bitdefender AV Support (macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Tests:
 * FIRE-4534 - Check Little Snitch on macOS
 * INSE-8050 - Test for insecure services on macOS
 * MACF-6208 - Allow non-privileged execution and filter permission issues
-* MALW-3280 - Detection for Avast daemon on macOS
+* MALW-3280 - Detection for Avast and Bitdefender daemons on macOS
 * PKGS-7381 - Improve test for pkg audit on FreeBSD
 
 Plugins (community and commercial):

--- a/include/tests_malware
+++ b/include/tests_malware
@@ -27,6 +27,7 @@
 #################################################################################
 #
     AVAST_DAEMON_RUNNING=0
+    BITDEFENDER_DAEMON_RUNNING=0
     CLAMD_RUNNING=0
     CLAMSCAN_INSTALLED=0
     ESET_DAEMON_RUNNING=0
@@ -108,6 +109,19 @@
             MALWARE_SCANNER_INSTALLED=1
             AddHP 2 2
             Report "malware_scanner[]=eset"
+        fi
+
+        # Bitdefender (macOS)
+        LogText "Test: checking process bdagentd"
+        IsRunning bdagentd
+        if [ ${RUNNING} -eq 1 ]; then
+            FOUND=1
+            Display --indent 2 --text "- ${GEN_CHECKING} Bitdefender agent" --result "${STATUS_FOUND}" --color GREEN
+            LogText "Result: found Bitdefender security product"
+            BITDEFENDER_DAEMON_RUNNING=1
+            MALWARE_SCANNER_INSTALLED=1
+            AddHP 2 2
+            Report "malware_scanner[]=bitdefender"
         fi
 
         # Avast (macOS)


### PR DESCRIPTION
Added support to detect if Bitdefender Antivirus for Mac is running.