### PR TITLE
[TIME-3160] Extend check for step-tickers file for RedHat

### DIFF
--- a/include/tests_time
+++ b/include/tests_time
@@ -429,9 +429,15 @@
         FOUND=0
         OUTPUT=$(${AWKBINARY} '/^[a-z0-9]/ { print $1 }' ${FILE})
         if [ -z "${OUTPUT}" ]; then
-            LogText "Result: ${FILE} is empty. The step-tickers contain no configured NTP servers"
-            Display --indent 2 --text "- Checking NTP step-tickers file" --result "EMPTY FILE" --color YELLOW
-            ReportSuggestion ${TEST_NO} "Use step-tickers file for quicker time synchronization"
+            if [ ${OS_REDHAT_OR_CLONE} -eq 1 -a -f "${FILE}" ]; then
+                # On RedHat if step-ticker file exists but is empty, the ntpdate start script uses the servers listed in ntp.conf for the initial time synchronization
+                LogText "Result: ${FILE} exists and it is empty. On RedHat the initial time synchronization will be done with the servers listed in ntp.conf."
+                Display --indent 2 --text "- Checking NTP step-tickers file" --result "${STATUS_OK}" --color GREEN
+            else
+                LogText "Result: ${FILE} is empty. The step-tickers contain no configured NTP servers"
+                Display --indent 2 --text "- Checking NTP step-tickers file" --result "EMPTY FILE" --color YELLOW
+                ReportSuggestion ${TEST_NO} "Use step-tickers file for quicker time synchronization"
+            fi
         else
             LogText "Result: ${FILE} is not empty, which is fine"
             Display --indent 2 --text "- Checking NTP step-tickers file" --result "${STATUS_OK}" --color GREEN


### PR DESCRIPTION
Hi Michael,

on RedHat if the step-tickers file exists even it it's empty, the ntpdate start script uses the servers listed in ntp.conf for the initial time synchronization.

Regards,
Carsten