### PR TITLE
osdetection: ignore quotes in OS_ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Changed several warning labels on screen
 - AUTH-9308 - More generic sulogin for systemd rescue.service
+- OS detection now ignores quotes for getting the OS ID.
 
 ---------------------------------------------------------------------------------
 

--- a/include/osdetection
+++ b/include/osdetection
@@ -137,7 +137,7 @@
 
             # Generic
             if [ -e /etc/os-release ]; then
-                OS_ID=$(grep "^ID=" /etc/os-release | awk -F= '{print $2}')
+                OS_ID=$(grep "^ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                 if [ ! -z "${OS_ID}" ]; then
                     case ${OS_ID} in
                         "arch")


### PR DESCRIPTION
Strip the double quotes from OS_ID too, currently it's only done for all the other fields.