### PR TITLE
[NETW-2705] This is related to #437 and resolvconf but is split up.

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -167,7 +167,11 @@
     Register --test-no NETW-2705 --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check availability two nameservers"
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ ! -z "${DIGBINARY}" ]; then
-            if [ ${NUMBERACTIVENS} -lt 2 ]; then
+            # if we have local resolvers we do not need 2
+            if [ `grep -c "127.0.[0-1].1" /etc/resolv.conf` -ge 1 ]; then
+                Display --indent 4 --text "- Resolvers matched 127.0.[0-1].1 so not checking the number of name servers" --result "${STATUS_OK}" --color GREEN
+                LogText "Result: one or more responsive nameservers matched 127.0.[0-1].1"
+            elif [ ${NUMBERACTIVENS} -lt 2 ]; then
                 Display --indent 4 --text "- Minimal of 2 responsive nameservers" --result "${STATUS_WARNING}" --color RED
                 LogText "Result: less than 2 responsive nameservers found"
                 ReportWarning ${TEST_NO} "Couldn't find 2 responsive nameservers"


### PR DESCRIPTION
This specifically makes it so that when `/etc/resolv.conf` has one or more nameservers matching `127.0.[0-1].1` it should not warn as it is using local resolvers.

We are simply using `grep -c "127.0.[0-1].1" /etc/resolv.conf` to determine this.