### PR TITLE
[BOOT-5260] Make "sulogin" more generic for systemd rescue.service

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -806,7 +806,7 @@
         if [ -f ${ROOTDIR}usr/lib/systemd/system/rescue.service ]; then
             LogText "Result: file /usr/lib/systemd/system/rescue.service"
             LogText "Test: checking presence sulogin for single user mode"
-            FIND=$(${EGREPBINARY} "^ExecStart=-(/bin/sh -c \")?(/usr)?/(s)?bin/sulogin" ${ROOTDIR}usr/lib/systemd/system/rescue.service)
+            FIND=$(${EGREPBINARY} "^ExecStart=.*sulogin" ${ROOTDIR}usr/lib/systemd/system/rescue.service)
             if [ ! -z "${FIND}" ]; then
                 FOUND=1
                 LogText "Result: found sulogin, so single user is protected"


### PR DESCRIPTION
fixes #428