### PR TITLE
[BOOT-5117] Add systemd-boot bootloader detection

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -108,6 +108,7 @@
                             autolog)                AUTOLOGBINARY="${BINARY}";         IDLE_SESSION_KILLER_INSTALLED=1;       LogText "  Found known binary: autolog (idle session killer) - ${BINARY}" ;;
                             base64)                 BASE64BINARY="${BINARY}";          LogText "  Found known binary: base64 (encoding tool) - ${BINARY}" ;;
                             blkid)                  BLKDBINARY="${BINARY}";            LogText "  Found known binary: blkid (information about block devices) - ${BINARY}" ;;
+			    bootctl)		    BOOTCTLBINARY="${BINARY}";	       LogText "  Found known binary: bootctl (systemd-boot manager utility) - ${BINARY}" ;;
                             cat)                    CAT_BINARY="${BINARY}";            LogText "  Found known binary: cat (generic file handling) - ${BINARY}" ;;
                             chkconfig)              CHKCONFIGBINARY=${BINARY};         LogText "  Found known binary: chkconfig (administration tool) - ${BINARY}" ;;
                             clamconf)               CLAMCONF_BINARY=${BINARY};         LogText "  Found known binary: clamconf (information about ClamAV) - ${BINARY}" ;;

--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -240,6 +240,23 @@
 #
 #################################################################################
 #
+    # Test        : BOOT-5117
+    # Description : Check for systemd-boot boot loader
+    if [ ! "${BOOTCTLBINARY}" = "" -a ${HAS_SYSTEMD} -eq 1 -a ${UEFI_BOOTED} -eq 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no BOOT-5117 --preqs-met ${PREQS_MET} --os "Linux" --weight L --network NO --category security --description "Check for systemd-boot bootloader presence"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        BOOT_LOADER_SEARCHED=1
+        CURRENT_BOOT_LOADER=$(${BOOTCTLBINARY} status --no-pager 2>/dev/null | ${AWKBINARY} '/Current Boot Loader/{ getline; print $2 }')
+        if [ "${CURRENT_BOOT_LOADER}" = "systemd-boot" ]; then
+	    Display --indent 2 --text "- Checking systemd-boot presence" --result "${STATUS_FOUND}" --color GREEN
+            LogText "Result: found systemd-boot"
+            BOOT_LOADER="systemd-boot"
+            BOOT_LOADER_FOUND=1
+        fi
+    fi
+#
+#################################################################################
+#
     # Test        : BOOT-5121
     # Description : Check for GRUB boot loader
     Register --test-no BOOT-5121 --weight L --network NO --category security --description "Check for GRUB boot loader presence"


### PR DESCRIPTION
Adds a test to detect systemd-boot. The 'bootctl' binary is also
added as this is the utility used to inspect the systemd-boot
configuration.

This test is only executed if systemd is installed, the bootctl
utility exists and the system is booted in UEFI mode.