### PR TITLE
update CentOS releases in software-eol.db

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -11,8 +11,8 @@
 #
 # CentOS
 #
-os:CentOS Linux release 5:2017-03-31:1490911200:
-os:CentOS Linux release 6:2020-11-30:1606690800:
+os:CentOS release 5:2017-03-31:1490911200:
+os:CentOS release 6:2020-11-30:1606690800:
 os:CentOS Linux release 7:2024-06-30:1719698400:
 #
 # FreeBSD - https://www.freebsd.org/security/unsupported.html


### PR DESCRIPTION
CentOS 5 and 6 is named `CentOS release`, not `CentOS Linux release`.

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>