### PR TITLE
Add remi repo php.ini paths to tests_php

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -65,7 +65,11 @@
                 ${ROOTDIR}opt/alt/php55/etc/php.ini \
                 ${ROOTDIR}opt/alt/php56/etc/php.ini \
                 ${ROOTDIR}opt/alt/php70/etc/php.ini \
-                ${ROOTDIR}opt/alt/php71/etc/php.ini"
+                ${ROOTDIR}opt/alt/php71/etc/php.ini \
+                ${ROOTDIR}etc/opt/remi/php56/php.ini \
+                ${ROOTDIR}etc/opt/remi/php70/php.ini \
+                ${ROOTDIR}etc/opt/remi/php71/php.ini \
+                ${ROOTDIR}etc/opt/remi/php72/php.ini"
 
     PHPINIDIRS="${ROOTDIR}etc/php5/conf.d \
                 ${ROOTDIR}etc/php/7.0/cli/conf.d \


### PR DESCRIPTION
I use the Remi repo for PHP and components on a server. Lynis currently doesn't detect PHP being installed when using the Remi repo as the paths are quite bespoke:

```
/etc/opt/remi/php56/php.ini
/etc/opt/remi/php70/php.ini
/etc/opt/remi/php71/php.ini
/etc/opt/remi/php72/php.ini
```

This should cover the locations for PHP 5.6 and the PHP 7 series.

https://rpms.remirepo.net/