### PR TITLE
Fix displayed result for signing keys check

### DIFF
--- a/include/helper_audit_dockerfile
+++ b/include/helper_audit_dockerfile
@@ -179,7 +179,7 @@ InsertSection "Basics"
         HASHING_USED=$(egrep "(sha1sum|sha256sum|sha512sum)" ${AUDIT_FILE})
         Display --indent 2 --text "Hashing" --result "${HASHING_USED}"
         KEYS_USED=$(egrep "(apt-key adv)" ${AUDIT_FILE})
-        Display --indent 2 --text "Signing keys used" --result ${SSL_USED}
+        Display --indent 2 --text "Signing keys used" --result ${KEYS_USED}
         Display --indent 2 --text "All downloads properly checked" --result "?"
     else
         Display --indent 2 --text "No files seems to be downloaded in this Dockerfile"


### PR DESCRIPTION
The result of the signing keys check is saved under KEYS_USED variable,
but SSL_USED was used to present the result to the end user.