### PR TITLE
remove non printable characters from code

### DIFF
--- a/include/consts
+++ b/include/consts
@@ -327,33 +327,33 @@ unset LANG
 #
 
     # Normal color names
-    CYAN="[0;36m"
-    BLUE="[0;34m"
-    BROWN="[0;33m"
-    DARKGRAY="[0;30m"
-    GRAY="[0;37m"
-    GREEN="[1;32m"
-    LIGHTBLUE="[0;94m"
-    MAGENTA="[1;35m"
-    PURPLE="[0;35m"
-    RED="[1;31m"
-    YELLOW="[1;33m"
-    WHITE="[1;37m"
+    CYAN="$(printf '\033[0;36m')"
+    BLUE="$(printf '\033[0;34m')"
+    BROWN="$(printf '\033[0;33m')"
+    DARKGRAY="$(printf '\033[0;30m')"
+    GRAY="$(printf '\033[0;37m')"
+    GREEN="$(printf '\033[1;32m')"
+    LIGHTBLUE="$(printf '\033[0;94m')"
+    MAGENTA="$(printf '\033[1;35m')"
+    PURPLE="$(printf '\033[0;35m')"
+    RED="$(printf '\033[1;31m')"
+    YELLOW="$(printf '\033[1;33m')"
+    WHITE="$(printf '\033[1;37m')"
 
     # Markup
     BOLD="${WHITE}"
 
     # With background
-    BG_BLUE="[0;44m"
+    BG_BLUE="$(printf '\033[0;44m')"
 
     # Semantic names
     HEADER="${WHITE}"
-    NORMAL="[0;39m"
-    WARNING="[1;31m"          # Bad (red)
-    SECTION="[1;33m"          # Section (yellow)
-    NOTICE="[1;33m"           # Notice (yellow)
-    OK="[1;32m"               # Ok (green)
-    BAD="[1;31m"              # Bad (red)
+    NORMAL="$(printf '\033[0m')"
+    WARNING="${RED}"
+    SECTION="${YELLOW}"
+    NOTICE="${YELLOW}"
+    OK="${GREEN}"
+    BAD="${RED}"
 
 #
 #################################################################################

--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -360,7 +360,7 @@
         TMPFILE="${TEMP_FILE}"
 
         COUNT=0
-        ${SEDBINARY} -e 's/^[ 	]*//' ${NGINX_CONF_LOCATION} | ${GREPBINARY} -v "^#" | ${GREPBINARY} -v "^$" | ${SEDBINARY} 's/[	]/ /g' | ${SEDBINARY} 's/  / /g' | ${SEDBINARY} 's/  / /g' >> ${TMPFILE}
+        ${SEDBINARY} -e 's/^[ \t]*//' ${NGINX_CONF_LOCATION} | ${GREPBINARY} -v "^#" | ${GREPBINARY} -v "^$" | ${SEDBINARY} 's/[\t]/ /g' | ${SEDBINARY} 's/  / /g' | ${SEDBINARY} 's/  / /g' >> ${TMPFILE}
         # Search for included configuration files (may include directories and wild cards)
         FIND=$(${GREPBINARY} "include" ${NGINX_CONF_LOCATION} | ${AWKBINARY} '{ if ($1=="include") { print $2 }}' | ${SEDBINARY} 's/;$//g')
         for I in ${FIND}; do
@@ -374,7 +374,7 @@
                     FileIsReadable ${J}
                     if [ ${CANREAD} -eq 1 ]; then
                         NGINX_CONF_FILES="${NGINX_CONF_FILES} ${J}"
-                        FIND3=$(sed -e 's/^[ 	]*//' ${J} | ${GREPBINARY} -v "^#" | ${GREPBINARY} -v "^$" | ${SEDBINARY} 's/[	]/ /g' | ${SEDBINARY} 's/  / /g' | ${SEDBINARY} 's/  / /g' >> ${TMPFILE})
+                        FIND3=$(sed -e 's/^[ \t]*//' ${J} | ${GREPBINARY} -v "^#" | ${GREPBINARY} -v "^$" | ${SEDBINARY} 's/[\t]/ /g' | ${SEDBINARY} 's/  / /g' | ${SEDBINARY} 's/  / /g' >> ${TMPFILE})
                     else
                         ReportException "${TEST_NO}:1" "Can not parse file ${J}, as it is not readable"
                     fi


### PR DESCRIPTION
Non printable ESC character is required to obtain terminal escape
sequence i.e. for changing output color.

Such sequences (especially ESC character) were replaced by command
substitution producing exactly same result (variable value), but using
only "safe" characters.

Use of printf and especialy '\033' or '\0ddd' sequences is described
here:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html#tag_20_94_13

Use of $(command) or command substitution is described here:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_03

Verbatim TAB characters were replaced with \t escape sequence as
described to avoid problems with editors silently replacing them or
developer accidentialy messing up the regex.