### PR TITLE
Added kernel.dmesg_restrict to sysctl checks.

### DIFF
--- a/default.prf
+++ b/default.prf
@@ -186,6 +186,7 @@ config-data=sysctl;kern.sugid_coredump;0;1;No description;sysctl -a;url:https;//
 config-data=sysctl;kernel.core_setuid_ok;0;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.core_uses_pid;1;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.ctrl-alt-del;0;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
+config-data=sysctl;kernel.dmesg_restrict;1;1;Restrict use of dmesg;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.exec-shield-randomize;1;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.exec-shield;1;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.kptr_restrict;2;1;Restrict access to kernel symbols;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;


### PR DESCRIPTION
Preventing an unprivileged user from viewing the kernel log buffer may be an important part of general hardening of the system.   This can help prevent an attacker from gathering debugging information that might be valuable during exploitation.

It's a simple 1 line addition to default.prf, what do you think?