### PR TITLE
[HRDN-7230] Result colors changed, added result log text

### DIFF
--- a/include/tests_hardening
+++ b/include/tests_hardening
@@ -105,9 +105,15 @@
             AddHP 3 3
         else
             LogText "Result: no malware scanner found"
+            if [$MACHINE_ROLE = "personal"]; then
+              Display --indent 4 --text "- Installed malware scanner" --result "${STATUS_NOT_FOUND}" --color YELLOW
+            else
+              Display --indent 4 --text "- Installed malware scanner" --result "${STATUS_NOT_FOUND}" --color RED
+            fi
             Display --indent 4 --text "- Installed malware scanner" --result "${STATUS_NOT_FOUND}" --color RED
             ReportSuggestion ${TEST_NO} "Harden the system by installing at least one malware scanner, to perform periodic file system scans" "-" "Install a tool like rkhunter, chkrootkit, OSSEC"
             AddHP 1 3
+            LogText "Result: no malware scanner found"
         fi
     fi
 #


### PR DESCRIPTION
Results for malware scanner will show  different color for “personal”
machine-roles (in yellow) rather than the other roles (in red).

Added for leniency towards typical personal PC users for not having
malware scanner (should be a suggestion).

Also included log text result if no scanner found, regardless of
machine-role.