### PR TITLE
[FILE-6332] Skips test FILE-6336 if no swap detected

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -261,6 +261,7 @@
           else
             Display --indent 2 --text "- Query swap partitions (fstab)" --result "${STATUS_NONE}" --color YELLOW
             LogText "Result: no swap partitions found in /etc/fstab"
+            skip-test=FILE-6336
         fi
     fi
 #


### PR DESCRIPTION
Lynis will skip test FILE-6336 (check swap mount options) if no swap
partitions are found in /etc/fstab from previous test FILE-6332.
