### PR TITLE
Redirect gradm stderr to /dev/null

### DIFF
--- a/include/tests_mac_frameworks
+++ b/include/tests_mac_frameworks
@@ -222,7 +222,7 @@
             Display --indent 2 --text "- Checking presence grsecurity" --result "${STATUS_NOT_FOUND}" --color WHITE
         fi
         if HasData "${GRADMBINARY}"; then
-            FIND=$(${GRADMBINARY} --status)
+            FIND=$(${GRADMBINARY} --status 2>/dev/null)
             if [ "${FIND}" = "The RBAC system is currently enabled." ]; then
                 MAC_FRAMEWORK_ACTIVE=1
             fi


### PR DESCRIPTION
If the tool exists but the kernel doesn't have grsec, you'll get the
following error into stderr:

Could not open /dev/grsec.
open: No such file or directory