### PR TITLE
query DNS with FQDN

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -137,7 +137,7 @@
                     if [ ! -z "${DIGBINARY}" ]; then
                         # See if we can query something at the nameserver
                         # 0=good, other=bad
-                        DNSRESPONSE=$(${DIGBINARY} +noall +time=3 +retry=0 @${I} ${I} > /dev/null ; echo $?)
+                        DNSRESPONSE=$(${DIGBINARY} +noall +time=3 +retry=0 @${I} ${FQDN} > /dev/null ; echo $?)
                         if [ "${DNSRESPONSE}" = "0" ]; then
                             Display --indent 8 --text "Nameserver: ${I}" --result "${STATUS_OK}" --color GREEN
                             LogText "Nameserver ${I} seems to respond to queries from this host."


### PR DESCRIPTION
Querying a nameserver with the same nameserver might result in a failure even if DNS is working.

```
Testing bionic @127.0.0.53:
OK
Testing www.google.com @127.0.0.53:
OK
Testing 127.0.0.53 @127.0.0.53:
;; connection timed out; no servers could be reached
FAIL
Testing bionic @1.1.1.1:
;; connection timed out; no servers could be reached
FAIL
Testing www.google.com @1.1.1.1:
;; connection timed out; no servers could be reached
FAIL
Testing 1.1.1.1 @1.1.1.1:
;; connection timed out; no servers could be reached
FAIL
```

```
#!/bin/bash
while read -r d; do
  echo "Testing $(hostname -f) @$d:"
  if dig +noall +time=3 +retry=0 @"$d" "$(hostname -f)"; then
    echo "OK"
  else
    echo "FAIL"
  fi

  echo "Testing www.google.com @$d:"
  if dig +noall +time=3 +retry=0 @"$d" "www.google.com"; then
    echo "OK"
  else
    echo "FAIL"
  fi

  echo "Testing $d @$d:"
  if dig +noall +time=3 +retry=0 @"$d" "$d"; then
    echo "OK"
  else
    echo "FAIL"
  fi
done <<< "$(grep -i '^nameserver' /etc/resolv.conf | awk '{print $NF}')"
```

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>