### PR TITLE
Add Additional php.ini Paths

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -26,6 +26,7 @@
 
     # Possible locations of php.ini
     PHPINILOCS="/etc/php.ini /etc/php.ini.default \
+                /etc/php/php.ini /etc/php5.5/php.ini /etc/php5.6/php.ini /etc/php7.0/php.ini /etc/php7.1/php.ini \
                 /etc/php/cgi-php5/php.ini /etc/php/cli-php5/php.ini /etc/php/apache2-php5/php.ini \
                 /etc/php/apache2-php7.1/php.ini /etc/php/apache2-php5.5/php.ini /etc/php/apache2-php5.6/php.ini /etc/php/apache2-php7.0/php.ini \
                 /etc/php/cgi-php7.1/php.ini /etc/php/cgi-php5.5/php.ini /etc/php/cgi-php5.6/php.ini /etc/php/cgi-php7.0/php.ini \


### PR DESCRIPTION
It wasn't finding my PHP config located at `/etc/php/php.ini`, added that path and some variations.