### PR TITLE
Pin db sync

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -45,6 +45,7 @@ AUTH-9340:test:security:authentication:Solaris:Solaris account locking:
 AUTH-9402:test:security:authentication::Query LDAP authentication support:
 AUTH-9406:test:security:authentication::Query LDAP servers in client configuration:
 AUTH-9408:test:security:authentication::Logging of failed login attempts via /etc/login.defs:
+AUTH-9489:test:security:authentication:DragonFly:Check login shells for passwordless accounts:
 BANN-7113:test:security:banners:FreeBSD:Check COPYRIGHT banner file:
 BANN-7124:test:security:banners::Check issue banner file:
 BANN-7126:test:security:banners::Check issue banner file contents:
@@ -69,12 +70,14 @@ BOOT-5180:test:security:boot_services:Linux:Check for Linux boot services (Debia
 BOOT-5184:test:security:boot_services:Linux:Check permissions for boot files/scripts:
 BOOT-5202:test:security:boot_services::Check uptime of system:
 BOOT-5260:test:security:boot_services::Check single user mode for systemd:
+BOOT-5261:test:security:boot_services:DragonFly:Check for DragonFly boot loader presence:
 CONT-8004:test:security:containers:Solaris:Query running Solaris zones:
 CONT-8102:test:security:containers::Checking Docker status and information:
 CONT-8104:test:security:containers::Checking Docker info for any warnings:
 CONT-8106:test:security:containers::Gather basic stats from Docker:
 CONT-8107:test:performance:containers::Check number of unused Docker containers:
 CONT-8108:test:security:containers::Check file permissions for Docker files:
+CORE-1000:test:performance:system_integrity::Check all system binaries:
 CRYP-7902:test:security:crypto::Check expire date of SSL certificates:
 DBS-1804:test:security:databases::Checking active MySQL process:
 DBS-1816:test:security:databases::Checking MySQL root password:
@@ -88,20 +91,6 @@ DBS-1882:test:security:databases::Redis configuration file:
 DBS-1884:test:security:databases::Redis configuration (requirepass):
 DBS-1886:test:security:databases::Redis configuration (CONFIG command renamed):
 DBS-1888:test:security:databases::Redis configuration (bind on localhost):
-FINT-4310:test:security:file_integrity::AFICK availability:
-FINT-4314:test:security:file_integrity::AIDE availability:
-FINT-4315:test:security:file_integrity::Check AIDE configuration file:
-FINT-4318:test:security:file_integrity::Osiris availability:
-FINT-4322:test:security:file_integrity::Samhain availability:
-FINT-4326:test:security:file_integrity::Tripwire availability:
-FINT-4328:test:security:file_integrity::OSSEC syscheck daemon running:
-FINT-4330:test:security:file_integrity::mtree availability:
-FINT-4334:test:security:file_integrity::Check lfd daemon status:
-FINT-4336:test:security:file_integrity::Check lfd configuration status:
-FINT-4338:test:security:file_integrity::osqueryd syscheck daemon running:
-FINT-4402:test:security:file_integrity::Checksums (SHA256 or SHA512):
-FINT-4350:test:security:file_integrity::File integrity software installed:
-FILE-7524:test:security:file_permissions::Perform file permissions check:
 FILE-6310:test:security:filesystems::Checking /tmp, /home and /var directory:
 FILE-6311:test:security:filesystems::Checking LVM volume groups:
 FILE-6312:test:security:filesystems::Checking LVM volumes:
@@ -113,12 +102,28 @@ FILE-6336:test:security:filesystems::Checking swap mount options:
 FILE-6344:test:security:filesystems:Linux:Checking proc mount options:
 FILE-6354:test:security:filesystems::Searching for old files in /tmp:
 FILE-6362:test:security:filesystems::Checking /tmp sticky bit:
+FILE-6363:test:security:filesystems::Checking /var/tmp sticky bit:
 FILE-6368:test:security:filesystems:Linux:Checking ACL support on root file system:
 FILE-6372:test:security:filesystems:Linux:Checking / mount options:
 FILE-6374:test:security:filesystems:Linux:Checking /boot mount options:
 FILE-6376:test:security:filesystems:Linux:Determine if /var/tmp is bound to /tmp:
 FILE-6410:test:security:filesystems::Checking Locate database:
 FILE-6430:test:security:filesystems::Disable mounting of some filesystems:
+FILE-6439:test:security:filesystems:DragonFly:Checking HAMMER PFS mounts:
+FILE-7524:test:security:file_permissions::Perform file permissions check:
+FINT-4310:test:security:file_integrity::AFICK availability:
+FINT-4314:test:security:file_integrity::AIDE availability:
+FINT-4315:test:security:file_integrity::Check AIDE configuration file:
+FINT-4318:test:security:file_integrity::Osiris availability:
+FINT-4322:test:security:file_integrity::Samhain availability:
+FINT-4326:test:security:file_integrity::Tripwire availability:
+FINT-4328:test:security:file_integrity::OSSEC syscheck daemon running:
+FINT-4330:test:security:file_integrity::mtree availability:
+FINT-4334:test:security:file_integrity::Check lfd daemon status:
+FINT-4336:test:security:file_integrity::Check lfd configuration status:
+FINT-4338:test:security:file_integrity::osqueryd syscheck daemon running:
+FINT-4350:test:security:file_integrity::File integrity software installed:
+FINT-4402:test:security:file_integrity::Checksums (SHA256 or SHA512):
 FIRE-4502:test:security:firewalls:Linux:Check iptables kernel module:
 FIRE-4508:test:security:firewalls::Check used policies of iptables chains:
 FIRE-4512:test:security:firewalls::Check iptables for empty ruleset:
@@ -175,6 +180,7 @@ KRNL-5770:test:security:kernel:Solaris:Checking active kernel modules:
 KRNL-5788:test:security:kernel:Linux:Checking availability new Linux kernel:
 KRNL-5820:test:security:kernel:Linux:Checking core dumps configuration:
 KRNL-5830:test:security:kernel:Linux:Checking if system is running on the latest installed kernel:
+KRNL-5831:test:security:kernel:DragonFly:Checking DragonFly loaded kernel modules:
 KRNL-6000:test:security:kernel_hardening::Check sysctl key pairs in scan profile:
 LDAP-2219:test:security:ldap::Check running OpenLDAP instance:
 LDAP-2224:test:security:ldap::Check presence slapd.conf:
@@ -182,9 +188,6 @@ LOGG-2130:test:security:logging::Check for running syslog daemon:
 LOGG-2132:test:security:logging::Check for running syslog-ng daemon:
 LOGG-2134:test:security:logging::Checking Syslog-NG configuration file consistency:
 LOGG-2136:test:security:logging::Check for running systemd journal daemon:
-LOGG-2210:test:security:logging::Check for running metalog daemon:
-LOGG-2230:test:security:logging::Check for running RSyslog daemon:
-LOGG-2240:test:security:logging::Check for running RFC 3195 compliant daemon:
 LOGG-2138:test:security:logging:Linux:Checking kernel logger daemon on Linux:
 LOGG-2142:test:security:logging:Linux:Checking minilog daemon:
 LOGG-2146:test:security:logging::Checking logrotate.conf and logrotate.d:
@@ -199,6 +202,9 @@ LOGG-2170:test:security:logging::Checking log paths:
 LOGG-2180:test:security:logging::Checking open log files:
 LOGG-2190:test:security:logging::Checking for deleted files in use:
 LOGG-2192:test:security:logging::Checking for opened log files that are empty:
+LOGG-2210:test:security:logging::Check for running metalog daemon:
+LOGG-2230:test:security:logging::Check for running RSyslog daemon:
+LOGG-2240:test:security:logging::Check for running RFC 3195 compliant daemon:
 MACF-6204:test:security:mac_frameworks::Check AppArmor presence:
 MACF-6208:test:security:mac_frameworks::Check if AppArmor is enabled:
 MACF-6232:test:security:mac_frameworks::Check SELINUX presence:
@@ -207,7 +213,7 @@ MACF-6290:test:security:mac_frameworks::Check for implemented MAC framework:
 MAIL-8802:test:security:mail_messaging::Check Exim status:
 MAIL-8814:test:security:mail_messaging::Check postfix process status:
 MAIL-8816:test:security:mail_messaging::Check Postfix configuration:
-MAIL-8816:test:security:mail_messaging::Postfix configuration errors:
+MAIL-8817:test:security:mail_messaging::Check Postfix configuration errors:
 MAIL-8818:test:security:mail_messaging::Postfix banner:
 MAIL-8820:test:security:mail_messaging::Postfix configuration:
 MAIL-8838:test:security:mail_messaging::Check dovecot process:
@@ -222,10 +228,6 @@ MALW-3282:test:security:malware::Check for clamscan:
 MALW-3284:test:security:malware::Check for clamd:
 MALW-3286:test:security:malware::Check for freshclam:
 MALW-3288:test:security:malware::Check for ClamXav:
-PROC-3602:test:security:memory_processes:Linux:Checking /proc/meminfo for memory details:
-PROC-3604:test:security:memory_processes:Solaris:Query prtconf for memory details:
-PROC-3612:test:security:memory_processes::Check dead or zombie processes:
-PROC-3614:test:security:memory_processes::Check heavy IO waiting based processes:
 NAME-4016:test:security:nameservices::Check /etc/resolv.conf default domain:
 NAME-4018:test:security:nameservices::Check /etc/resolv.conf search domains:
 NAME-4020:test:security:nameservices::Check non default options:
@@ -317,6 +319,10 @@ PRNT-2314:test:security:printers_spools::Check lpd status:
 PRNT-2316:test:security:printers_spools:AIX:Checking /etc/qconfig file:
 PRNT-2418:test:security:printers_spools:AIX:Checking qdaemon printer spooler status:
 PRNT-2420:test:security:printers_spools:AIX:Checking old print jobs:
+PROC-3602:test:security:memory_processes:Linux:Checking /proc/meminfo for memory details:
+PROC-3604:test:security:memory_processes:Solaris:Query prtconf for memory details:
+PROC-3612:test:security:memory_processes::Check dead or zombie processes:
+PROC-3614:test:security:memory_processes::Check heavy IO waiting based processes:
 RBAC-6272:test:security:mac_frameworks::Check grsecurity presence:
 SCHD-7702:test:security:scheduling::Check status of cron daemon:
 SCHD-7704:test:security:scheduling::Check crontab/cronjobs:
@@ -328,6 +334,7 @@ SHLL-6211:test:security:shells::Checking available and valid shells:
 SHLL-6220:test:security:shells::Checking available and valid shells:
 SHLL-6230:test:security:shells::Perform umask check for shell configurations:
 SHLL-6290:test:security:shells::Perform Shellshock vulnerability tests:
+SINT-7010:test:security:system_integrity::System Integrity Status:
 SNMP-3302:test:security:snmp::Check for running SNMP daemon:
 SNMP-3304:test:security:snmp::Check SNMP daemon file location:
 SNMP-3306:test:security:snmp::Check SNMP communities:
@@ -374,4 +381,5 @@ TOOL-5104:test:security:tooling::Enabled tests for Fail2ban:
 TOOL-5120:test:security:tooling::Presence of Snort IDS:
 TOOL-5122:test:security:tooling::Snort IDS configuration file:
 TOOL-5190:test:security:tooling::Check presence of available IDS/IPS tooling:
+USB-3000:test:security:storage:Linux:Check for presence of USBGuard:
 # EOF

--- a/include/tests_accounting
+++ b/include/tests_accounting
@@ -353,7 +353,7 @@
 #
 #################################################################################
 #
-    # Test        : ACCT-9662
+    # Test        : ACCT-9660
     # Description : Check location for audit events
     if [ ${SOLARIS_AUDITD_RUNNING} -eq 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no ACCT-9660 --os Solaris --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check location of audit events"
@@ -386,7 +386,7 @@
 #
 #################################################################################
 #
-    # Test        : ACCT-9672
+    # Test        : ACCT-9662
     # Description : check auditstat
     if [ ${SOLARIS_AUDITD_RUNNING} -eq 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no ACCT-9662 --os Solaris --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check Solaris auditing stats"

--- a/include/tests_firewalls
+++ b/include/tests_firewalls
@@ -522,7 +522,7 @@
 #
     # Test        : FIRE-4594
     # Description : Check for APF (Advanced Policy Firewall)
-    Register --test-no FIRE-4592 --weight L --network NO --category security --description "Check for APF presence"
+    Register --test-no FIRE-4594 --weight L --network NO --category security --description "Check for APF presence"
     if [ ! -z "${IPTABLESBINARY}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     if [ ${SKIPTEST} -eq 0 ]; then
         FILE="/etc/apf/conf.apf"

--- a/include/tests_nameservices
+++ b/include/tests_nameservices
@@ -476,7 +476,7 @@
 #
 #################################################################################
 #
-    # Test        : NAME-4302
+    # Test        : NAME-4304
     # Description : Check NIS ypbind daemon status
     Register --test-no NAME-4304 --weight L --network NO --category security --description "Check NIS ypbind status"
     if [ ${SKIPTEST} -eq 0 ]; then

--- a/include/tests_printers_spools
+++ b/include/tests_printers_spools
@@ -202,7 +202,7 @@
 #
 #################################################################################
 #
-    # Test        : PRNT-2416
+    # Test        : PRNT-2316
     # Description : Check /etc/qconfig file
     Register --test-no PRNT-2316 --os AIX --weight L --network NO --category security --description "Checking /etc/qconfig file"
     if [ ${SKIPTEST} -eq 0 ]; then

--- a/plugins/plugin_systemd_phase1
+++ b/plugins/plugin_systemd_phase1
@@ -258,7 +258,7 @@
     # Test        : PLGN-3856
     # Description : Check if systemd-coredump is used
     if [ -f /proc/sys/kernel/core_pattern -a ${SYSTEMD_RUNNING} -eq 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
-    Register --test-no PLGN-3856 --preqs-met ${PREQS_MET} --weight L --network NO --description "Query coredumps from journals since Yesterday" --progress
+    Register --test-no PLGN-3856 --preqs-met ${PREQS_MET} --weight L --network NO --description "Check if systemd-coredump is used" --progress
     if [ ${SKIPTEST} -eq 0 ]; then
         SYSTEMD_COREDUMP_USED=1
         FIND=`cat /proc/sys/kernel/core_pattern | grep systemd-coredump`


### PR DESCRIPTION
There are several tests that have minor differences between the testname in the comment, the Register statement, and db/tests.db. 
There is one duplicate db record.
There are nine tests that have no db record.  New db records are created using the Register arguments for testname, os, and description.  The Group is formed from the filename that holds the test.  The CORE-1000 is given to the system_integrity group as it seems the best fit.

The db records are sorted.  No FINT,PROC lines were changed, except for their position.


Given that the USB tests are migrating from STRG, these changes should be scrutinized carefully.
