### PR TITLE
Add additional DirectAdmin paths for php.ini

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -42,6 +42,11 @@
                 ${ROOTDIR}etc/php/7.0/cli/php.ini ${ROOTDIR}etc/php/7.0/fpm/php.ini \
                 ${ROOTDIR}var/www/conf/php.ini \
                 ${ROOTDIR}usr/local/etc/php.ini ${ROOTDIR}usr/local/lib/php.ini \
+                ${ROOTDIR}usr/local/etc/php5/cgi/php.ini \
+                ${ROOTDIR}usr/local/php54/lib/php.ini \
+                ${ROOTDIR}usr/local/php56/lib/php.ini \
+                ${ROOTDIR}usr/local/php70/lib/php.ini \
+                ${ROOTDIR}usr/local/php71/lib/php.ini \
                 ${ROOTDIR}usr/local/zend/etc/php.ini \
                 ${ROOTDIR}usr/pkg/etc/php.ini \
                 ${ROOTDIR}opt/cpanel/ea-php54/root/etc/php.ini \


### PR DESCRIPTION
My PHP FPM setup is currently not detected by Lynis. I use DirectAdmin and the php.ini for php-fpm via Custombuild 2.0 is installed to the following location:

```/usr/local/php70/lib/php.ini```

The `php70` would vary based on the PHP base version.

https://help.directadmin.com/item.php?id=301

It looks like the default PHP CLI path is already searched, but the CGI and PHP-FPM implementations would not be detected. I've added these paths to the `PHPINILOCS` variable.

