### PR TITLE
Add /usr/lib/apache module search path for DirectAdmin

### DIFF
--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -29,7 +29,7 @@
     # Reset Apache status
     APACHE_INSTALLED=0
     APACHE_MODULES_ENABLED_LOCS="${ROOTDIR}etc/apache2/mods-enabled"
-    APACHE_MODULES_LOCS="${ROOTDIR}etc/httpd/modules ${ROOTDIR}opt/local/apache2/modules ${ROOTDIR}usr/lib/apache2 ${ROOTDIR}usr/lib/httpd/modules ${ROOTDIR}usr/libexec/apache2 ${ROOTDIR}usr/lib64/apache2 ${ROOTDIR}usr/lib64/apache2/modules ${ROOTDIR}usr/lib64/httpd/modules ${ROOTDIR}usr/local/libexec/apache ${ROOTDIR}usr/local/libexec/apache22"
+    APACHE_MODULES_LOCS="${ROOTDIR}etc/httpd/modules ${ROOTDIR}opt/local/apache2/modules ${ROOTDIR}usr/lib/apache ${ROOTDIR}usr/lib/apache2 ${ROOTDIR}usr/lib/httpd/modules ${ROOTDIR}usr/libexec/apache2 ${ROOTDIR}usr/lib64/apache2 ${ROOTDIR}usr/lib64/apache2/modules ${ROOTDIR}usr/lib64/httpd/modules ${ROOTDIR}usr/local/libexec/apache ${ROOTDIR}usr/local/libexec/apache22"
     NGINX_RUNNING=0
     NGINX_CONF_LOCS="${ROOTDIR}etc/nginx ${ROOTDIR}usr/local/etc/nginx ${ROOTDIR}usr/local/nginx/conf"
     NGINX_CONF_LOCATION=""


### PR DESCRIPTION
Further to https://github.com/CISOfy/lynis/issues/415

The Apache modules path on DirectAdmin based servers that compile Apache via custombuild is `/usr/lib/apache`. This is currently not recognised by lynis, only `/usr/lib/apache2` is searched currently.

