### PR TITLE
Fix for NAME-4408: getent hosts localhost   may show two lines on Ope…

### DIFF
--- a/include/tests_nameservices
+++ b/include/tests_nameservices
@@ -662,13 +662,17 @@
     Register --test-no NAME-4408 --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Check localhost entry"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Check server hostname not locally mapped in /etc/hosts"
-        FIND=$(${GETENT_BINARY} hosts localhost | ${AWKBINARY} '{print $1}')
-        if [ "${FIND}" = "127.0.0.1" ]; then
+        FIND=$(${GETENT_BINARY} hosts localhost | ${AWKBINARY} '{print $1}' | ${SORTBINARY} | ${TRBINARY} '\n' ' ')
+        if [ "${FIND}" = "127.0.0.1 " ]; then
             LogText "Result: localhost mapped to 127.0.0.1"
             Display --indent 4 --text "- Checking /etc/hosts (localhost to IP)" --result "${STATUS_OK}" --color GREEN
             report "localhost-mapped-to=${FIND}"
-        elif [ "${FIND}" = "::1" ]; then
+        elif [ "${FIND}" = "::1 " ]; then
             LogText "Result: localhost mapped to ::1"
+            Display --indent 4 --text "- Checking /etc/hosts (localhost to IP)" --result "${STATUS_OK}" --color GREEN
+            report "localhost-mapped-to=${FIND}"
+        elif [ "${FIND}" = "127.0.0.1 ::1 " ]; then
+            LogText "Result: localhost mapped to 127.0.0.1 and ::1"
             Display --indent 4 --text "- Checking /etc/hosts (localhost to IP)" --result "${STATUS_OK}" --color GREEN
             report "localhost-mapped-to=${FIND}"
         else

--- a/include/tests_nameservices
+++ b/include/tests_nameservices
@@ -662,16 +662,16 @@
     Register --test-no NAME-4408 --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Check localhost entry"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Check server hostname not locally mapped in /etc/hosts"
-        FIND=$(${GETENT_BINARY} hosts localhost | ${AWKBINARY} '{print $1}' | ${SORTBINARY} | ${TRBINARY} '\n' ' ')
-        if [ "${FIND}" = "127.0.0.1 " ]; then
+        FIND=$(${GETENT_BINARY} hosts localhost | ${AWKBINARY} '{print $1}' | ${SORTBINARY} | ${TRBINARY} -d '\n')
+        if [ "${FIND}" = "127.0.0.1" ]; then
             LogText "Result: localhost mapped to 127.0.0.1"
             Display --indent 4 --text "- Checking /etc/hosts (localhost to IP)" --result "${STATUS_OK}" --color GREEN
             report "localhost-mapped-to=${FIND}"
-        elif [ "${FIND}" = "::1 " ]; then
+        elif [ "${FIND}" = "::1" ]; then
             LogText "Result: localhost mapped to ::1"
             Display --indent 4 --text "- Checking /etc/hosts (localhost to IP)" --result "${STATUS_OK}" --color GREEN
             report "localhost-mapped-to=${FIND}"
-        elif [ "${FIND}" = "127.0.0.1 ::1 " ]; then
+        elif [ "${FIND}" = "127.0.0.1::1" ]; then
             LogText "Result: localhost mapped to 127.0.0.1 and ::1"
             Display --indent 4 --text "- Checking /etc/hosts (localhost to IP)" --result "${STATUS_OK}" --color GREEN
             report "localhost-mapped-to=${FIND}"


### PR DESCRIPTION
…nBSD