### PR TITLE
[FIRE-4540] Modify test to better measure rules

### DIFF
--- a/include/tests_firewalls
+++ b/include/tests_firewalls
@@ -506,13 +506,13 @@
     # Test        : FIRE-4540
     # Description : Check nftables configuration
     if HasData "${NFTBINARY}"; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
-    Register --test-no FIRE-4540 --os Linux --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check for empty nftables configuration"
+    Register --test-no FIRE-4540 --os Linux --preqs-met ${PREQS_MET} --weight L --network NO --root-only YES --category security --description "Check for empty nftables configuration"
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check for empty ruleset
-        NFT_RULES_LENGTH=$(${NFTBINARY} export json 2> /dev/null | wc -c)
-        if [ ${NFT_RULES_LENGTH} -le 16 ]; then
+        NFT_RULES_LENGTH=$(${NFTBINARY} list ruleset --stateless 2> /dev/null | ${EGREPBINARY} -v "table|chain|;$|}$|^$" | ${WCBINARY} -l)
+        if [ ${NFT_RULES_LENGTH} -le 3 ]; then
             FIREWALL_EMPTY_RULESET=1
-            LogText "Result: this firewall set has 16 rules or less and is considered to be empty"
+            LogText "Result: this firewall set has 3 rules or less and is considered to be empty"
         else
             LogText "Result: found ${NFT_RULES_LENGTH} rules in nftables configuration"
         fi


### PR DESCRIPTION
This test was previously measuring the number of bytes (wc -c)
in the exported JSON which is likely not what was intended and
will lead to false positives anytime the number of output bytes 
exceeds 16.

The export feature is [poorly documented](https://bugzilla.netfilter.org/show_bug.cgi?id=1279) and requires the jansson
package on the target system to export as JSON - which may not
always be the case. 

Lastly, 16 is an arbitrary and uncessarily high number. A simple
workstation firewall can have only [3 rules](https://wiki.nftables.org/wiki-nftables/index.php/Simple_ruleset_for_a_workstation) and be effective.

This commit makes use of 'nft list ruleset' instead of the export
command, strips out blank lines as well as table & chain headers
before measuring the number of lines in the output. Any result
with more than 3 rules is now considered non-empty. This is more
consistent with the equivalent iptables test case.