### PR TITLE
Add lowercase path for changelog search (eg: Fedora/EPEL pkg)

### DIFF
--- a/include/helper_show
+++ b/include/helper_show
@@ -129,7 +129,8 @@ if [ $# -gt 0 ]; then
             if [ $# -gt 1 ]; then
                 shift; SEARCH_VERSION="$1"
             fi
-            CHANGELOG_PATHS="/usr/share/doc/${PROGRAM_NAME} /usr/share/doc/${PROGRAM_NAME}-${PROGRAM_VERSION} ."
+            PROGRAM_NAME_LOWER=$( echo ${PROGRAM_NAME} | tr '[:upper:]' '[:lower:]')
+            CHANGELOG_PATHS="/usr/share/doc/${PROGRAM_NAME} /usr/share/doc/${PROGRAM_NAME}-${PROGRAM_VERSION} /usr/share/doc/${PROGRAM_NAME_LOWER} ."
             CHANGELOG=""
             if [ -z "${SEARCH_VERSION}" ]; then SEARCH_VERSION="${PROGRAM_VERSION}"; fi
             STARTED=0


### PR DESCRIPTION
Hi,

This PR is to fix changelog path on Fedora/RHEL systems, since the package name is lower case.

**Before the patch:**

```
[athmane@devel2 ~]$ sudo lynis show changelog

Error: Could not find the changelog file (searched in /usr/share/doc/Lynis /usr/share/doc/Lynis-2.5.1 .)
```
**After the patch:**
```
[athmane@devel2 ~]$ sudo lynis show changelog
Lynis 2.5.1 (2017-05-31)

Changes:
- Hebrew translation by Dolev Farhi
- Improved detection of SSL certificate files
- Minor changes to improve logging and results

Tests:
--------
* BOOT-5104 - Added support for macOS
* FIRE-4524 - Determine if CSF is in testing mode
* HTTP-6716 - Improved log message

---------------------------------------------------------------------------------


```