### PR TITLE
better OpenBSD support

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -45,6 +45,8 @@ AUTH-9340:test:security:authentication:Solaris:Solaris account locking:
 AUTH-9402:test:security:authentication::Query LDAP authentication support:
 AUTH-9406:test:security:authentication::Query LDAP servers in client configuration:
 AUTH-9408:test:security:authentication::Logging of failed login attempts via /etc/login.defs:
+AUTH-9409:test:security:authentication:OpenBSD:Check for doas file:
+AUTH-9410:test:security:authentication:OpenBSD:Check for doas file permissions:
 AUTH-9489:test:security:authentication:DragonFly:Check login shells for passwordless accounts:
 BANN-7113:test:security:banners:FreeBSD:Check COPYRIGHT banner file:
 BANN-7124:test:security:banners::Check issue banner file:
@@ -71,6 +73,8 @@ BOOT-5184:test:security:boot_services:Linux:Check permissions for boot files/scr
 BOOT-5202:test:security:boot_services::Check uptime of system:
 BOOT-5260:test:security:boot_services::Check single user mode for systemd:
 BOOT-5261:test:security:boot_services:DragonFly:Check for DragonFly boot loader presence:
+BOOT-5262:test:security:boot_services:OpenBSD:Check for OpenBSD boot daemons:
+BOOT-5263:test:security:boot_services:OpenBSD:Check permissions for boot files/scripts:
 CONT-8004:test:security:containers:Solaris:Query running Solaris zones:
 CONT-8102:test:security:containers::Checking Docker status and information:
 CONT-8104:test:security:containers::Checking Docker info for any warnings:

--- a/include/binaries
+++ b/include/binaries
@@ -109,9 +109,11 @@
                             base64)                 BASE64BINARY="${BINARY}";          LogText "  Found known binary: base64 (encoding tool) - ${BINARY}" ;;
                             blkid)                  BLKDBINARY="${BINARY}";            LogText "  Found known binary: blkid (information about block devices) - ${BINARY}" ;;
                             cat)                    CAT_BINARY="${BINARY}";            LogText "  Found known binary: cat (generic file handling) - ${BINARY}" ;;
+                            cc)                     CCBINARY="${BINARY}";              COMPILER_INSTALLED=1;  LogText "  Found known binary: cc (compiler) - ${BINARY}" ;;			    
                             chkconfig)              CHKCONFIGBINARY=${BINARY};         LogText "  Found known binary: chkconfig (administration tool) - ${BINARY}" ;;
                             clamconf)               CLAMCONF_BINARY=${BINARY};         LogText "  Found known binary: clamconf (information about ClamAV) - ${BINARY}" ;;
                             clamscan)               CLAMSCANBINARY=${BINARY};          LogText "  Found known binary: clamscan (AV scanner) - ${BINARY}" ;;
+                            clang)                  CLANGBINARY=${BINARY};             COMPILER_INSTALLED=1;  LogText "  Found known binary: clang (compiler) - ${BINARY}" ;;			    
                             cfagent)                CFAGENTBINARY="${BINARY}";         FILE_INT_TOOL_FOUND=1;                 LogText "  Found known binary: cfengine agent (configuration tool) - ${BINARY}" ;;
                             chkrootkit)             CHKROOTKITBINARY="${BINARY}";      MALWARE_SCANNER_INSTALLED=1;           LogText "  Found known binary: chkrootkit (malware scanner) - ${BINARY}" ;;
                             comm)                   COMMBINARY="${BINARY}";            LogText "  Found known binary: comm (file compare) - ${BINARY}" ;;
@@ -194,6 +196,7 @@
                             python)                 PYTHONBINARY="${BINARY}";          PYTHONVERSION=$(${BINARY}  --version 2>&1 | sed 's/^Python //'); LogText "Found known binary: ${FILENAME} (programming language interpreter) - ${BINARY} (version ${PYTHONVERSION})" ;;
                             python2)                PYTHON2BINARY="${BINARY}";         PYTHON2VERSION=$(${BINARY}  --version 2>&1 | sed 's/^Python //'); LogText "Found known binary: ${FILENAME} (programming language interpreter) - ${BINARY} (version ${PYTHON2VERSION})" ;;
                             python3)                PYTHON3BINARY="${BINARY}";         PYTHON3VERSION=$(${BINARY}  --version 2>&1 | sed 's/^Python //'); LogText "Found known binary: ${FILENAME} (programming language interpreter) - ${BINARY} (version ${PYTHON3VERSION})" ;;
