### PR TITLE
umask can be 0027 or 0077

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes:
 
 Tests:
 ------
+* AUTH-9328 - Add missing 0027 and 0077 masks
 * BOOT-5104 - Add initsplash and minor code enhancements
 
 ---------------------------------------------------------------------------------

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -996,7 +996,7 @@
                 for FILE in ${FIND}; do
                     HAS_MASK=$(${GREPBINARY} umask ${FILE} | ${SEDBINARY} 's/^[ \t]*//' | ${GREPBINARY} -v "^#" | ${AWKBINARY} '{ print $2 }')
                     for MASK in ${HAS_MASK}; do
-                        if [ "${MASK}" = "077" -o "${MASK}" = "027" ]; then
+                        if [ "${MASK}" = "077" -o "${MASK}" = "027" -o "${MASK}" = "0077" -o "${MASK}" = "0027"]; then
                             LogText "Result: found a strong umask '${MASK}' set in ${FILE}"
                             GOOD_UMASK=1
                         else
@@ -1025,7 +1025,7 @@
             elif [ "${FIND2}" = "1" ]; then
                 LogText "Result: found umask (prefixed with spaces)"
                 FOUND_UMASK=1
-                if [ ! "${FIND}" = "077" -a ! "${FIND}" = "027" ]; then
+                if [ ! "${FIND}" = "077" -a ! "${FIND}" = "027" -a ! "${FIND}" = "0077" -a ! "${FIND}" = "0027"]; then
                     LogText "Result: found umask ${FIND}, which could be more strict"
                     WEAK_UMASK=1
                 else
@@ -1037,7 +1037,7 @@
                 LogText "Result: found multiple umask values configured in /etc/profile"
                 FOUND_UMASK=1
                 for I in ${FIND}; do
-                    if [ ! "${I}" = "077" -a ! "${I}" = "027" ]; then
+                    if [ ! "${I}" = "077" -a ! "${I}" = "027" -a ! "${I}" = "0077" -a ! "${I}" = "0027"]; then
                         LogText "Result: umask ${I} could be more strict"
                         WEAK_UMASK=1
                         AddHP 1 2
@@ -1094,7 +1094,7 @@
                 Display --indent 4 --text "- umask (/etc/login.defs)" --result "${STATUS_SUGGESTION}" --color YELLOW
                 ReportSuggestion ${TEST_NO} "Default umask in /etc/login.defs could not be found and defaults usually to 022, which could be more strict like 027"
                 AddHP 1 2
-            elif [ "${FIND}" = "077" -o "${FIND}" = "027" ]; then
+            elif [ "${FIND}" = "077" -o "${FIND}" = "027" -o "${FIND}" = "0077" -o "${FIND}" = "0027"]; then
                 LogText "Result: umask is ${FIND}, which is fine"
                 Display --indent 4 --text "- umask (/etc/login.defs)" --result "${STATUS_OK}" --color GREEN
                 AddHP 2 2
@@ -1117,7 +1117,7 @@
             if [ "${FIND}" = "" ]; then
                 LogText "Result: umask is not configured"
                 Display --indent 4 --text "- umask (/etc/init.d/functions)" --result "${STATUS_NONE}" --color WHITE
-            elif [ "${FIND}" = "077" -o "${FIND}" = "027" ]; then
+            elif [ "${FIND}" = "077" -o "${FIND}" = "027" -o "${FIND}" = "0077" -o "${FIND}" = "0027"]; then
                 LogText "Result: umask is ${FIND}, which is fine"
                 Display --indent 4 --text "- umask (/etc/init.d/functions)" --result "${STATUS_OK}" --color GREEN
                 AddHP 2 2
@@ -1141,7 +1141,7 @@
                 Display --indent 4 --text "- Checking umask (/etc/init.d/rc)" --result "${STATUS_SUGGESTION}" --color YELLOW
                 ReportSuggestion ${TEST_NO} "Default umask in /etc/init.d/rc could not be found and defaults usually to 022, which could be more strict like 027"
                 AddHP 1 2
-            elif [ "${FIND}" = "077" -o "${FIND}" = "027" ]; then
+            elif [ "${FIND}" = "077" -o "${FIND}" = "027" -o "${FIND}" = "0077" -o "${FIND}" = "0027"]; then
                 LogText "Result: umask is ${FIND}, which is fine"
                 Display --indent 4 --text "- umask (/etc/init.d/rc)" --result "${STATUS_OK}" --color GREEN
                 AddHP 2 2


### PR DESCRIPTION
Actually : 
```
Test: Checking umask value in /etc/init.d/functions
Result: found umask 0027, which could be improved
```

Expected : 
```
Test: Checking umask value in /etc/init.d/functions
Result: umask 0027 is considered a properly hardened value
```