### PR TITLE
Fix error printed to screen when run from shell without "command"

### DIFF
--- a/lynis
+++ b/lynis
@@ -110,7 +110,7 @@ Make sure to execute ${PROGRAM_NAME} from untarred directory or check your insta
     fi
 
     # Auto detection of language based on locale (first two characters). Set to English when nothing found.
-    if [ -x "$(command -v locale)" ]; then
+    if [ -x "$(command -v locale 2> /dev/null)" ]; then
         LANGUAGE=$(locale | egrep "^LANG=" | cut -d= -f2 | cut -d_ -f1 | egrep "^[a-z]{2}$")
     fi
     if [ -z "${LANGUAGE}" ]; then


### PR DESCRIPTION
Issue is present on busybox ash shell without "command" builtin. Fix
issue by redirecting errors to /dev/null