### PR TITLE
Add a check for csf testing mode

### DIFF
--- a/include/tests_firewalls
+++ b/include/tests_firewalls
@@ -313,6 +313,13 @@
             FIREWALL_SOFTWARE="csf"
             Report "firewall_software[]=csf"
             Display --indent 2 --text "- Checking CSF status (configuration file)" --result "${STATUS_FOUND}" --color GREEN
+            LogText "Test: check if CSF testing mode is disabled"
+            FIND=$(${GREPBINARY} -P "^TESTING(\s|=)" ${FILE} | ${CUTBINARY} -d= -f2 | ${XARGSBINARY})
+            if [ "${FIND}" = "0" ]; then
+              Display --indent 4 --text "- Check if CSF testing mode is disabled" --result "${STATUS_OK}" --color GREEN
+            else
+              Display --indent 4 --text "- Check if CSF testing mode is disabled" --result "${STATUS_WARNING}" --color RED
+            fi
         else
             LogText "Result: ${FILE} does NOT exist"
         fi


### PR DESCRIPTION
This should notify the one who make audits that CSF is in testing mode as sometimes you may forget to  disable it on a production environment which leads to flushing the firewall every N seconds. What do you think ?