### PR TITLE
Do not unset PHPVERSION after detect it

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -71,8 +71,6 @@
                 ${ROOTDIR}opt/alt/php56/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php70/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php71/etc/php.d.all"
-
-    PHPVERSION=""
 #
 #################################################################################
 #


### PR DESCRIPTION
For some reason, the variable PHPVERSION is reset at the beginning of tests_php file. So, the tests that use it cannot work (e.g. PHP-2368).