### PR TITLE
enhance nginx include config detection …

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2249,6 +2249,30 @@
                             if [ "${CONF}" = "${VALUE}" ]; then FOUND=1; LogText "Found this file already in our configuration files array (additions), not adding to queue"; fi
                         done
                         if [ ${FOUND} -eq 0 ]; then NGINX_CONF_FILES_ADDITIONS="${NGINX_CONF_FILES_ADDITIONS} ${VALUE}"; fi
+                    # Check if include value is a relative path only
+                    elif [ -f "${CONFIG_FILE%nginx.conf}${VALUE%;*}" ]; then
+                        VALUE="${CONFIG_FILE%nginx.conf}${VALUE}"
+                        FOUND=0
+                        for CONF in ${NGINX_CONF_FILES}; do
+                            if [ "${CONF}" = "${VALUE}" ]; then FOUND=1; LogText "Found this file already in our configuration files array, not adding to queue"; fi
+                        done
+                        for CONF in ${NGINX_CONF_FILES_ADDITIONS}; do
+                            if [ "${CONF}" = "${VALUE}" ]; then FOUND=1; LogText "Found this file already in our configuration files array (additions), not adding to queue"; fi
+                        done
+                        if [ ${FOUND} -eq 0 ]; then NGINX_CONF_FILES_ADDITIONS="${NGINX_CONF_FILES_ADDITIONS} ${VALUE}"; fi
+                    # Check for additional config files included as follows
+                    # "include sites-enabled/*.conf"
+                    elif [ $(echo ${VALUE} | grep -F -c "*.conf") -gt 0 ]; then
+                        for FOUND_CONF in $(ls ${CONFIG_FILE%nginx.conf}${VALUE%;*}); do
+                            FOUND=0
+                            for CONF in ${NGINX_CONF_FILES}; do
+                                if [ "${CONF}" = "${FOUND_CONF}" ]; then FOUND=1; LogText "Found this file already in our configuration files array, not adding to queue"; fi
+                            done
+                            for CONF in ${NGINX_CONF_FILES_ADDITIONS}; do
+                                if [ "${CONF}" = "${FOUND_CONF}" ]; then FOUND=1; LogText "Found this file already in our configuration files array (additions), not adding to queue"; fi
+                            done
+                            if [ ${FOUND} -eq 0 ]; then NGINX_CONF_FILES_ADDITIONS="${NGINX_CONF_FILES_ADDITIONS} ${FOUND_CONF}"; fi
+                        done
                     else
                         LogText "Result: this include does not point to a file"
                     fi


### PR DESCRIPTION
... to correctly include configs via relative path and wildcards

Hello,
These changes should fix https://github.com/CISOfy/lynis/issues/168
I had a similar issue and noticed that the root cause of my and this issue are the missing support for
- relative paths
- wildcard includes (like sites-enabled/*.conf)

In both cases the conf files were not found and therefor not parsed.
I included the necessary code, which works perfectly fine on 
- bash 5.0.9
- ksh 2020.0

Unfortunately I have no clue how to install bourne-shell on Arch Linux to test that as well :(

This is my first real contribution with bigger code-changes to an open-source project, so please have a little patience with me. I'm willing to do further code changes, if you could show me the direction how to better test or what to change to support bourne-shell as well. Thanks a lot!