### PR TITLE
add Ubuntu nologin path

### DIFF
--- a/include/tests_homedirs
+++ b/include/tests_homedirs
@@ -57,7 +57,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check if users' home directories permissions are 750 or more restrictive
         FOUND=0
-        for LINE in "$(${CAT_BINARY} ${ROOTDIR}etc/passwd | ${EGREPBINARY} -v '^(root|halt|sync|shutdown)' | ${AWKBINARY} -F: '($7 !="/sbin/nologin" && $7 != "/bin/false") { print }')"; do
+        for LINE in "$(${EGREPBINARY} -v '^(root|halt|sync|shutdown)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !="/sbin/nologin" && $7 !="/usr/sbin/nologin" && $7 != "/bin/false") { print }')"; do
             USER=$(echo ${LINE} | ${CUTBINARY} -d: -f1)
             DIR=$(echo ${LINE} | ${CUTBINARY} -d: -f6)
             if [ -d ${DIR} ]; then
@@ -87,7 +87,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check if users own their home directories
         FOUND=0
-        for LINE in "$(${CAT_BINARY} ${ROOTDIR}etc/passwd | ${EGREPBINARY} -v '^(root|halt|sync|shutdown)' | ${AWKBINARY} -F: '($7 !="/sbin/nologin" && $7 != "/bin/false") { print }')"; do
+        for LINE in "$(${EGREPBINARY} -v '^(root|halt|sync|shutdown)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !="/sbin/nologin" && $7 !="/usr/sbin/nologin" && $7 != "/bin/false") { print }')"; do
             USER=$(echo ${LINE} | ${CUTBINARY} -d: -f1)
             DIR=$(echo ${LINE} | ${CUTBINARY} -d: -f6)
             if [ -d ${DIR} ]; then


### PR DESCRIPTION
Exclude the default Ubuntu `nologin` shell path so that `HOME-9304` and `HOME-9306` doesn't trigger for e.g. the `daemon` user with the `/usr/sbin` home directory and the `nologin` shell.

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>