### PR TITLE
Fix --user in isRunning allowing word split and cleanup ShellCheck warns

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1404,17 +1404,18 @@
         if [ -z "${search}" ]; then ExitFatal "Missing process to search for when using IsRunning function"; fi
         RUNNING=0
         # AIX does not fully support pgrep options, so using ps instead
-        if [ -n "${PGREPBINARY}" -a ! "${OS}" = "AIX" ]; then
+        if [ -n "${PGREPBINARY}" ] && [ "${OS}" != "AIX" ]; then
             # When --user is used, perform a search using the -u option
                             # Initialize users for strict mode
             if [ -n "${users:-}" ]; then
-                for u in "${users}"; do
-                    user_uid=$(getent passwd ${u} 2> /dev/null | ${AWKBINARY} -F: '{print $3}')
+                for u in ${users}; do
+                    # shellcheck disable=SC2016
+                    user_uid=$(getent passwd "${u}" 2> /dev/null | ${AWKBINARY} -F: '{print $3}')
                     # Only perform search if user exists and we had no match yet
                     if [ -n "${user_uid}" ]; then
                         if [ -z "${FIND}" ]; then
                             LogText "Performing pgrep scan using uid ${user_uid}"
-                            FIND=$(${PGREPBINARY} ${pgrep_options} -u ${user_uid} "${search}" | ${TRBINARY} '\n' ' ')
+                            FIND=$(${PGREPBINARY} ${pgrep_options} -u "${user_uid}" "${search}" | ${TRBINARY} '\n' ' ')
                         fi
                     fi
                 done
@@ -1423,24 +1424,29 @@
                 FIND=$(${PGREPBINARY} ${pgrep_options} "${search}" | ${TRBINARY} '\n' ' ')
             fi
         else
-            if [ ${SHELL_IS_BUSYBOX} -eq 1 ]; then
+            if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
                 # This search is not foolproof
                 LogText "Performing simple ps scan (busybox)"
                 PSOPTIONS=" -o args="
+                # shellcheck disable=SC2086
                 FIND=$(${PSBINARY} ${PSOPTIONS} | ${EGREPBINARY} "( |/)${search}" | ${GREPBINARY} -v "grep")
             else
+                # TODO: Test in AIX with strict mode
                 if [ -n "${users}" ]; then
-                    for u in "${users}"; do
-                        user_uid=$(getent passwd ${u} 2> /dev/null | ${AWKBINARY} -F: '{print $3}')
+                    for u in ${users}; do
+                        # shellcheck disable=SC2016
+                        user_uid=$(getent passwd "${u}" 2> /dev/null | ${AWKBINARY} -F: '{print $3}')
                         # Only perform search if user exists and we had no match yet
                         if [ -n "${user_uid}" ]; then
                             if [ -z "${FIND}" ]; then
                                 if [ ${PARTIAL_SEARCH} -eq 1 ]; then
                                     LogText "Performing ps scan using partial match and for uid ${user_uid}"
-                                    FIND=$(${PSBINARY} -u ${user_uid} -o comm= "${search}" | ${AWKBINARY} -v pattern="${search}" '$0 ~ pattern {print}')
+                                    # shellcheck disable=SC2016
+                                    FIND=$(${PSBINARY} -u "${user_uid}" -o comm= "${search}" | ${AWKBINARY} -v pattern="${search}" '$0 ~ pattern {print}')
                                 else
                                     LogText "Performing ps scan using exact match and for uid ${user_uid}"
-                                    FIND=$(${PSBINARY} -u ${user_uid} -o comm= "${search}" | ${AWKBINARY} -v pattern="^${search}$" '$0 ~ pattern {print}')
+                                    # shellcheck disable=SC2016
+                                    FIND=$(${PSBINARY} -u "${user_uid}" -o comm= "${search}" | ${AWKBINARY} -v pattern="^${search}$" '$0 ~ pattern {print}')
                                 fi
                             fi
                         fi
@@ -1453,9 +1459,11 @@
                     esac
                     if [ ${PARTIAL_SEARCH} -eq 1 ]; then
                         LogText "Performing ps scan using partial match and without uid"
+                        # shellcheck disable=SC2086,SC2016
                         FIND=$(${PSBINARY} ${PSOPTIONS} | ${AWKBINARY} -v pattern="${search}" '$0 ~ pattern {print}')
                     else
                         LogText "Performing ps scan using exact match and without uid"
+                        # shellcheck disable=SC2086,SC2016
                         FIND=$(${PSBINARY} ${PSOPTIONS} | ${AWKBINARY} -v pattern="^${search}$" '$0 ~ pattern {print}')
                     fi
                 fi


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/wiki/SC2066

Add TODO reminder to test --user functionality on AIX with strict mode