### PR TITLE
nginx-test: add log file detection for relative paths

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2181,8 +2181,9 @@
                         if [ ! "${VALUE}" = "" ]; then
                             # If multiple values follow, select first one
                             VALUE=$(echo ${VALUE} | awk '{ print $1 }')
-                            if [ ! -f ${VALUE} ]; then
-                                LogText "Result: could not find referenced log file ${VALUE} in nginx configuration"
+                            # Find both, log files provided with full or relative path
+                            if [ ! -f ${VALUE} -a ! -f "${CONFIG_FILE%nginx.conf}${VALUE}" ]; then
+                                LogText "Result: could not find log file ${VALUE} referenced in nginx configuration"
                                 NGINX_ACCESS_LOG_MISSING=1
                             fi
                         fi
@@ -2218,7 +2219,8 @@
                     # Check if log file exists
                     FILE=$(echo ${VALUE} | awk '{ print $1 }')
                     if [ ! "${FILE}" = "" ]; then
-                        if [ ! -f ${FILE} ]; then
+                        # Find both, log files provided with full or relative path
+                        if [ ! -f ${FILE} -a ! -f "${CONFIG_FILE%nginx.conf}${FILE}" ]; then
                             NGINX_ERROR_LOG_MISSING=1
                         fi
                     else

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -1048,7 +1048,7 @@
             if [ -n "${FIND}" ]; then
                 LogText "Result: found /etc/profile.d, with one or more files in it"
                 for FILE in ${FIND}; do
-                    HAS_MASK=$(${GREPBINARY} umask ${FILE} | ${SEDBINARY} 's/^[ \t]*//' | ${GREPBINARY} -v "^#" | ${AWKBINARY} '{ print $2 }')
+                    HAS_MASK=$(${GREPBINARY} umask ${FILE} 2> /dev/null | ${SEDBINARY} 's/^[ \t]*//' | ${GREPBINARY} -v "^#" | ${AWKBINARY} '{ print $2 }')
                     for MASK in ${HAS_MASK}; do
                         if [ "${MASK}" = "077" -o "${MASK}" = "027" -o "${MASK}" = "0077" -o "${MASK}" = "0027" ]; then
                             LogText "Result: found a strong umask '${MASK}' set in ${FILE}"

--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -140,7 +140,7 @@
         # cryptsetup only works as root
         if [ -n "${LSBLKBINARY}" -a -n "${CRYPTSETUPBINARY}" -a ${FORENSICS_MODE} -eq 0 ]; then
             for BLOCK_DEV in $(${LSBLKBINARY} --noheadings --list --paths -o NAME); do
-                if ${CRYPTSETUPBINARY} isLuks ${BLOCK_DEV}; then
+                if ${CRYPTSETUPBINARY} isLuks ${BLOCK_DEV} 2> /dev/null; then
                     LogText "Result: Found LUKS encrypted block device: ${BLOCK_DEV}"
                     Report "encryption[]=luks,block_device,${BLOCK_DEV}"
                     FOUND=$((FOUND +1))

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -442,8 +442,8 @@
         if [ -f ${ROOTDIR}etc/security/limits.conf ]; then
             LogText "Result: file ${ROOTDIR}etc/security/limits.conf exists"
             LogText "Test: Checking if core dumps are disabled in ${ROOTDIR}etc/security/limits.conf and ${ROOTDIR}etc/security/limits.d/*"
