### PR TITLE
fix opensuse os detection with os-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Command 'lynis show options' provides up-to-date list
 - Option '--dump-options' is deprecated
 - Several options and commands have been extended with more examples
+- OS detection with `/etc/os-release` now supports openSUSE
 
 ---------------------------------------------------------------------------------
 

--- a/include/osdetection
+++ b/include/osdetection
@@ -162,6 +162,19 @@
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="Ubuntu Linux"
                         ;;
+                        "opensuse-tumbleweed")
+                            LINUX_VERSION="openSUSE Tumbleweed"
+                            OS_FULLNAME=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            # It's rolling release but has a snapshot version (the date of the snapshot)
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_NAME="openSUSE"
+                        ;;
+                        "opensuse-leap")
+                            LINUX_VERSION="openSUSE Leap"
+                            OS_FULLNAME=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_NAME="openSUSE"
+                        ;;
                         *)
                             Debug "Unknown OS found in /etc/os-release. Do you know what it is? Create an issue at ${PROGRAM_SOURCE}"
                         ;;


### PR DESCRIPTION
openSUSE uses the os-release file too

I'm not sure what you want to have in OS_NAME vs LINUX_VERSION