### PR TITLE
Updated tests_ssh, removed extra ssh in the test 

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -47,7 +47,7 @@
             CreateTempFile
             SSH_DAEMON_OPTIONS_FILE="${TEMP_FILE}"
             # Use a non-existing user, to ensure that systems that have a Match block configured, will be evaluated as well
-            ${SSHDBINARY} -T sshd-C user=doesnotexist,host=none,addr=none 2> /dev/null > ${SSH_DAEMON_OPTIONS_FILE}
+            ${SSHDBINARY} -T -C user=doesnotexist,host=none,addr=none 2> /dev/null > ${SSH_DAEMON_OPTIONS_FILE}
         else
             Display --indent 2 --text "- Checking running SSH daemon" --result "${STATUS_NOT_FOUND}" --color WHITE
         fi


### PR DESCRIPTION
Seems like in the patch there was an extra 'ssh' added in the command line, which is breaking the ssh tests.  Removing the ssh keyword... -T -C ... fixes the problem.