### PR TITLE
Add Debian EOL

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -69,3 +69,12 @@ os:Slackware Linux 12.2:2013-12-09:1386540000:
 os:Slackware Linux 13.0:2018-07-05:1530738000:
 os:Slackware Linux 13.1:2018-07-05:1530738000:
 os:Slackware Linux 13.37:2018-07-05:1530738000:
+#
+# Debian - https://wiki.debian.org/DebianReleases#Production_Releases
+#
+os:Debian 5.0:2012-02-06:1328482800
+os:Debian 6.0:2016-02-29:1456700400
+os:Debian 7:2018-05-31:1527717600
+os:Debian 8:2020-06-30:1593468000
+os:Debian 9:2022-01-01:1640991600
+os:Debian 10:2022-01-01:1640991600


### PR DESCRIPTION
- Tested on Debian 10.
- use EOL or EOL LTS if exists (but not EOL ELTS)