+                            rcctl)                  RCCTLBINARY="${BINARY}";           LogText "  Found known binary: rcctl (services and daemons configuration and control) - ${BINARY}" ;;
                             readlink)               READLINKBINARY="${BINARY}";        LogText "  Found known binary: readlink (follows symlinks) - ${BINARY}" ;;
                             rkhunter)               RKHUNTERBINARY="${BINARY}";        MALWARE_SCANNER_INSTALLED=1;           LogText "  Found known binary: rkhunter (malware scanner) - ${BINARY}" ;;
                             rootsh)                 ROOTSHBINARY="${BINARY}";          LogText "  Found known binary: rootsh (wrapper for shells) - ${BINARY}" ;;

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -1371,6 +1371,50 @@
 #
 #################################################################################
 #
+    # Test        : AUTH-9409
+    # Description : Check for doas file
+    DOAS_FILE=""
+    Register --test-no AUTH-9409 --os OpenBSD --weight L --network NO --category security --description "Checking /etc/doas.conf file"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        FOUND=0
+        LogText "Test: checking presence /etc/doas.conf"
+        if [ -f /etc/doas.conf ]; then
+        DOAS_FILE=/etc/doas.conf
+            FOUND=1
+            LogText "Result: file /etc/doas.conf found"
+        else
+            LogText "Result: file /etc/doas.conf not found"
+        fi
+        if [ ${FOUND} -eq 1 ]; then
+            LogText "Result: /etc/doas.conf file found"
+            Display --indent 2 --text "- doas file" --result "${STATUS_FOUND}" --color GREEN
+        else
+            LogText "Result: doas file NOT found"
+            Display --indent 2 --text "- doas file" --result "${STATUS_NOT_FOUND}" --color YELLOW
+        fi
+    fi
+#
+#################################################################################
+#
+    # Test        : AUTH-9410
+    # Description : Check for doas file permissions
+    if [ ! -z "${DOAS_FILE}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no AUTH-9410 --os OpenBSD --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check /etc/doas.conf file permissions"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        LogText "Test: checking /etc/doas.conf permissions"
+        FIND=$(ls -l ${DOAS_FILE} | ${CUTBINARY} -c 2-10)
+        LogText "Result: Found /etc/doas.conf file permissions: ${FIND}"
+        if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ]; then
+            LogText "Result: file /etc/doas.conf has correct permissions"
+            Display --indent 4 --text "- Check doas file permissions" --result "${STATUS_OK}" --color GREEN
+        else
+            LogText "Result: file has possibly unsafe file permissions"
+            Display --indent 4 --text "- Check doas file permissions" --result "${STATUS_WARNING}" --color RED
+        fi
+    fi
+#
+#################################################################################
+#
 
 Report "auth_failed_logins_logged=${AUTH_FAILED_LOGINS_LOGGED}"
 Report "ldap_auth_enabled=${LDAP_AUTH_ENABLED}"

--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -125,7 +125,7 @@
                     if [ -f /usr/bin/init-openrc ]; then SERVICE_MANAGER="openrc"; fi
                 fi
             ;;
-            "DragonFly" | "NetBSD" | "FreeBSD")
+            "DragonFly" | "NetBSD" | "FreeBSD" | "OpenBSD")
                 if [ -x /sbin/init -a -d ${ROOTDIR}etc/rc.d -a -f ${ROOTDIR}etc/rc ]; then
                     SERVICE_MANAGER="bsdrc"
                 fi
@@ -819,6 +819,120 @@
             fi
         else
             LogText "Result: file ${ROOTDIR}usr/lib/systemd/system/rescue.service does not exist"
