### PR TITLE
Fix regex to disregard locked accounts

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -825,7 +825,7 @@
             LogText "Data: Days since epoch is ${DAYS_SINCE_EPOCH}"
             LogText "Test: collecting accounts which have an expired password (last day changed + maximum change time)"
             # Skip fields with a !, *, or x, or !* (field $3 is last changed, $5 is maximum changed)
-            FIND=$(${EGREPBINARY} -v ":[\!\*x](\*)?:" /etc/shadow | ${AWKBINARY} -v today=${DAYS_SINCE_EPOCH} -F: '{ if (($5!="") && (today>$3+$5)) { print $1 }}')
+            FIND=$(${EGREPBINARY} -v ":[\!\*x]([\*\!])?:" /etc/shadow | ${AWKBINARY} -v today=${DAYS_SINCE_EPOCH} -F: '{ if (($5!="") && (today>$3+$5)) { print $1 }}')
             if [ ! "${FIND}" = "" ]; then
                 for ACCOUNT in ${FIND}; do
                     LogText "Result: password of user ${ACCOUNT} has been expired"


### PR DESCRIPTION
This way, accounts that have ":!!:" in shadow and have an entry in
"Password expires" field don't get flagged with "Result: password of
user XYZ has been expired" by AUTH-9288.

Fixes #362