### PR TITLE
Updates to include/tests_authentication

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -89,6 +89,7 @@
             LogText "Result: test skipped, ${PASSWD_FILE} file not available"
         fi
         LogText "Remarks: Non unique UIDs can riskful for the system or part of a configuration mistake"
+        LogText "Remarks: Non unique UIDs can be a risk for the system or part of a configuration mistake"
     fi
 #
 #################################################################################
@@ -274,6 +275,7 @@
     # Notes       : AIX: 100+
     #               HPUX: 100+
     #               Mac OS X: needs to be improved (just reading passwd file is not enough)
+    #               (NOTE: macOS doesn't have any user info in /etc/passwd, users are managed with opendirectoryd)
     #               OpenBSD/NetBSD: unknown
     #               Arch Linux / CentOS / Ubuntu: 1000+
     Register --test-no AUTH-9234 --weight L --network NO --category security --description "Query user accounts"
@@ -312,6 +314,10 @@
                 LogText "Solaris real users output (ID =0, or 100+, but not 60001/65534):"
                 FIND=`${AWKBINARY} -F: '($3 >= 100 && $3 != 60001 && $3 != 65534) || ($3 == 0) { print $1","$3 }' /etc/passwd`
             ;;
+#            "macOS")
+#                LogText "macOS real users output (ID = 0, or 500-599)"
+#               #NOTE# The specific line for using dscacheutil is:
+#               # dscacheutil -q user | grep -A 3 -B 2 -e uid:\ 5'[0-9][0-9]'                
             *)
                 # Want to help improving Lynis? Determine what user IDs belong to normal user accounts
                 ReportException "${TEST_NO}:1" "Can not determine user accounts"


### PR DESCRIPTION
The LogText Output for test 9208 was worded oddly. 
"Non unique UIDs can riskful for..." has been changed to:
"Non unique UIDs can be a risk for..."

- and - 

Test 9234, specifically finding the Real User info, originally using `/etc/passwd`.  macOS does NOT use `/etc/passwd` to store the user info, but rather the default system users. macOS uses `opendirectoryd` for the backend user service. Thus, the program `dscacheutil` is whats recommended to query the various items in opendirectoryd. I left comments in the test section with the basic commands you can use as reference for building out the correct FIND commands.