### PR TITLE
added path information Apache 2.4 on FreeBSD

### DIFF
--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -29,7 +29,7 @@
     # Reset Apache status
     APACHE_INSTALLED=0
     APACHE_MODULES_ENABLED_LOCS="${ROOTDIR}etc/apache2/mods-enabled"
-    APACHE_MODULES_LOCS="${ROOTDIR}etc/httpd/modules ${ROOTDIR}opt/local/apache2/modules ${ROOTDIR}usr/lib/apache ${ROOTDIR}usr/lib/apache2 ${ROOTDIR}usr/lib/httpd/modules ${ROOTDIR}usr/libexec/apache2 ${ROOTDIR}usr/lib64/apache2 ${ROOTDIR}usr/lib64/apache2/modules ${ROOTDIR}usr/lib64/httpd/modules ${ROOTDIR}usr/local/libexec/apache ${ROOTDIR}usr/local/libexec/apache22"
+    APACHE_MODULES_LOCS="${ROOTDIR}etc/httpd/modules ${ROOTDIR}opt/local/apache2/modules ${ROOTDIR}usr/lib/apache ${ROOTDIR}usr/lib/apache2 ${ROOTDIR}usr/lib/httpd/modules ${ROOTDIR}usr/libexec/apache2 ${ROOTDIR}usr/lib64/apache2 ${ROOTDIR}usr/lib64/apache2/modules ${ROOTDIR}usr/lib64/httpd/modules ${ROOTDIR}usr/local/libexec/apache ${ROOTDIR}usr/local/libexec/apache22 ${ROOTDIR}usr/local/libexec/apache24"
     NGINX_RUNNING=0
     NGINX_CONF_LOCS="${ROOTDIR}etc/nginx ${ROOTDIR}usr/local/etc/nginx ${ROOTDIR}usr/local/nginx/conf"
     NGINX_CONF_LOCATION=""
@@ -42,7 +42,7 @@
         ${ROOTDIR}opt/apache \
         ${ROOTDIR}usr/local/apache ${ROOTDIR}usr/local/apache2 \
         ${ROOTDIR}usr/local/etc/apache ${ROOTDIR}usr/local/etc/apache2 ${ROOTDIR}usr/local/etc/apache22 \
-        ${ROOTDIR}usr/pkg/etc/httpd ${ROOTDIR}etc/sysconfig/apache2"
+        ${ROOTDIR}usr/pkg/etc/httpd ${ROOTDIR}etc/sysconfig/apache2 ${ROOTDIR}usr/local/etc/apache24"
 
     CreateTempFile || ExitFatal
     TMPFILE="${TEMP_FILE}"


### PR DESCRIPTION
As mentioned in issue #561, the default installation of Apache 2.4 from the ports tree on FreeBSD goes to /..../apache24 folders.
This pull-request contains the patch for this.
Tested on FreeBSD 11.2 and 10.4