+        fi
+    fi
+#
+#################################################################################
+#
+    # Test        : BOOT-5262
+    # Description : Check for OpenBSD boot daemons
+    Register --test-no BOOT-5262 --os OpenBSD --weight L --network NO --category security --description "Check for OpenBSD boot daemons"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        if HasData "${RCCTLBINARY}"; then
+            LogText "Result: rcctl binary found, trying that to discover information"
+            # OpenBSD (Ask rcctl(8) for running daemons)
+            LogText "Searching for running daemons (rcctl)"
+            FIND=$(${RCCTLBINARY} ls started)
+            COUNT=0
+            Report "running_service_tool=rcctl"
+            for ITEM in ${FIND}; do
+                LogText "Found running daemon: ${ITEM}"
+                Report "running_service[]=${ITEM}"
+                COUNT=$((COUNT + 1 ))
+            done
+            LogText "Note: Run rcctl ls all | egrep  '^(pf|check_quotas|library_aslr)$' to see all daemons"
+            Display --indent 2 --text "- Check running daemons (rcctl)" --result "${STATUS_DONE}" --color GREEN
+            Display --indent 8 --text "Result: found ${COUNT} running daemons"
+            LogText "Result: Found ${COUNT} running daemons"
+
+            # OpenBSD (Ask rcctl(8) for enabled daemons)
+            LogText "Searching for enabled daemons (rcctl)"
+            FIND=$(${RCCTLBINARY} ls on | ${EGREPBINARY} -v '^(pf|check_quotas|library_aslr)$')
+            COUNT=0
+            Report "boot_service_tool=rcctl"
+            for ITEM in ${FIND}; do
+                LogText "Found enabled daemon at boot: ${ITEM}"
+                Report "boot_service[]=${ITEM}"
+                COUNT=$((COUNT + 1 ))
+            done
+            LogText "Note: Run rcctl ls all | egrep  '^(pf|check_quotas|library_aslr)$' to see all daemons"
+            Display --indent 2 --text "- Check enabled daemons at boot (rcctl)" --result "${STATUS_DONE}" --color GREEN
+            Display --indent 8 --text "Result: found ${COUNT} enabled daemons at boot"
+            LogText "Result: Found ${COUNT} enabled daemons at boot"
+        fi
+    fi
+#
+#################################################################################
+#
+    # Test        : BOOT-5263
+    # Description : Check OpenBSD world writable startup scripts
+    Register --test-no BOOT-5263 --os OpenBSD --weight L --network NO --category security --description "Check permissions for boot files/scripts"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        FOUND=0
+        CHECKDIR="${ROOTDIR}etc/rc.d"
+        LogText "Result: checking ${ROOTDIR}etc/rc.d scripts for writable bit"
+        LogText "Test: checking if directory ${DIR} exists"
+        if [ -d ${CHECKDIR} ]; then
+            LogText "Result: directory ${DIR} found"
+            LogText "Test: checking for available files in directory"
+            # OpenBSD uses symlinks to create another instance of daemons
+            FIND=$(${FINDBINARY} ${CHECKDIR} \( -type f -o -type l \) -print | ${SORTBINARY})
+            if [ ! -z "${FIND}" ]; then
+                LogText "Result: found files in directory, checking permissions now"
+                for FILE in ${FIND}; do
+                    LogText "Test: checking permissions of file ${FILE}"
+                    ShowSymlinkPath "${FILE}"
+                    if [ ${FOUNDPATH} -eq 1 ]; then
+                        CHECKFILE="${SYMLINK}"
+                        LogText "Result: found the path behind this symlink (${CHECKFILE} --> ${FILE})"
+                    else
+                        CHECKFILE="${FILE}"
+                    fi
+                    if IsWorldWritable ${CHECKFILE}; then
+                        FOUND=1
+                        LogText "Result: warning, file ${CHECKFILE} is world writable"
+                    else
+                        LogText "Result: good, file ${CHECKFILE} not world writable"
+                    fi
+                done
+            else
+                LogText "Result: found no files in directory."
+            fi
+        else
+            LogText "Result: directory ${CHECKDIR} not found. Skipping.."
+        fi
+
+        # Other files
+        CHECKFILES="${ROOTDIR}etc/rc ${ROOT}etc/rc.conf ${ROOT}etc/rc.conf.local ${ROOTDIR}etc/rc.local"
+        for I in ${CHECKFILES}; do
+            if [ -f ${I} ]; then
+                ShowSymlinkPath "${I}"
+                if [ ${FOUNDPATH} -eq 1 ]; then
+                    CHECKFILE="${SYMLINK}"
+                    LogText "Result: found the path behind this symlink (${CHECKFILE} --> ${I})"
+                else
+                    CHECKFILE="${I}"
+                fi
+                LogText "Test: Checking ${CHECKFILE} file for writable bit"
+                if IsWorldWritable ${CHECKFILE}; then
+                    FOUND=1
+                    ReportWarning ${TEST_NO} "Found writable startup script ${CHECKFILE}"
+                    LogText "Result: warning, file ${CHECKFILE} is world writable"
+                else
+                    LogText "Result: good, file ${CHECKFILE} not world writable"
+                fi
+            fi
+        done
+
+        # Check results
+        if [ ${FOUND} -eq 1 ]; then
+            Display --indent 2 --text "- Check startup files (permissions)" --result "${STATUS_WARNING}" --color RED
+            ReportWarning ${TEST_NO} "Found world writable startup scripts" "-" "-"
+            LogText "Result: found one or more scripts which are possibly writable by other users"
+            AddHP 0 3
+        else
+            Display --indent 2 --text "- Check startup files (permissions)" --result "${STATUS_OK}" --color GREEN
+            AddHP 3 3
         fi
     fi
 #

