### PR TITLE
delayed is a legacy synonym

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -110,7 +110,7 @@
         SSHOPS="AllowTcpForwarding:NO,LOCAL,YES:=\
                 ClientAliveCountMax:2,4,16:<\
                 ClientAliveInterval:300,600,900:<\
-                Compression:(DELAYED|NO),,YES:=\
+                Compression:NO,,YES:=\
                 FingerprintHash:SHA256,MD5,:=\
                 GatewayPorts:NO,,YES:=\
                 IgnoreRhosts:YES,,NO:=\


### PR DESCRIPTION
Suggesting `Compression (YES --> (DELAYED|NO))` is not necessary since delayed is `a legacy synonym for yes` according to SSHD_CONFIG(5).

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>