### PR TITLE
Issue/288

### DIFF
--- a/include/tests_databases
+++ b/include/tests_databases
@@ -76,10 +76,10 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Trying to login to local MySQL server without password"
 
-	# "-u root --password=" avoids ~/.my.cnf authentication settings
-	# "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used 
-	FIND=$(${MYSQLCLIENTBINARY} --no-defaults -u root --password= --silent --batch --execute="SELECT count(*) FROM mysql.user WHERE user = 'root' AND plugin = 'mysql_native_password' AND authentication_string = ''" mysql 2>/dev/null)
-	if [ "${FIND}" > "0" ]; then
+        # "-u root --password=" avoids ~/.my.cnf authentication settings
+        # "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used 
+        FIND=$(${MYSQLCLIENTBINARY} --no-defaults -u root --password= --silent --batch --execute="SELECT count(*) FROM mysql.user WHERE user = 'root' AND plugin = 'mysql_native_password' AND authentication_string = ''" mysql 2>/dev/null)
+        if [ "${FIND}" > "0" ]; then
            LogText "Result: Login succeeded, no MySQL root password set!"
            ReportWarning ${TEST_NO} "No MySQL root password set"
            Display --indent 4 --text "- Checking empty MySQL root password" --result "${STATUS_WARNING}" --color RED

--- a/include/tests_databases
+++ b/include/tests_databases
@@ -75,12 +75,15 @@
     Register --test-no DBS-1816 --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Checking MySQL root password"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Trying to login to local MySQL server without password"
-        FIND=$(${MYSQLCLIENTBINARY} -u root --password= --silent --batch --execute="" 2> /dev/null; echo $?)
-        if [ "${FIND}" = "0" ]; then
-            LogText "Result: Login succeeded, no MySQL root password set!"
-            ReportWarning ${TEST_NO} "No MySQL root password set"
-            Display --indent 4 --text "- Checking empty MySQL root password" --result "${STATUS_WARNING}" --color RED
-            AddHP 0 5
+
+	# "-u root --password=" avoids ~/.my.cnf authentication settings
+	# "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used 
+	FIND=$(${MYSQLCLIENTBINARY} --no-defaults -u root --password= --silent --batch --execute="SELECT count(*) FROM mysql.user WHERE user = 'root' AND plugin = 'mysql_native_password' AND authentication_string = ''" mysql 2>/dev/null)
+	if [ "${FIND}" > "0" ]; then
+           LogText "Result: Login succeeded, no MySQL root password set!"
+           ReportWarning ${TEST_NO} "No MySQL root password set"
+           Display --indent 4 --text "- Checking empty MySQL root password" --result "${STATUS_WARNING}" --color RED
+           AddHP 0 5
         else
             LogText "Result: Login did not succeed, so a MySQL root password is set"
             if IsVerbose; then Display --indent 4 --text "- Checking MySQL root password" --result "${STATUS_OK}" --color GREEN; fi


### PR DESCRIPTION
This should actually work and avoid false positives using mysql authentication plugins.
It will not have a false positive if ~/.my.cnf has authentication settings, because we set user and password in CLI command, which overrides any .my.cnf settings.