### PR TITLE
avoid “can't shift that many” error

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -496,11 +496,11 @@
                     INDENT=$1
                 ;;
                 --result)
-                    shift
+                    shift $(( $# > 0 ? 1 : 0 ))
                     RESULT=$1
                 ;;
                 --text)
-                    shift
+                    shift $(( $# > 0 ? 1 : 0 ))
                     TEXT=$1
                 ;;
                 *)
@@ -509,7 +509,7 @@
                 ;;
             esac
             # Go to next parameter
-            shift
+            shift $(( $# > 0 ? 1 : 0 ))
         done
 
         if [ -z "${RESULT}" ]; then


### PR DESCRIPTION
got this error on debian auditing a docker file when testing an ubuntu Dockerfile when lynis try to find KEY_USED