### PR TITLE
sort BIN_PATHS before process

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -44,8 +44,8 @@
 
         # Test if our PATH variable provides a set of paths (otherwise we use predefined list in include/consts)
         if [ ! -z "${PATH}" ]; then BIN_PATHS=$(echo ${PATH} | tr ':' ' '); fi
-
-        for SCANDIR in ${BIN_PATHS}; do
+        SORTED_BIN_PATHS=$(echo ${BIN_PATHS} | tr ' ' '\n' | sort | tr '\n' ' ')
+        for SCANDIR in ${SORTED_BIN_PATHS}; do
             LogText "Test: Checking binaries in directory ${SCANDIR}"
             ORGPATH=""
             if [ -d ${SCANDIR} ]; then
@@ -277,6 +277,7 @@
                 LogText "Result: Directory ${SCANDIR} does NOT exist"
             fi
         done
+        unset SORTED_BIN_PATHS
         BINARY_SCAN_FINISHED=1
         BINARY_PATHS_FOUND=$(echo ${BINARY_PATHS_FOUND} | sed 's/^, //g' | sed 's/ //g')
         LogText "Discovered directories: ${BINARY_PATHS_FOUND}"


### PR DESCRIPTION
sorting BIN_PATHS before traversing each one will produce results that are repeatable.  This isn't a big deal but it is nice to have when comparing logs to establish trends.