### PR TITLE
Solved null byte bash warning

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -71,7 +71,7 @@
         case ${OS} in
             "Linux")
                 if [ -f /proc/1/cmdline ]; then
-                    FILENAME=$(${AWKBINARY} '/(^\/|init)/ { print $1 }' /proc/1/cmdline)
+                    FILENAME=$(${AWKBINARY} '/(^\/|init)/ { print $1 }' /proc/1/cmdline | tr -d '\0')
                     LogText "Result: cmdline found = ${FILENAME}"
                     ISFILE=$(echo ${FILENAME} | ${GREPBINARY} "^/")
                     if [ ! -z "${ISFILE}" ]; then

--- a/include/tests_firewalls
+++ b/include/tests_firewalls
@@ -115,7 +115,7 @@
         TABLES="filter"
         for TABLE in ${TABLES}; do
             LogText "Test: gathering information from table ${TABLE}"
-            FIND="$FIND""\n"$(${IPTABLESBINARY} -t ${TABLE} --numeric --list | ${EGREPBINARY}  -z -o -w  '[A-Z]+' | ${AWKBINARY} -v t=${TABLE} 'NR%2 {printf "%s %s ",t, $0 ; next;}1')
+            FIND="$FIND""\n"$(${IPTABLESBINARY} -t ${TABLE} --numeric --list | ${EGREPBINARY}  -z -o -w  '[A-Z]+' | tr -d '\0' | ${AWKBINARY} -v t=${TABLE} 'NR%2 {printf "%s %s ",t, $0 ; next;}1')
         done
 
         echo "${FIND}" | while read line; do


### PR DESCRIPTION
Creating new pull request for this. Previous one got messed up and could not find a good workaround.

Commit solves Null Byte Bash Warning as reported on Issue #515 . Similar error was present on test_boot_services, solved here as well.