-            FIND1=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf ${LIMITS_DIRECTORY} | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }')
-            FIND2=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf ${LIMITS_DIRECTORY} | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }')
+            FIND1=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf $( if [ -d ${LIMITS_DIRECTORY} ]; then echo "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }')
+            FIND2=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf $( if [ -d ${LIMITS_DIRECTORY} ]; then echo "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }')
             if [ "${FIND2}" = "hard core disabled" ]; then
                 LogText "Result: core dumps (soft and hard) are both disabled"
                 Display --indent 2 --text "- Checking core dumps configuration" --result "${STATUS_DISABLED}" --color GREEN

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -541,10 +541,16 @@
                     else
                         ReportException "${TEST_NO}:1" "Can't determine kernel version on disk, need debug data"
                     fi
-                elif [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
-                    LogText "Result: /found /boot/vmlinuz-linux (usually Arch Linux or similar)"
-                    LogText "Test: checking kernel version on disk"
-                    VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
+                    if [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
+                        LogText "Result: /found /boot/vmlinuz-linux (usually Arch Linux or similar)"
+                        LogText "Test: checking kernel version on disk"
+                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                    else
+                        LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
+                        LogText "Test: checking kernel version on disk"
+                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux-lts | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                    fi
                     if [ -n "${VERSION_ON_DISK}" ]; then
                         LogText "Result: found version ${VERSION_ON_DISK}"
                         ACTIVE_KERNEL=$(uname -r)

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -542,17 +542,16 @@
                     else
                         ReportException "${TEST_NO}:1" "Can't determine kernel version on disk, need debug data"
                     fi
-                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts -o -f $(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1) ]; then
+                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts -o -f $(ls -t ${ROOTDIR}boot/vmlinuz-* 2> /dev/null | head -1) ]; then
                     if [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
                         FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux
                     elif [ -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
                         FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux-lts
                     else
-                        FOUND_VMLINUZ=$(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1)
+                        FOUND_VMLINUZ=$(ls -t ${ROOTDIR}boot/vmlinuz-* 2> /dev/null | head -1)
                     fi
-                    LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
+                    LogText "Result: /found ${FOUND_VMLINUZ} (usually Arch Linux or similar)"
                     LogText "Test: checking kernel version on disk"
-                    #VERSION_ON_DISK=$(${FILEBINARY} -b ${FOUND_VMLINUZ} | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
                     NEXTLINE=0
                     VERSION_ON_DISK=""
                     for I in $(file ${FOUND_VMLINUZ}); do

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -527,6 +527,7 @@
                     for I in $(file ${ROOTDIR}boot/vmlinuz-linux); do
                         if [ ${NEXTLINE} -eq 1 ]; then
                             FINDVERSION="${I}"
+                            break
                         else
                             # Searching for the Linux kernel after the keyword 'version'
                             if [ "${I}" = "version" ]; then NEXTLINE=1; fi
@@ -541,16 +542,28 @@
                     else
                         ReportException "${TEST_NO}:1" "Can't determine kernel version on disk, need debug data"
                     fi
-                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
+                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts -o -f $(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1) ]; then
                     if [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
-                        LogText "Result: /found /boot/vmlinuz-linux (usually Arch Linux or similar)"
-                        LogText "Test: checking kernel version on disk"
-                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                        FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux
+                    elif [ -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
+                        FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux-lts
                     else
-                        LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
-                        LogText "Test: checking kernel version on disk"
-                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux-lts | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                        FOUND_VMLINUZ=$(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1)
                     fi
+                    LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
+                    LogText "Test: checking kernel version on disk"
+                    #VERSION_ON_DISK=$(${FILEBINARY} -b ${FOUND_VMLINUZ} | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                    NEXTLINE=0
+                    VERSION_ON_DISK=""
+                    for I in $(file ${FOUND_VMLINUZ}); do
+                        if [ ${NEXTLINE} -eq 1 ]; then
+                            VERSION_ON_DISK="${I}"
+                            break
+                        else
+                            # Searching for the Linux kernel after the keyword 'version'
+                            if [ "${I}" = "version" ]; then NEXTLINE=1; fi
+                        fi
+                    done
                     if [ -n "${VERSION_ON_DISK}" ]; then
                         LogText "Result: found version ${VERSION_ON_DISK}"
                         ACTIVE_KERNEL=$(uname -r)


### PR DESCRIPTION
Hi again :)

Just like in https://github.com/CISOfy/lynis/pull/761 I added support for relative paths. So whenever someone uses something like

```
error_log  logs/error.log;
access_log  logs/access.log;
```
these log files are found now.

Tested with:
- bash 5.0.9
- dash 0.5.10.2