### PR TITLE
[CRYP-7930] Modify to use 'lsblk' and 'cryptsetup'

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -141,6 +141,7 @@
                             cfagent)                CFAGENTBINARY="${BINARY}";         FILE_INT_TOOL_FOUND=1;                 LogText "  Found known binary: cfengine agent (configuration tool) - ${BINARY}" ;;
                             chkrootkit)             CHKROOTKITBINARY="${BINARY}";      MALWARE_SCANNER_INSTALLED=1;           LogText "  Found known binary: chkrootkit (malware scanner) - ${BINARY}" ;;
                             comm)                   COMMBINARY="${BINARY}";            LogText "  Found known binary: comm (file compare) - ${BINARY}" ;;
+                            cryptsetup)             CRYPTSETUPBINARY="${BINARY}";      LogText "  Found known binary: cryptsetup (block device encryption) - ${BINARY}" ;;
                             csum)                   CSUMBINARY="${BINARY}";            LogText "  Found known binary: csum (hashing tool on AIX) - ${BINARY}" ;;
                             curl)                   CURLBINARY="${BINARY}";            CURLVERSION=$(${BINARY} --version | grep "^curl" | awk '{ if ($1=="curl") { print $2 }}'); LogText "  Found known binary: curl (browser, download utility) - ${BINARY}" ;;
                             cut)                    CUTBINARY="${BINARY}";             LogText "  Found known binary: cut (text stream editor) - ${BINARY}" ;;
@@ -186,6 +187,7 @@
                             logrotate)              LOGROTATEBINARY="${BINARY}";       LogText "  Found known binary: logrotate (log rotation tool) - ${BINARY}" ;;
                             ls)                     LSBINARY="${BINARY}";              LogText "  Found known binary: ls (file listing) - ${BINARY}" ;;
                             lsattr)                 LSATTRBINARY="${BINARY}";          LogText "  Found known binary: lsattr (file attributes) - ${BINARY}" ;;
+			    lsblk)		    LSBLKBINARY="${BINARY}";	       LogText "  Found known binary: lsblk (block devices) - ${BINARY}" ;;
                             lsmod)                  LSMODBINARY="${BINARY}";           LogText "  Found known binary: lsmod (kernel modules) - ${BINARY}" ;;
                             lsof)                   LSOFBINARY="${BINARY}";            LogText "  Found known binary: lsof (open files) - ${BINARY}" ;;
                             lsvg)                   LSVGBINARY=${BINARY};              LogText "  Found known binary: lsvg (volume manager) - ${BINARY}" ;;

--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -144,7 +144,7 @@
 	fi
       done
       Display --indent 2 --text "- Found ${FOUND} LUKS encrypted block devices." --result OK --color WHITE
-      unset BLOCK_DEV
+      unset BLOCK_DEV FOUND
     fi
 #
 #################################################################################

--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -126,34 +126,28 @@
             ReportSuggestion ${TEST_NO} "Check available certificates for expiration"
         fi
     fi
+
 #
 #################################################################################
 #
     # Test        : CRYP-7930
-    # Description : Determine if system uses disk or file encryption
-    Register --test-no CRYP-7930 --weight L --network NO --category security --description "Determine if system uses disk or file encryption"
+    # Description : Determine if system uses LUKS block device encryption
+    if [ ! "${LSBLKBINARY}" = "" -a ! "${CRYPTSETUPBINARY}" = "" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no CRYP-7930 --preqs-met ${PREQS_MET} --weight L --network NO --root-only YES --category security --description "Determine if system uses LUKS block device encryption"
     if [ ${SKIPTEST} -eq 0 ]; then
-        FILE="${ROOTDIR}etc/crypttab"
-        if [ -f ${FILE} ]; then
-            LogText "Result: crypttab file (${FILE}) exists"
-            DATA=$(${GREPBINARY} "^[a-z]" ${FILE} | ${TRBINARY} -cd '[:alnum:]_\-=,\n\t ' | ${SEDBINARY} 's/[[:blank:]]/__space__/g')
-            for LINE in ${DATA}; do
-                LINE=$(echo ${LINE} | ${SEDBINARY} 's/__space__/ /g')
-                if ContainsString "luks," "${LINE}"; then
-                    PARTITION=$(echo ${LINE} | ${AWKBINARY} '{print $1}' | ${AWKBINARY} -F_ '{print $1}')
-                    LogText "Result: Found LUKS encryption on partition ${PARTITION}"
-                    Report "encryption[]=luks,partition,${PARTITION}"
-                fi
-            done
-            unset DATA LINE PARTITION
-        else
-            LogText "Result: crypttab file (${FILE}) does not exist"
-        fi
+      FOUND=0
+      for BLOCK_DEV in $(${LSBLKBINARY} --noheadings -o PATH); do
+	if ${CRYPTSETUPBINARY} isLuks ${BLOCK_DEV}; then
+	  LogText "Result: Found LUKS encrypted block device: ${BLOCK_DEV}"
+	  Report "encryption[]=luks,block_device,${BLOCK_DEV}"
+	  ((FOUND++))
+	fi
+      done
+      Display --indent 2 --text "- Found ${FOUND} LUKS encrypted block devices." --result OK --color WHITE
+      unset BLOCK_DEV
     fi
 #
 #################################################################################
-#
-
 WaitForKeyPress
 
 #


### PR DESCRIPTION
There are several challenges with the existing method of using
/etc/crypttab:

1)encrypted rootfs partitions are not typically listed in this
file (users are prompted for password in early boot instead)

2)the 'luks' option is the default option so it is possible for
/etc/crypttab entries to never have this set explicitly and any
block device configured as such is currently missed

3)any device mounted manually, or using any other mechanism aside
from /etc/crypttab will be missed

This commit executes 'cryptsetup isLuks' on every block device in
the system to determine whether it is a LUKS device. This handles
all 3 cases mentioned above and closes issue #615.

Test case wording was also updated to reflect the fact that it
only checks for LUKS encrypted block devices. So, plain dm-crypt
and TrueCrypt/VeraCrypt block device encryption is not detected.
Nor is any file system level encryption such as eCryptfs, EncFs,
gocryptfs.