### PR TITLE
Added php.ini locations for Ubuntu 16.04LTS

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -39,6 +39,7 @@
                 ${ROOTDIR}etc/php5/apache2/php.ini \
                 ${ROOTDIR}etc/php5/fpm/php.ini \
                 ${ROOTDIR}private/etc/php.ini \
+                ${ROOTDIR}etc/php/7.0/cli/php.ini ${ROOTDIR}etc/php/7.0/fpm/php.ini \
                 ${ROOTDIR}var/www/conf/php.ini \
                 ${ROOTDIR}usr/local/etc/php.ini ${ROOTDIR}usr/local/lib/php.ini \
                 ${ROOTDIR}usr/local/zend/etc/php.ini \


### PR DESCRIPTION
Lynis does not find php.ini files when executed under Ubuntu 16.04LTS. Added the php.ini file locations for ubuntu 16.04LTS to tests.php.
