### PR TITLE
touchup BOOT_LOADER_SEARCHED setting for BOOT-5106 and BOOT-5108

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -148,6 +148,7 @@
     # Description : Check if boot.efi is found on macOS/macOS
     Register --test-no BOOT-5106 --os "macOS" --weight L --network NO --root-only YES --category security --description "Check EFI boot file on Mac OS X/macOS"
     if [ ${SKIPTEST} -eq 0 ]; then
+        BOOT_LOADER_SEARCHED=1
         FileExists ${ROOTDIR}System/Library/CoreServices/boot.efi
         if [ ${FILE_FOUND} -eq 1 ]; then
             LogText "Result: found macOS/Mac OS X boot.efi file"
@@ -162,6 +163,7 @@
     # Description : Check for Syslinux
     Register --test-no BOOT-5108 --os "Linux" --weight L --network NO --root-only YES --category security --description "Check Syslinux as bootloader"
     if [ ${SKIPTEST} -eq 0 ]; then
+        BOOT_LOADER_SEARCHED=1
         FileExists ${ROOTDIR}boot/syslinux/syslinux.cfg
         if [ ${FILE_FOUND} -eq 1 ]; then
             LogText "Result: found Syslinux"


### PR DESCRIPTION
The SEARCHED flag seems it should be set for these tests.