### PR TITLE
[AUTH-9252] Sudo configuration file/folder check improvements

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -483,34 +483,36 @@
 #################################################################################
 #
     # Test        : AUTH-9252
-    # Description : Check permissions for sudo configuration files
+    # Description : Check ownership and permissions for sudo configuration files
     if [ ! -z "${SUDOERS_FILE}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
-    Register --test-no AUTH-9252 --preqs-met ${PREQS_MET} --weight L --network NO --root-only YES --category security --description "Check permissions for sudo configuration files"
+    Register --test-no AUTH-9252 --preqs-met ${PREQS_MET} --weight L --network NO --root-only YES --category security --description "Check ownership and permissions for sudo configuration files"
     if [ ${SKIPTEST} -eq 0 ]; then
       SUDO_CONFIG_FILES="${SUDOERS_FILE}"
       SUDOERS_D="${SUDOERS_FILE}.d"
       if [ -d "${SUDOERS_D}" ]; then
-	LogText "Test: checking drop-in directory (${SUDOERS_D}) permissions"
-	FIND=$(ls -ld ${SUDOERS_D} | ${CUTBINARY} -c 2-10)
-	LogText "Result: Found directory permissions: ${FIND}"
-	if [ "${FIND}" = "rwxrwx---" -o "${FIND}" = "rwxr-x---" -o "${FIND}" = "rwx------" ]; then
-	  LogText "Result: directory ${SUDOERS_D} permissions OK"
+	LogText "Test: checking drop-in directory (${SUDOERS_D})"
+	FIND=$(${LSBINARY} -ld ${SUDOERS_D} | ${CUTBINARY} -c 2-10)
+	FIND1=$(${LSBINARY} -nd ${SUDOERS_D} | ${AWKBINARY} '{print $3$4}')
+	LogText "Result: Found directory permissions: ${FIND} and owner UID GID: ${FIND1}"
+	if [ "${FIND}" = "rwxrwx---" -o "${FIND}" = "rwxr-x---" -o "${FIND}" = "rwx------" ] && [ "${FIND1}" = "00" ]; then
+	  LogText "Result: directory ${SUDOERS_D} permissions/ownership OK"
 	  Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_OK}" --color GREEN
 	else
-	  LogText "Result: directory has possibly unsafe permissions"
-          Display --indent 4 --text "- Permissions for: ${SUDOERS_D}" --result "${STATUS_WARNING}" --color RED
+	  LogText "Result: directory has possibly unsafe permissions/ownership"
+          Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_WARNING}" --color RED
 	fi
 	SUDO_CONFIG_FILES="${SUDO_CONFIG_FILES} $(${FINDBINARY} ${SUDOERS_D} -type f -print)"
       fi
       for f in ${SUDO_CONFIG_FILES}; do
-        LogText "Test: checking file (${f}) permissions"
-        FIND=$(ls -l ${f} | ${CUTBINARY} -c 2-10)
-        LogText "Result: Found file permissions: ${FIND}"
-        if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ]; then
-            LogText "Result: file ${f} permissions OK"
+        LogText "Test: checking file (${f})"
+        FIND=$(${LSBINARY} -l ${f} | ${CUTBINARY} -c 2-10)
+	FIND1=$(${LSBINARY} -n ${f} | ${AWKBINARY} '{print $3$4}')
+        LogText "Result: Found file permissions: ${FIND} and owner UID GID: ${FIND1}"
+        if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ] && [ "${FIND1}" = "00" ]; then
+            LogText "Result: file ${f} permissions/ownerhsip OK"
 	    Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_OK}" --color GREEN
         else
-            LogText "Result: file has possibly unsafe permissions"
+            LogText "Result: file has possibly unsafe permissions/ownership"
 	    Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_WARNING}" --color RED
         fi
       done

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -483,20 +483,27 @@
 #################################################################################
 #
     # Test        : AUTH-9252
