### PR TITLE
Fix for umask check in case of multiple files

### DIFF
--- a/include/tests_shells
+++ b/include/tests_shells
@@ -235,9 +235,9 @@
     Register --test-no SHLL-6230 --weight H --network NO --category security --description "Perform umask check for shell configurations"
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0
-        HARDENING_POSSIBLE=0
         Display --indent 2 --text "- Checking default umask values"
         for FILE in ${SHELL_CONFIG_FILES}; do
+            HARDENING_POSSIBLE=0
             FIND=""
             if [ -f ${FILE} ]; then
                 LogText "Result: file ${FILE} exists"


### PR DESCRIPTION
In case when umask is checked in multiple files and in some of the files except the last one a weak umask is found, the tool reports weak mask for the rest of the files. In the example bellow, the weak umask is only in /etc/csh.cshrc. However, the check /etc/profile is reported weak as well.

Expected:

Checking default umask values
Checking default umask in /etc/bashrc [ OK ]
Checking default umask in /etc/csh.cshrc [ WEAK ]
Checking default umask in /etc/profile [ OK ]
Actual:

Checking default umask values
Checking default umask in /etc/bashrc [ OK ]
Chhhhecking default umask in /etc/csh.cshrc [ WEAK ]
Chhhhecking default umask in /etc/profile [ WEAK ]