### PR TITLE
[BOOT 5177] Simplify service filter & support multiple periods in names

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -547,7 +547,7 @@
             LogText "Result: systemctl binary found, trying that to discover information"
             # Running services
             LogText "Searching for running services (systemctl services only)"
-            FIND=$(${SYSTEMCTLBINARY} --full --type=service | ${AWKBINARY} '{ if ($4=="running") { print $1 } }' | ${AWKBINARY} -F.service '{ print $1 }')
+            FIND=$(${SYSTEMCTLBINARY} --no-legend --full --type=service --state=running | ${AWKBINARY} -F.service '{ print $1 }')
             COUNT=0
             Report "running_service_tool=systemctl"
             for ITEM in ${FIND}; do
@@ -562,7 +562,7 @@
 
             # Services at boot
             LogText "Searching for enabled services (systemctl services only)"
-            FIND=$(${SYSTEMCTLBINARY} list-unit-files --type=service | ${SORTBINARY} -u | ${AWKBINARY} '{ if ($2=="enabled") { print $1 } }' | ${AWKBINARY} -F.service '{ print $1 }')
+            FIND=$(${SYSTEMCTLBINARY} list-unit-files --no-legend --type=service --state=enabled | ${SORTBINARY} -u | ${AWKBINARY} -F.service '{ print $1 }')
             COUNT=0
             Report "boot_service_tool=systemctl"
             for ITEM in ${FIND}; do

--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -547,7 +547,7 @@
             LogText "Result: systemctl binary found, trying that to discover information"
             # Running services
             LogText "Searching for running services (systemctl services only)"
-            FIND=$(${SYSTEMCTLBINARY} --full --type=service | ${AWKBINARY} '{ if ($4=="running") { print $1 } }' | ${AWKBINARY} -F. '{ print $1 }')
+            FIND=$(${SYSTEMCTLBINARY} --full --type=service | ${AWKBINARY} '{ if ($4=="running") { print $1 } }' | ${AWKBINARY} -F.service '{ print $1 }')
             COUNT=0
             Report "running_service_tool=systemctl"
             for ITEM in ${FIND}; do
@@ -562,7 +562,7 @@
 
             # Services at boot
             LogText "Searching for enabled services (systemctl services only)"
-            FIND=$(${SYSTEMCTLBINARY} list-unit-files --type=service | ${SORTBINARY} -u | ${AWKBINARY} '{ if ($2=="enabled") { print $1 } }' | ${AWKBINARY} -F. '{ print $1 }')
+            FIND=$(${SYSTEMCTLBINARY} list-unit-files --type=service | ${SORTBINARY} -u | ${AWKBINARY} '{ if ($2=="enabled") { print $1 } }' | ${AWKBINARY} -F.service '{ print $1 }')
             COUNT=0
             Report "boot_service_tool=systemctl"
             for ITEM in ${FIND}; do


### PR DESCRIPTION
The first commit fixes a corner case where _systemd_ service names contain multiple periods and were getting truncated after the first one. Using '-F.service' as the _awk_ filter instead of '-F.' ensures the entire service name up to '.service' is captured. Grepping the source tree didn't turn up any further instances of this.

The 2nd commit simplifies the service filtering to use _systemctl_ switches instead of an additional pipe to _awk_.