### PR TITLE
Detect BSD-style (rc.d) init in Linux systems

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -96,7 +96,11 @@
                                 ;;
 
                                 "init" | "initsplash")
-                                    SERVICE_MANAGER="SysV Init"
+                                    if [ -d ${ROOTDIR}etc/rc.d ]; then
+                                        SERVICE_MANAGER="bsdrc.d"
+                                    else
+                                        SERVICE_MANAGER="SysV Init"
+                                    fi
                                 ;;
                                 systemd)
                                     SERVICE_MANAGER="systemd"


### PR DESCRIPTION
At least Slackware Linux uses this. Even though it's compatible with SysV init scripts, it's still technically BSD-style init.

I wasn't sure whether to name it `bsdrc` or `bsdrc.d`, but there's no monolithic `/etc/rc` script I think the `rc.d` is more appropriate. Also for instance [this article](https://www.freebsd.org/doc/en/articles/rc-scripting/article.html) uses `rc.d` name for it.