### PR TITLE
Fix URL in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,7 +12,7 @@ The Lynis project is very thankful to the individuals who contributed to the pro
   - Share missing results and findings
   - Check for grammar issues
 
-  See https://github.com/CISOfy/lynis/CONTRIBUTIONS.md for more details
+  See [CONTRIBUTIONS.md](https://github.com/CISOfy/lynis/blob/master/CONTRIBUTIONS.md) for more details.
 
 ==========================================================================================
 


### PR DESCRIPTION
There is a broken URL within the `CONTRIBUTORS.md` file.