--- a/include/tests_hardening
+++ b/include/tests_hardening
@@ -54,7 +54,7 @@
             LogText "Result: no compilers found"
         else
             # TODO - c89 c99 cpp ld
-            TEST_BINARIES="${ASBINARY} ${GCCBINARY}"
+            TEST_BINARIES="${ASBINARY} ${CCBINARY} ${CLANGBINARY} ${GCCBINARY}"
             for ITEM in ${TEST_BINARIES}; do
                 FILE="${ITEM}"
                 LogText "Test: Check file permissions for ${ITEM}"

--- a/include/tests_php
+++ b/include/tests_php
@@ -72,6 +72,9 @@
                 ${ROOTDIR}etc/opt/remi/php70/php.ini \
                 ${ROOTDIR}etc/opt/remi/php71/php.ini \
                 ${ROOTDIR}etc/opt/remi/php72/php.ini"
+    # HEADS-UP: OpenBSD, last two releases are supported, and snapshots of -current
+    PHPINILOCS="${PHPINILOCS} \
+                ${ROOTDIR}etc/php-5.6.ini ${ROOTDIR}etc/php-7.0.ini ${ROOTDIR}etc/php-7.1.ini ${ROOTDIR}etc/php-7.2.ini"
 
     PHPINIDIRS="${ROOTDIR}etc/php5/conf.d \
                 ${ROOTDIR}etc/php/7.0/cli/conf.d \
@@ -92,6 +95,9 @@
                 ${ROOTDIR}opt/alt/php56/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php70/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php71/etc/php.d.all"
+    # HEADS-UP: OpenBSD, last two releases are supported, and snapshots of -current
+    PHPINIDIRS="${PHPINIDIRS} \
+                ${ROOTDIR}etc/php-5.6 ${ROOTDIR}etc/php-7.0 ${ROOTDIR}etc/php-7.1 ${ROOTDIR}etc/php-7.2"
 #
 #################################################################################
 #


### PR DESCRIPTION
- doas is OpenBSD sudo alternative
- OpenBSD uses init and /etc/rc, /etc/rc.d, thus let's call its service manager bsdrc not to see UNKNOWN
- OpenBSD uses rcctl for start/enable daemons (well it lists also non-daemons thus filtered out via grep)
- check OpenBSD rc scripts and configs for not being world readable
- OpenBSD uses clang and gcc as compiler, both present via cc and clang (amd64) and gcc for GNU cc
- php ini and configuration on OpenBSD tunning