### PR TITLE
EXIM4: Removed WARNINGs from unset certificate and private key

### DIFF
--- a/include/tests_mail_messaging
+++ b/include/tests_mail_messaging
@@ -137,28 +137,28 @@
                 LogText "Result: ${EXIM_CERTIFICATE}"
                 if [ -f "${EXIM_CERTIFICATE}" ]; then
                     Display --indent 4 --text "- Certificate" --result "${STATUS_FOUND}" --color GREEN
-                    LogText "Result: Certificate found."
+                    LogText "Result: Certificate found"
                 else
                     Display --indent 4 --text "- Certificate" --result "${STATUS_NOT_FOUND}" --color YELLOW
-                    LogText "Result: Certificate not found."
+                    LogText "Result: Certificate not found"
                 fi
             else
-                LogText "Result: Certificate not set."
-                Display --indent 4 --text "- Certificate not set" --result "${STATUS_WARNING}" --color WHITE
+                LogText "Result: Certificate not set"
+                Display --indent 4 --text "- Certificate" --result "Not Configured" --color WHITE
             fi
 
             if [ -n "${EXIM_PRIVATEKEY}" ]; then
                 LogText "Result: ${EXIM_PRIVATEKEY}"
                 if [ -f "${EXIM_PRIVATEKEY}" ]; then
-                    LogText "Result: Private Key found."
+                    LogText "Result: Private Key found"
                     Display --indent 4 --text "- Private Key" --result "${STATUS_FOUND}" --color GREEN
                 else
                     Display --indent 4 --text "- Private Key" --result "${STATUS_NOT_FOUND}" --color YELLOW
-                    LogText "Result: Private Key not found."
+                    LogText "Result: Private Key not found"
                 fi
             else
-                LogText "Result: Private Key not set."
-                Display --indent 4 --text "- Private Key not set" --result "${STATUS_WARNING}" --color WHITE
+                LogText "Result: Private Key not set"
+                Display --indent 4 --text "- Private Key" --result "Not Configured" --color WHITE
             fi
 
             LogText "Test: Exim Verify Certificates"
@@ -204,35 +204,33 @@
 
             LogText "Test: Exim Try Verify Hosts"
             if [ ! -z "${EXIM_TRY_VERIFY_HOSTS}" ]; then
+                LogText "Result: Try Verify Hosts enabled"
                 case "${EXIM_TYPE}" in
                     "INTERNET HOST" )
-                        LogText "Result: Try Verify Hosts enabled."
                         Display --indent 4 --text "- Try Verify Hosts" --result "ENABLED" --color GREEN
                         ;;
                     "SATELLITE" | "SMARTHOST" )
-                        LogText "Result: Try Verify Hosts."
                         Display --indent 4 --text "- Try Verify Hosts" --result "ENABLED" --color YELLOW
                         ;;
                 esac
             else
-                LogText "Result: Try Verify Hosts not enabled."
+                LogText "Result: Try Verify Hosts not enabled"
                 Display --indent 4 --text "- Try Verify Hosts" --result "NOT ENABLED" --color WHITE
             fi
 
             LogText "Test: Exim Verify Hosts"
             if [ ! -z "${EXIM_VERIFY_HOSTS}" ]; then
+                LogText "Result: Verify Hosts enabled"
                 case "${EXIM_TYPE}" in
                     "INTERNET HOST" )
-                        LogText "Result: Verify Hosts."
                         Display --indent 4 --text "- Verify Hosts" --result "ENABLED" --color YELLOW
                         ;;
                     "SATELLITE" | "SMARTHOST" )
-                        LogText "Result: Verify Hosts."
                         Display --indent 4 --text "- Verify Hosts" --result "ENABLED" --color GREEN
                         ;;
                 esac
             else
-                LogText "Result: Verify Hosts."
+                LogText "Result: Verify Hosts not enabled"
                 Display --indent 4 --text "- Verify Hosts" --result "NOT ENABLED" --color WHITE
             fi
         fi


### PR DESCRIPTION
I've been working on a few alternatives for the issues imthenachoman reported in https://github.com/CISOfy/lynis/issues/656

Bad news, I haven't found a simple way to keep the WARNING for unset certificate and private keys.

Good news, removing the WARNINGs does not seem to adversely affect the test.

I haven't previously assigned any hardening points in these tests but it is entirely possible that may be the best way to distinguish between these configuration differences without scaring the users.  I need to experiment with that some more before I have any more changes to submit.

Dave