### PR TITLE
Fix Dockerfile audit

### DIFF
--- a/include/parameters
+++ b/include/parameters
@@ -42,7 +42,7 @@
                                 ExitFatal
                               else
                                 shift; shift
-                                HELPER_PARAMS="$1 $2 $3"
+                                HELPER_PARAMS="$1"
                                 HELPER="audit_dockerfile"
                                 break
                             fi


### PR DESCRIPTION
The Dockerfile audit command is currently broken since it tries to pull too many parameters.