### PR TITLE
Do not limit debsums to Debian systems

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -633,7 +633,7 @@
     # Test        : PKGS-7370
     # Description : Checking debsums installation status and presence in cron job
     # Note        : Run this only when it is a DPKG based system
-    if [ ! -z "${DPKGBINARY}" -a "${LINUX_VERSION}" = "Debian" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ ! -z "${DPKGBINARY}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no "PKGS-7370" --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking for debsums utility"
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ ! -z "${DEBSUMSBINARY}" ]; then


### PR DESCRIPTION
Debsums is supported on Debian and other systems as per GitHub issue #446. 
Undo commit d1969001c6df84ea58c7913140a7a03f6b2486a1 (which was requested in #413).