### PR TITLE
Fix printed error when wget comes from busybox

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -235,7 +235,7 @@
                             vgdisplay)              VGDISPLAYBINARY="${BINARY}";       LogText "  Found known binary: vgdisplay (LVM tool) - ${BINARY}" ;;
                             vmtoolsd)               VMWARETOOLSDBINARY="${BINARY}";    LogText "  Found known binary: vmtoolsd (VMWare tools) - ${BINARY}" ;;
                             wc)                     WCBINARY="${BINARY}";              LogText "  Found known binary: wc (word count) - ${BINARY}" ;;
-                            wget)                   WGETBINARY="${BINARY}";            WGETVERSION=$(${BINARY} -V | grep "^GNU Wget" | awk '{ print $3 }'); LogText "Found ${BINARY} (version ${WGETVERSION})" ;;
+                            wget)                   WGETBINARY="${BINARY}";            WGETVERSION=$(${BINARY} -V 2> /dev/null | grep "^GNU Wget" | awk '{ print $3 }'); LogText "Found ${BINARY} (version ${WGETVERSION})" ;;
                             yum)                    YUMBINARY="${BINARY}";             LogText "  Found known binary: yum (package manager) - ${BINARY}" ;;
                             xargs)                  XARGSBINARY="${BINARY}";           LogText "  Found known binary: xargs (command output redirection) - ${BINARY}" ;;
                             zgrep)                  ZGREPBINARY=${BINARY};             LogText "  Found known binary: zgrep (text search for compressed files) - ${BINARY}" ;;


### PR DESCRIPTION
Busybox's wget does't provide the -V parameter to get the version, so
redirect stderr to /dev/null to hide the printed error message