### PR TITLE
Fix typos from the fixes for #743

### DIFF
--- a/include/tests_homedirs
+++ b/include/tests_homedirs
@@ -89,7 +89,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check if users own their home directories
         FOUND=0
-        for LINE in "$(${EGREPBINARY} -v '^(daemon|git-shell|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }') { print }')"; do
+        for LINE in "$(${EGREPBINARY} -v '^(daemon|git|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }') { print }')"; do
             USER=$(echo ${LINE} | ${CUTBINARY} -d: -f1)
             DIR=$(echo ${LINE} | ${CUTBINARY} -d: -f6)
             if [ -d ${DIR} ]; then

--- a/include/tests_homedirs
+++ b/include/tests_homedirs
@@ -57,7 +57,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check if users' home directories permissions are 750 or more restrictive
         FOUND=0
-        for LINE in "$(${EGREPBINARY} -v '^(daemon|git-shell|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }')"; do
+        for LINE in "$(${EGREPBINARY} -v '^(daemon|git|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }')"; do
             USER=$(echo ${LINE} | ${CUTBINARY} -d: -f1)
             DIR=$(echo ${LINE} | ${CUTBINARY} -d: -f6)
             if [ -d "${DIR}" ]; then


### PR DESCRIPTION
Define 'git' instead of 'git-shell'.