### PR TITLE
Slackware Linux OS detection

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -214,6 +214,13 @@
                             OS_FULLNAME="${OS_NAME} ${OS_VERSION_FULL}"
                             OS_REDHAT_OR_CLONE=1
                         ;;
+                        "slackware")
+                            LINUX_VERSION="Slackware"
+                            OS_FULLNAME=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_NAME="Slackware Linux"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         *)
                             ReportException "OS Detection" "Unknown OS found in /etc/os-release"
                         ;;


### PR DESCRIPTION
What kind of tool is this if it would fail to detect the oldest living distro?! :smile: 

The `os-release` can be seen here: <ftp://ftp.slackware.com/pub/slackware/slackware64-current/source/a/aaa_base/os-release>