### PR TITLE
Avoid /tmp symlink race in unpriviledged scan mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .bzrignore
 custom.prf
 *.swp
+lynis-report.dat
+lynis.log

--- a/lynis
+++ b/lynis
@@ -236,17 +236,17 @@ Make sure to execute ${PROGRAM_NAME} from untarred directory or check your insta
     # Disable logging if no alternative was provided
     if [ ${PRIVILEGED} -eq 0 ]; then
         if [ -z "${LOGFILE}" ]; then
-            # Try creating a log file in temporary directory
-            if [ ! -f /tmp/lynis.log ]; then
-                touch /tmp/lynis.log
-                if [ $? -eq 0 ]; then LOGFILE="/tmp/lynis.log"; else LOGFILE="/dev/null"; fi
+            # Try creating a log file in current working directory
+            if [ ! -f ./lynis.log ]; then
+                touch ./lynis.log
+                if [ $? -eq 0 ]; then LOGFILE="./lynis.log"; else LOGFILE="/dev/null"; fi
             else
-                LOGFILE="/tmp/lynis.log"
+                LOGFILE="./lynis.log"
             fi
         fi
         if [ -z "${REPORTFILE}" ]; then
-            touch /tmp/lynis-report.dat
-            if [ $? -eq 0 ]; then REPORTFILE="/tmp/lynis-report.dat"; else REPORTFILE="/dev/null"; fi
+            touch ./lynis-report.dat
+            if [ $? -eq 0 ]; then REPORTFILE="./lynis-report.dat"; else REPORTFILE="/dev/null"; fi
         fi
     fi
 #
@@ -308,10 +308,10 @@ ${NORMAL}
 #
 #################################################################################
 #
-    # Decide where to write our PID file. For unprivileged users this will be in their home directory, or /tmp if their
+    # Decide where to write our PID file. For unprivileged users this will be in their home directory, or actual working directory if their
     # home directory isn't set. For root it will be /var/run, or the current working directory if /var/run doesn't exist.
     MYHOMEDIR=$(echo ~ 2> /dev/null)
-    if [ -z "${MYHOMEDIR}" ]; then MYHOMEDIR="/tmp"; fi
+    if [ -z "${MYHOMEDIR}" ]; then MYHOMEDIR="."; fi
 
     if [ ${PRIVILEGED} -eq 0 ]; then
         PIDFILE="${MYHOMEDIR}/lynis.pid"


### PR DESCRIPTION
If someone makes:
ln -s /home/$user/.bashrc /tmp/lynis.log

$user being user which uses lynis,
contents of .bashrc are overwritten.