-    # Description : Check for sudoers file permissions
+    # Description : Check permissions for sudo configuration files
     if [ ! -z "${SUDOERS_FILE}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
-    Register --test-no AUTH-9252 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check sudoers file"
+    Register --test-no AUTH-9252 --preqs-met ${PREQS_MET} --weight L --network NO --root-only YES --category security --description "Check permissions for sudo configuration files"
     if [ ${SKIPTEST} -eq 0 ]; then
-        LogText "Test: checking sudoers file (${SUDOERS_FILE}) permissions"
-        FIND=$(ls -l ${SUDOERS_FILE} | ${CUTBINARY} -c 2-10)
+      SUDO_CONFIG_FILES="${SUDOERS_FILE}"
+      SUDOERS_D="${SUDOERS_FILE}.d"
+      if [ -d "${SUDOERS_D}" ]; then
+	SUDO_CONFIG_FILES="${SUDO_CONFIG_FILES} $(${FINDBINARY} ${SUDOERS_D} -type f -print)"
+      fi
+      for f in ${SUDO_CONFIG_FILES}; do
+        LogText "Test: checking file (${f}) permissions"
+        FIND=$(ls -l ${f} | ${CUTBINARY} -c 2-10)
         LogText "Result: Found file permissions: ${FIND}"
         if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ]; then
-            LogText "Result: file ${SUDOERS_FILE} has correct permissions"
-            Display --indent 4 --text "- Check sudoers file permissions" --result "${STATUS_OK}" --color GREEN
+            LogText "Result: file ${f} has correct permissions"
+	    Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_OK}" --color GREEN
         else
-            LogText "Result: file has possibly unsafe file permissions"
-            Display --indent 4 --text "- Check sudoers file permissions" --result "${STATUS_WARNING}" --color RED
+            LogText "Result: file has possibly unsafe permissions"
+	    Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_WARNING}" --color RED
         fi
+      done
     fi
 #
 #################################################################################

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -490,6 +490,16 @@
       SUDO_CONFIG_FILES="${SUDOERS_FILE}"
       SUDOERS_D="${SUDOERS_FILE}.d"
       if [ -d "${SUDOERS_D}" ]; then
+	LogText "Test: checking drop-in directory (${SUDOERS_D}) permissions"
+	FIND=$(ls -ld ${SUDOERS_D} | ${CUTBINARY} -c 2-10)
+	LogText "Result: Found directory permissions: ${FIND}"
+	if [ "${FIND}" = "rwxrwx---" -o "${FIND}" = "rwxr-x---" -o "${FIND}" = "rwx------" ]; then
+	  LogText "Result: directory ${SUDOERS_D} permissions OK"
+	  Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_OK}" --color GREEN
+	else
+	  LogText "Result: directory has possibly unsafe permissions"
+          Display --indent 4 --text "- Permissions for: ${SUDOERS_D}" --result "${STATUS_WARNING}" --color RED
+	fi
 	SUDO_CONFIG_FILES="${SUDO_CONFIG_FILES} $(${FINDBINARY} ${SUDOERS_D} -type f -print)"
       fi
       for f in ${SUDO_CONFIG_FILES}; do
@@ -497,7 +507,7 @@
         FIND=$(ls -l ${f} | ${CUTBINARY} -c 2-10)
         LogText "Result: Found file permissions: ${FIND}"
         if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ]; then
-            LogText "Result: file ${f} has correct permissions"
+            LogText "Result: file ${f} permissions OK"
 	    Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_OK}" --color GREEN
         else
             LogText "Result: file has possibly unsafe permissions"


### PR DESCRIPTION
First commit adds permissions checks for files in the configuration drop-in directory (eg. /etc/sudoers.d) if it exists and closes #600 .

Second commit adds permissions checks for the drop-in directory if it exists. Previously only files were checked.

Third commit adds file & directory ownership checks to ensure all sudo configuration files/folders are owned by UID=0 and GID=0.

Also includes minor changes to phrasing and changing all references of 'ls' to 'LSBINARY'.

This has been tested on Linux (Archlinux). Tests included checking (and finding) bad drop-in directory permissions and bad permissions/ownership of files within the drop-in directory.

Needs testing on non-Linux hosts, specifically *BSDs which I understand can have multiple accounts with a UID of 0.