### PR TITLE
enable shellcheck in travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
 
 script:
     - cd .. && cd ./lynis-sdk && sh lynis-devkit run unit-tests
+    - cd ../lynis && find lynis include extras plugins -type f -exec shellcheck {} +
 
 notifications:
   email:


### PR DESCRIPTION
Shellcheck was not enabled or was not used (lynis-sdk required `shellcheck` to be installed to `/home/$(whoami)/.cabal/bin/shellcheck` to work).

Sadly this PR cannot be merged, as travis job will fail with 2956 shellcheck findings. With excludes from https://github.com/CISOfy/lynis-sdk/blob/master/linters/linter-shellcheck.sh#L9 shellcheck will find mere 77 issues.

I do agree with excludes like SC2034 (unused variables, 707 hits), but SC2086 (quote to prevent word splitting, 1385) might result in unexpected and possibly dangerous behavior.