### PR TITLE
[FINT-4315] Warning for missing AIDE conf file

### DIFF
--- a/include/tests_file_integrity
+++ b/include/tests_file_integrity
@@ -83,7 +83,8 @@
         done
 
         if [ -z "${AIDECONFIG}" ]; then
-            Display --indent 6 --text "- AIDE config file" --result "${STATUS_NOT_FOUND}" --color YELLOW
+            Display --indent 6 --text "- AIDE config file" --result "${STATUS_NOT_FOUND}" --color RED
+            ReportWarning "${TEST_NO}" "No AIDE configuration file was found, needed for AIDE functionality"
         else
             LogText "Checking configuration file ${AIDECONFIG} for errors"
             FIND=$(${AIDEBINARY} --config=${AIDECONFIG} -D)


### PR DESCRIPTION
Warning given if AIDE is detected but no configuration file found.
Without configuration file AIDE will not work.