### PR TITLE
VBoxService running is another VirtualBox clue

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1491,6 +1491,8 @@
                 if [ ${RUNNING} -eq 1 ]; then SHORT="virtualbox"; fi
                 IsRunning VBoxClient
                 if [ ${RUNNING} -eq 1 ]; then SHORT="virtualbox"; fi
+                IsRunning VBoxService
+                if [ ${RUNNING} -eq 1 ]; then SHORT="virtualbox"; fi
         else
             LogText "Result: skipped processes test, as we already found platform"
         fi


### PR DESCRIPTION
Add a check for process VBoxService , observed to be running in a vagrant VM that uses VirtualBox 5.1.22.