### PR TITLE
restore UsePrivilegeSeparation to list of ssh daemon checks

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -127,6 +127,7 @@
                 StrictModes:YES,,NO:=\
                 TCPKeepAlive:NO,,YES:=\
                 UseDNS:NO,,YES:=\
+                UsePrivilegeSeparation:SANDBOX,YES,NO:=\
                 VerifyReverseMapping:YES,,NO:=\
                 X11Forwarding:NO,,YES:=\
                 AllowAgentForwarding:NO,,YES:="


### PR DESCRIPTION
This configuration item is still in play on modern SSH (Ubuntu,RHEL 7).  it may be on by default, but in my opinion, it should still be tested.

It was active in 2.5.1, but by the time 2.5.7 came around, it was missing.  This patch restores the value.