### PR TITLE
KRNL-5820: add checks for disabled coredumps in systemd & etc/profile

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -263,6 +263,7 @@
                             sysctl)                 SYSCTLBINARY="${BINARY}";          LogText "  Found known binary: sysctl (kernel parameters) - ${BINARY}" ;;
                             syslog-ng)              SYSLOGNGBINARY="${BINARY}";        SYSLOGNGVERSION=$(${BINARY} -V 2>&1 | grep "^syslog-ng" | awk '{ print $2 }'); LogText "Found ${BINARY} (version ${SYSLOGNGVERSION})" ;;
                             systemctl)              SYSTEMCTLBINARY="${BINARY}";       LogText "  Found known binary: systemctl (client to systemd) - ${BINARY}" ;;
+                            tail)                   TAILBINARY="${BINARY}";            LogText "  Found known binary: tail (text filter) - ${BINARY}" ;;
                             timedatectl)            TIMEDATECTL="${BINARY}";           LogText "  Found known binary: timedatectl (timedate client) - ${BINARY}" ;;
                             tomoyo-init)            TOMOYOINITBINARY=${BINARY};        LogText "  Found known binary: tomoyo-init (tomoyo component) - ${BINARY}" ;;
                             tr)                     TRBINARY="${BINARY}";              LogText "  Found known binary: tr (text transformation) - ${BINARY}" ;;
@@ -305,6 +306,7 @@
         [ "${FINDBINARY:-}" ] || ExitFatal "find binary not found"
         [ "${GREPBINARY:-}" ] || ExitFatal "grep binary not found"
         [ "${HEADBINARY:-}" ] || ExitFatal "head binary not found"
+        [ "${TAILBINARY:-}" ] || ExitFatal "tail binary not found"
         [ "${LSBINARY:-}" ] || ExitFatal "ls binary not found"
         [ "${PSBINARY:-}" ] || ExitFatal "ps binary not found"
         [ "${SEDBINARY:-}" ] || ExitFatal "sed binary not found"

--- a/include/functions
+++ b/include/functions
@@ -2181,8 +2181,9 @@
                         if [ ! "${VALUE}" = "" ]; then
                             # If multiple values follow, select first one
                             VALUE=$(echo ${VALUE} | awk '{ print $1 }')
-                            if [ ! -f ${VALUE} ]; then
-                                LogText "Result: could not find referenced log file ${VALUE} in nginx configuration"
+                            # Find both, log files provided with full or relative path
+                            if [ ! -f ${VALUE} -a ! -f "${CONFIG_FILE%nginx.conf}${VALUE}" ]; then
+                                LogText "Result: could not find log file ${VALUE} referenced in nginx configuration"
                                 NGINX_ACCESS_LOG_MISSING=1
                             fi
                         fi
@@ -2218,7 +2219,8 @@
                     # Check if log file exists
                     FILE=$(echo ${VALUE} | awk '{ print $1 }')
                     if [ ! "${FILE}" = "" ]; then
-                        if [ ! -f ${FILE} ]; then
+                        # Find both, log files provided with full or relative path
+                        if [ ! -f ${FILE} -a ! -f "${CONFIG_FILE%nginx.conf}${FILE}" ]; then
                             NGINX_ERROR_LOG_MISSING=1
                         fi
                     else

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -1048,7 +1048,7 @@
             if [ -n "${FIND}" ]; then
                 LogText "Result: found /etc/profile.d, with one or more files in it"
                 for FILE in ${FIND}; do
-                    HAS_MASK=$(${GREPBINARY} umask ${FILE} | ${SEDBINARY} 's/^[ \t]*//' | ${GREPBINARY} -v "^#" | ${AWKBINARY} '{ print $2 }')
+                    HAS_MASK=$(${GREPBINARY} umask ${FILE} 2> /dev/null | ${SEDBINARY} 's/^[ \t]*//' | ${GREPBINARY} -v "^#" | ${AWKBINARY} '{ print $2 }')
                     for MASK in ${HAS_MASK}; do
                         if [ "${MASK}" = "077" -o "${MASK}" = "027" -o "${MASK}" = "0077" -o "${MASK}" = "0027" ]; then
                             LogText "Result: found a strong umask '${MASK}' set in ${FILE}"

--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -140,7 +140,7 @@
         # cryptsetup only works as root
         if [ -n "${LSBLKBINARY}" -a -n "${CRYPTSETUPBINARY}" -a ${FORENSICS_MODE} -eq 0 ]; then
             for BLOCK_DEV in $(${LSBLKBINARY} --noheadings --list --paths -o NAME); do
-                if ${CRYPTSETUPBINARY} isLuks ${BLOCK_DEV}; then
+                if ${CRYPTSETUPBINARY} isLuks ${BLOCK_DEV} 2> /dev/null; then
                     LogText "Result: Found LUKS encrypted block device: ${BLOCK_DEV}"
                     Report "encryption[]=luks,block_device,${BLOCK_DEV}"
                     FOUND=$((FOUND +1))

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -442,8 +442,8 @@
         if [ -f ${ROOTDIR}etc/security/limits.conf ]; then
             LogText "Result: file ${ROOTDIR}etc/security/limits.conf exists"
             LogText "Test: Checking if core dumps are disabled in ${ROOTDIR}etc/security/limits.conf and ${ROOTDIR}etc/security/limits.d/*"
-            FIND1=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf ${LIMITS_DIRECTORY} | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }')
-            FIND2=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf ${LIMITS_DIRECTORY} | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }')
+            FIND1=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf $( if [ -d ${LIMITS_DIRECTORY} ]; then echo "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }')
+            FIND2=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf $( if [ -d ${LIMITS_DIRECTORY} ]; then echo "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }')
             if [ "${FIND2}" = "hard core disabled" ]; then
                 LogText "Result: core dumps (soft and hard) are both disabled"
                 Display --indent 2 --text "- Checking core dumps configuration" --result "${STATUS_DISABLED}" --color GREEN

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -541,10 +541,16 @@
                     else
                         ReportException "${TEST_NO}:1" "Can't determine kernel version on disk, need debug data"
                     fi
-                elif [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
-                    LogText "Result: /found /boot/vmlinuz-linux (usually Arch Linux or similar)"
-                    LogText "Test: checking kernel version on disk"
-                    VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
+                    if [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
+                        LogText "Result: /found /boot/vmlinuz-linux (usually Arch Linux or similar)"
+                        LogText "Test: checking kernel version on disk"
+                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                    else
+                        LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
+                        LogText "Test: checking kernel version on disk"
+                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux-lts | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                    fi
                     if [ -n "${VERSION_ON_DISK}" ]; then
                         LogText "Result: found version ${VERSION_ON_DISK}"
                         ACTIVE_KERNEL=$(uname -r)

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -542,17 +542,16 @@
                     else
                         ReportException "${TEST_NO}:1" "Can't determine kernel version on disk, need debug data"
                     fi
-                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts -o -f $(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1) ]; then
+                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts -o -f $(ls -t ${ROOTDIR}boot/vmlinuz-* 2> /dev/null | head -1) ]; then
                     if [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
                         FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux
                     elif [ -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
                         FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux-lts
                     else
-                        FOUND_VMLINUZ=$(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1)
+                        FOUND_VMLINUZ=$(ls -t ${ROOTDIR}boot/vmlinuz-* 2> /dev/null | head -1)
                     fi
-                    LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
+                    LogText "Result: /found ${FOUND_VMLINUZ} (usually Arch Linux or similar)"
                     LogText "Test: checking kernel version on disk"
-                    #VERSION_ON_DISK=$(${FILEBINARY} -b ${FOUND_VMLINUZ} | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
                     NEXTLINE=0
                     VERSION_ON_DISK=""
                     for I in $(file ${FOUND_VMLINUZ}); do

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -517,9 +517,10 @@
         if [ -f "${ROOTDIR}etc/security/limits.conf" ]; then
             LogText "Result: file ${ROOTDIR}etc/security/limits.conf exists"
             LogText "Test: Checking if core dumps are disabled in ${ROOTDIR}etc/security/limits.conf and ${LIMITS_DIRECTORY}/*"
-            FIND1=$(${GREPBINARY} -r -v "^#" "${ROOTDIR}etc/security/limits.conf" $( if [ -d "${LIMITS_DIRECTORY}" ]; then ${ECHOCMD} "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }' | ${TAILBINARY} -1)
-            FIND2=$(${GREPBINARY} -r -v "^#" "${ROOTDIR}etc/security/limits.conf" $( if [ -d "${LIMITS_DIRECTORY}" ]; then ${ECHOCMD} "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }' | ${TAILBINARY} -1)
-            
+            # using find instead of grep -r to stay POSIX compliant. On AIX and HPUX grep -r is not available.
+            FIND1=$(${FINDBINARY} "${ROOTDIR}etc/security/limits.conf" "${ROOTDIR}etc/security/limits.conf.d" -type f -exec ${CAT_BINARY} {} \; 2> /dev/null | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }' | ${TAILBINARY} -1)
+            FIND2=$(${FINDBINARY} "${ROOTDIR}etc/security/limits.conf" "${ROOTDIR}etc/security/limits.conf.d" -type f -exec ${CAT_BINARY} {} \; 2> /dev/null | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }' | ${TAILBINARY} -1)
+
             IS_SOFTCORE_DISABLED="$(if [ "${FIND1}" = "soft core disabled" ]; then ${ECHOCMD} DISABLED; elif [ "${FIND1}" = "soft core enabled" ]; then ${ECHOCMD} ENABLED; else ${ECHOCMD} DEFAULT; fi)"
             IS_HARDCORE_DISABLED="$(if [ "${FIND2}" = "hard core disabled" ]; then ${ECHOCMD} DISABLED; elif [ "${FIND2}" = "hard core enabled" ]; then ${ECHOCMD} ENABLED; else ${ECHOCMD} DEFAULT; fi)"
 

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -527,6 +527,7 @@
                     for I in $(file ${ROOTDIR}boot/vmlinuz-linux); do
                         if [ ${NEXTLINE} -eq 1 ]; then
                             FINDVERSION="${I}"
+                            break
                         else
                             # Searching for the Linux kernel after the keyword 'version'
                             if [ "${I}" = "version" ]; then NEXTLINE=1; fi
@@ -541,16 +542,28 @@
                     else
                         ReportException "${TEST_NO}:1" "Can't determine kernel version on disk, need debug data"
                     fi
-                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
+                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts -o -f $(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1) ]; then
                     if [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
-                        LogText "Result: /found /boot/vmlinuz-linux (usually Arch Linux or similar)"
-                        LogText "Test: checking kernel version on disk"
-                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                        FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux
+                    elif [ -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
+                        FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux-lts
                     else
-                        LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
-                        LogText "Test: checking kernel version on disk"
-                        VERSION_ON_DISK=$(${FILEBINARY} -b ${ROOTDIR}boot/vmlinuz-linux-lts | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                        FOUND_VMLINUZ=$(ls -t ${ROOTDIR}boot/vmlinuz-* | head -1)
                     fi
+                    LogText "Result: /found /boot/vmlinuz-linux-lts (usually Arch Linux or similar)"
+                    LogText "Test: checking kernel version on disk"
+                    #VERSION_ON_DISK=$(${FILEBINARY} -b ${FOUND_VMLINUZ} | ${AWKBINARY} '{ if ($1=="Linux" && $7=="version") { print $8 }}')
+                    NEXTLINE=0
+                    VERSION_ON_DISK=""
+                    for I in $(file ${FOUND_VMLINUZ}); do
+                        if [ ${NEXTLINE} -eq 1 ]; then
+                            VERSION_ON_DISK="${I}"
+                            break
+                        else
+                            # Searching for the Linux kernel after the keyword 'version'
+                            if [ "${I}" = "version" ]; then NEXTLINE=1; fi
+                        fi
+                    done
                     if [ -n "${VERSION_ON_DISK}" ]; then
                         LogText "Result: found version ${VERSION_ON_DISK}"
                         ACTIVE_KERNEL=$(uname -r)

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -26,7 +26,6 @@
 #
 #################################################################################
 #
-    CORE_DUMPS_DISABLED=0
     CPU_PAE=0
     CPU_NX=0
     LINUXCONFIGFILE=""
@@ -49,7 +48,7 @@
                     LogText "Exception: can't find the target of the symlink of /etc/systemd/system/default.target"
                     ReportException "${TEST_NO}:01"
                 else
-                    FIND2=$(echo ${FIND} | ${EGREPBINARY} "runlevel5|graphical")
+                    FIND2=$(${ECHOCMD} ${FIND} | ${EGREPBINARY} "runlevel5|graphical")
                     if HasData "${FIND2}"; then
                         LogText "Result: Found match on runlevel5/graphical"
                         Display --indent 2 --text "- Checking default runlevel" --result "runlevel 5" --color GREEN
@@ -437,33 +436,128 @@
     # Description : Checking core dumps configuration (Linux)
     Register --test-no KRNL-5820 --os Linux --weight L --network NO --category security --description "Checking core dumps configuration"
     if [ ${SKIPTEST} -eq 0 ]; then
+        Display --indent 2 --text "- Checking core dumps configuration"
+        LogText "Test: Checking presence of systemd"
+        # systemd option
+        if [ $HAS_SYSTEMD -eq 1 ]; then
+            LogText "Result: systemd is present on this system"
+            LogText "Test: Checking if core dumps are disabled in ${ROOTDIR}etc/systemd/coredump.conf and ${ROOTDIR}etc/systemd/coredump.conf.d/*.conf"
+            # check likely main config file for systemd: ${ROOTDIR}etc/systemd/coredump.conf for ProcessSizeMax=0 and Storage=none
+            SYSD_CORED_BASE_PROCSIZEMAX_NR_DISABLED=$(${GREPBINARY} -v "^\s*#" ${ROOTDIR}etc/systemd/coredump.conf 2> /dev/null | ${GREPBINARY} -i "ProcessSizeMax=0" | ${WCBINARY} -l)
+            SYSD_CORED_BASE_STORAGE_NR_DISABLED=$(${GREPBINARY} -v "^\s*#" ${ROOTDIR}etc/systemd/coredump.conf 2> /dev/null | ${GREPBINARY} -i "Storage=none" | ${WCBINARY} -l)
+            # check conf files in possibly existing coredump.conf.d folders 
+            # using find instead of grep -r to stay POSIX compliant. On AIX and HPUX grep -r is not available.
+            # while there could be multiple files overwriting each other, we are checking the number of occurrences
+            SYSD_CORED_SUB_PROCSIZEMAX_NR_DISABLED=$(${FINDBINARY} /etc/systemd/coredump.conf.d/ /run/systemd/coredump.conf.d/ /usr/lib/systemd/coredump.conf.d/ -type f -iname "*.conf" -exec ${SEDBINARY} 's/^\s*//g' {} \; 2> /dev/null | ${GREPBINARY} -i "^ProcessSizeMax=" | ${CUTBINARY} -d'=' -f2 | ${SEDBINARY} 's/ .*$//g ; s/\([A-Z][a-z]*\)*$//g' | ${GREPBINARY} "^0\s*$" | ${WCBINARY} -l)
+            SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED=$(${FINDBINARY} /etc/systemd/coredump.conf.d/ /run/systemd/coredump.conf.d/ /usr/lib/systemd/coredump.conf.d/ -type f -iname "*.conf" -exec ${SEDBINARY} 's/^\s*//g' {} \; 2> /dev/null | ${GREPBINARY} -i "^ProcessSizeMax=" | ${CUTBINARY} -d'=' -f2 | ${SEDBINARY} 's/ .*$//g ; s/\([A-Z][a-z]*\)*$//g' | ${GREPBINARY} -v "^0\s*$" | ${WCBINARY} -l)
+            
+            SYSD_CORED_SUB_STORAGE_FOUND=$(${FINDBINARY} /etc/systemd/coredump.conf.d/ /run/systemd/coredump.conf.d/ /usr/lib/systemd/coredump.conf.d/ -type f -iname "*.conf" -exec ${SEDBINARY} 's/^\s*//g' {} \; 2> /dev/null | ${GREPBINARY} -i "^Storage=" | ${CUTBINARY} -d'=' -f2 | ${SEDBINARY} 's/ .*$//g')
+            SYSD_CORED_SUB_STORAGE_NR_ENABLED=$(${ECHOCMD} "${SYSD_CORED_SUB_STORAGE_FOUND}" | ${SEDBINARY} 's/none//g' | ${WCBINARY} | ${AWKBINARY} '{print $2}')
+            SYSD_CORED_SUB_STORAGE_NR_DISABLED=$(${ECHOCMD} "${SYSD_CORED_SUB_STORAGE_FOUND}" | ${GREPBINARY} -o "none" | ${WCBINARY} | ${AWKBINARY} '{print $2}')
+            
+            if ( [ ${SYSD_CORED_BASE_PROCSIZEMAX_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_BASE_STORAGE_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -eq 0 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -eq 0 ] ) || \
+               ( [ ${SYSD_CORED_BASE_PROCSIZEMAX_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -eq 0 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -eq 0 ] ) || \
+               ( [ ${SYSD_CORED_BASE_STORAGE_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -eq 0 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -eq 0 ] ) || \
+               ( [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -eq 0 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -eq 0 ] ); then
+                LogText "Result: core dumps are disabled by 'ProcessSizeMax=0' and 'Storage=none' in systemd configuration files"
+                AddHP 1 1
+                TMP_COLOR="GREEN"
+                if [ ${SYSD_CORED_BASE_PROCSIZEMAX_NR_DISABLED} -gt 1 ] || [ ${SYSD_CORED_BASE_STORAGE_NR_DISABLED} -gt 1 ] || [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_DISABLED} -gt 1 ] || [ ${SYSD_CORED_SUB_STORAGE_NR_DISABLED} -gt 1 ]; then
+                    LogText "Result: 'ProcessSizeMax=0' and 'Storage=none' are set multiple times in systemd configuration files. Check config!"
+                    ReportSuggestion ${TEST_NO} "Check systemd configuration for duplicate entries of core dump settings"
+                    TMP_COLOR="YELLOW"
+                fi
+                Display --indent 4 --text "- configuration in systemd conf files" --result "${STATUS_DISABLED}" --color "${TMP_COLOR}"
+            elif [ ${SYSD_CORED_BASE_PROCSIZEMAX_NR_DISABLED} -ge 1 ] && [ ${SYSD_CORED_BASE_STORAGE_NR_DISABLED} -ge 1 ] && ( [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -ge 1 ] || [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -ge 1 ] ); then
+                LogText "Result: 'ProcessSizeMax=0' and 'Storage=none' are set in ${ROOTDIR}etc/systemd/coredump.conf but overwritten in subdir config files"
+                ReportSuggestion ${TEST_NO} "Check systemd configuration for overwriting core dump settings"
+                Display --indent 4 --text "- configuration in systemd conf files" --result "${STATUS_ENABLED}" --color YELLOW
+                AddHP 0 1
+            elif ( [ ${SYSD_CORED_BASE_PROCSIZEMAX_NR_ENABLED} -ge 1 ] && [ ${SYSD_CORED_BASE_STORAGE_NR_ENABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -ge 1 ] ) || \
+                 ( [ ${SYSD_CORED_BASE_PROCSIZEMAX_NR_ENABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -ge 1 ] ) || \
+                 ( [ ${SYSD_CORED_BASE_STORAGE_NR_ENABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -ge 1 ] ) || \
+                 ( [ ${SYSD_CORED_SUB_PROCSIZEMAX_NR_ENABLED} -ge 1 ] && [ ${SYSD_CORED_SUB_STORAGE_NR_ENABLED} -ge 1 ] ); then
+                LogText "Result: core dumps are explicitely enabled in systemd configuration files"
+                ReportSuggestion ${TEST_NO} "If not required, consider explicit disabling of core dump in ${ROOTDIR}etc/systemd/coredump.conf ('ProcessSizeMax=0', 'Storage=none')"
+                Display --indent 4 --text "- configuration in systemd conf files" --result "${STATUS_ENABLED}" --color RED
+                AddHP 0 1
+            else
+                LogText "Result: core dumps are not disabled in systemd configuration. Didn't find settings 'ProcessSizeMax=0' and 'Storage=none'"
+                Display --indent 4 --text "- configuration in systemd conf files" --result "DEFAULT" --color WHITE
+                AddHP 0 1
+            fi
+        fi
+        # Profile option
+        LogText "Test: Checking presence ${ROOTDIR}etc/profile"
+        if [ -f "${ROOTDIR}etc/profile" ]; then
+            LogText "Test: Checking if 'ulimit -c 0' exists in ${ROOTDIR}etc/profile or ${ROOTDIR}etc/profile.d/*.sh"
+            # use tail -1 in the following commands to get the last entry, which is the one that counts (in case of profile.d/ probably counts)
+            ULIMIT_C_VALUE="$(${GREPBINARY} "ulimit -c " ${ROOTDIR}etc/profile 2> /dev/null | ${SEDBINARY} 's/^\s*//g' | ${GREPBINARY} -v "^#" | ${TAILBINARY} -1 | ${CUTBINARY} -d' ' -f3 | ${SEDBINARY} 's/ .*$//g ; s/\([A-Z][a-z]*\)*$//g')"
+            ULIMIT_C_VALUE_SUB="$(${FINDBINARY} ${ROOTDIR}etc/profile.d -name "*.sh" -type f -exec ${CAT_BINARY} {} \; 2> /dev/null | ${GREPBINARY} "ulimit -c " | ${SEDBINARY} 's/^\s*//g' | ${GREPBINARY} -v "^#" | ${TAILBINARY} -1 | ${CUTBINARY} -d' ' -f3 | ${SEDBINARY} 's/ .*$//g ; s/\([A-Z][a-z]*\)*$//g')"
+            
+            if ( [ -n "${ULIMIT_C_VALUE_SUB}" ] && [ "${ULIMIT_C_VALUE_SUB}" = "0" ] ) || ( [ -n "${ULIMIT_C_VALUE}" ] && [ -z "${ULIMIT_C_VALUE_SUB}" ] && [ "${ULIMIT_C_VALUE}" = "0" ] ); then
+                LogText "Result: core dumps are disabled by 'ulimit -c 0' in ${ROOTDIR}etc/profile or ${ROOTDIR}etc/profile.d/*.sh"
+                Display --indent 4 --text "- configuration in etc/profile" --result "${STATUS_DISABLED}" --color GREEN
+                AddHP 1 1
+            elif [ -z "${ULIMIT_C_VALUE_SUB}" ] && [ -z "${ULIMIT_C_VALUE}" ]; then
+                LogText "Result: core dumps are not disabled in ${ROOTDIR}etc/profile or ${ROOTDIR}etc/profile.d/*.sh config files. Didn't find setting 'ulimit -c 0'"
+                Display --indent 4 --text "- configuration in etc/profile" --result "DEFAULT" --color WHITE
+                AddHP 0 1
+            elif ( [ -n "${ULIMIT_C_VALUE_SUB}" ] && ( [ "${ULIMIT_C_VALUE_SUB}" = "unlimited" ] || [ "${ULIMIT_C_VALUE_SUB}" != "0" ] ) ) || ( [ -n "${ULIMIT_C_VALUE}" ] && [ -z "${ULIMIT_C_VALUE_SUB}" ] && ( [ "${ULIMIT_C_VALUE}" = "unlimited" ] || [ "${ULIMIT_C_VALUE}" != "0" ] ) ); then
+                LogText "Result: core dumps are enabled in ${ROOTDIR}etc/profile or ${ROOTDIR}etc/profile.d/*.sh config files. A value higher than 0 is configured for 'ulimit -c'"
+                Display --indent 4 --text "- configuration in etc/profile" --result "${STATUS_ENABLED}" --color RED
+                AddHP 0 1
+            else
+                LogText "Result: ERROR - something went wrong. Unexpected result during check of ${ROOTDIR}etc/profile and ${ROOTDIR}etc/profile.d/*.sh config files. Please report on Github!"
+                Display --indent 4 --text "- configuration in etc/profile" --result "ERROR" --color YELLOW
+            fi
+        fi
         # Limits option
         LogText "Test: Checking presence ${ROOTDIR}etc/security/limits.conf"
-        if [ -f ${ROOTDIR}etc/security/limits.conf ]; then
+        if [ -f "${ROOTDIR}etc/security/limits.conf" ]; then
             LogText "Result: file ${ROOTDIR}etc/security/limits.conf exists"
-            LogText "Test: Checking if core dumps are disabled in ${ROOTDIR}etc/security/limits.conf and ${ROOTDIR}etc/security/limits.d/*"
-            FIND1=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf $( if [ -d ${LIMITS_DIRECTORY} ]; then echo "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }')
-            FIND2=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf $( if [ -d ${LIMITS_DIRECTORY} ]; then echo "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }')
+            LogText "Test: Checking if core dumps are disabled in ${ROOTDIR}etc/security/limits.conf and ${LIMITS_DIRECTORY}/*"
+            FIND1=$(${GREPBINARY} -r -v "^#" "${ROOTDIR}etc/security/limits.conf" $( if [ -d "${LIMITS_DIRECTORY}" ]; then ${ECHOCMD} "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="soft" && $3=="core" && $4=="0") { print "soft core disabled" } else if ($1=="*" && $2=="soft" && $3=="core" && $4!="0") { print "soft core enabled" } }' | ${TAILBINARY} -1)
+            FIND2=$(${GREPBINARY} -r -v "^#" "${ROOTDIR}etc/security/limits.conf" $( if [ -d "${LIMITS_DIRECTORY}" ]; then ${ECHOCMD} "${LIMITS_DIRECTORY}"; fi ) | ${AWKBINARY} -F ":" '{print $2}' | ${GREPBINARY} -v "^$" | ${AWKBINARY} '{ if ($1=="*" && $2=="hard" && $3=="core" && $4=="0") { print "hard core disabled" } else if ($1=="*" && $2=="hard" && $3=="core" && $4!="0") { print "hard core enabled" } }' | ${TAILBINARY} -1)
+            
+            IS_SOFTCORE_DISABLED="$(if [ "${FIND1}" = "soft core disabled" ]; then ${ECHOCMD} DISABLED; elif [ "${FIND1}" = "soft core enabled" ]; then ${ECHOCMD} ENABLED; else ${ECHOCMD} DEFAULT; fi)"
+            IS_HARDCORE_DISABLED="$(if [ "${FIND2}" = "hard core disabled" ]; then ${ECHOCMD} DISABLED; elif [ "${FIND2}" = "hard core enabled" ]; then ${ECHOCMD} ENABLED; else ${ECHOCMD} DEFAULT; fi)"
+
             if [ "${FIND2}" = "hard core disabled" ]; then
-                LogText "Result: core dumps (soft and hard) are both disabled"
-                Display --indent 2 --text "- Checking core dumps configuration" --result "${STATUS_DISABLED}" --color GREEN
-                CORE_DUMPS_DISABLED=1
+                LogText "Result: core dumps are hard disabled"
+                Display --indent 4 --text "- 'hard' configuration in security/limits.conf" --result "${IS_HARDCORE_DISABLED}" --color "GREEN"
+                if [ "${FIND1}" = "soft core disabled" ]; then
+                    Display --indent 4 --text "- 'soft' configuration in security/limits.conf" --result "${IS_SOFTCORE_DISABLED}" --color "GREEN"
+                else
+                    Display --indent 4 --text "- 'soft' config in security/limits.conf (implicit)" --result "${STATUS_DISABLED}" --color "GREEN"
+                fi
                 AddHP 3 3
-            elif [ "${FIND1}" = "soft core enabled" -o "${FIND2}" = "hard core enabled" ]; then
-                LogText "Result: core dumps (soft or hard) are enabled"
-                Display --indent 2 --text "- Checking core dumps configuration" --result "${STATUS_ENABLED}" --color YELLOW
-                ReportSuggestion "${TEST_NO}" "Check if core dumps need to be enabled on this system"
-                AddHP 1 3
+            elif [ "${FIND1}" = "soft core enabled" ] && [ "${FIND2}" = "hard core enabled" ]; then
+                LogText "Result: core dumps (soft and hard) are enabled"
+                Display --indent 4 --text "- 'hard' configuration in security/limits.conf" --result "${STATUS_ENABLED}" --color "RED"
+                Display --indent 4 --text "- 'soft' configuration in security/limits.conf" --result "${STATUS_ENABLED}" --color "RED"
+                ReportSuggestion "${TEST_NO}" "If not required, consider explicit disabling of core dump in /etc/security/limits.conf file"
+                AddHP 0 3
+            elif [ "${FIND1}" = "soft core disabled" ]; then
+                LogText "Result: core dumps are disabled for 'soft' ('hard'=${IS_HARDCORE_DISABLED})"
+                Display --indent 4 --text "- 'hard' configuration in security/limits.conf" --result "${IS_HARDCORE_DISABLED}" --color "$(if [ "${IS_HARDCORE_DISABLED}" = "ENABLED" ]; then ${ECHOCMD} RED; elif [ "${IS_HARDCORE_DISABLED}" = "DISABLED" ]; then ${ECHOCMD} GREEN; else ${ECHOCMD} WHITE; fi)"
+                Display --indent 4 --text "- 'soft' configuration in security/limits.conf" --result "${IS_SOFTCORE_DISABLED}" --color "GREEN"
+                AddHP 2 3
+            elif [ "${FIND1}" = "soft core enabled" ] || [ "${FIND2}" = "hard core enabled" ]; then
+                LogText "Result: core dumps are partially enabled ('hard'=${IS_HARDCORE_DISABLED}, 'soft'=${IS_SOFTCORE_DISABLED})"
+                Display --indent 4 --text "- 'hard' configuration in security/limits.conf" --result "${IS_HARDCORE_DISABLED}" --color "$(if [ "${IS_HARDCORE_DISABLED}" = "ENABLED" ]; then ${ECHOCMD} RED; elif [ "${IS_HARDCORE_DISABLED}" = "DISABLED" ]; then ${ECHOCMD} GREEN; else ${ECHOCMD} WHITE; fi)"
+                Display --indent 4 --text "- 'soft' configuration in security/limits.conf" --result "${IS_SOFTCORE_DISABLED}" --color "$(if [ "${IS_SOFTCORE_DISABLED}" = "ENABLED" ]; then ${ECHOCMD} RED; elif [ "${IS_SOFTCORE_DISABLED}" = "DISABLED" ]; then ${ECHOCMD} GREEN; else ${ECHOCMD} WHITE; fi)"
+                AddHP 0 3
             else
                 LogText "Result: core dumps are not explicitly disabled"
-                Display --indent 2 --text "- Checking core dumps configuration" --result "${STATUS_NOT_FOUND}" --color WHITE
-                ReportSuggestion "${TEST_NO}" "If not required, consider explicit disabling of core dump in /etc/security/limits.conf file"
-                AddHP 2 3
+                Display --indent 4 --text "- 'hard' configuration in security/limits.conf" --result "${IS_HARDCORE_DISABLED}" --color "WHITE"
+                Display --indent 4 --text "- 'soft' configuration in security/limits.conf" --result "${IS_HARDCORE_DISABLED}" --color "WHITE"
+                ReportSuggestion "${TEST_NO}" "If not required, consider explicit disabling of core dump in ${ROOTDIR}etc/security/limits.conf file"
+                AddHP 1 3
             fi
         else
             LogText "Result: file ${ROOTDIR}etc/security/limits.conf does not exist, skipping test"
         fi
-        # TODO: Check ulimit settings in /etc/profile and /etc/profile.d
 
         # Sysctl option
         LogText "Test: Checking sysctl value of fs.suid_dumpable"
@@ -475,7 +569,7 @@
         fi
         if [ "${FIND}" = "2" ]; then
             LogText "Result: programs can dump core dump, but only readable by root (value 2, for debugging with file protection)"
-            Display --indent 4 --text "- Checking setuid core dumps configuration" --result PROTECTED --color GREEN
+            Display --indent 4 --text "- Checking setuid core dumps configuration" --result PROTECTED --color WHITE
             AddHP 1 1
         elif [ "${FIND}" = "1" ]; then
             LogText "Result: all programs can perform core dumps (value 1, for debugging)"
@@ -483,8 +577,10 @@
             ReportSuggestion "${TEST_NO}" "Determine if all binaries need to be able to core dump"
             AddHP 0 1
         else
-            LogText "Result: found default option, some programs can dump (not processes which need to change credentials)"
-            Display --indent 4 --text "- Checking setuid core dumps configuration" --result DEFAULT --color WHITE
+            # 0 - (default) - traditional behaviour. Any process which has changed privilege levels or is execute only will not be dumped
+            # https://www.kernel.org/doc/Documentation/sysctl/fs.txt
+            LogText "Result: found default option (0), no execute only program or program with changed privilege levels can dump"
+            Display --indent 4 --text "- Checking setuid core dumps configuration" --result DISABLED --color GREEN
             AddHP 1 1
         fi
     fi
@@ -596,7 +692,7 @@
                         # Ignore rescue images. Remove generic. and huge. for Slackware machines
                         LogText "Action: checking relevant kernels"
                         KERNELS=$(${LSBINARY} /boot/vmlinuz* | ${GREPBINARY} -v rescue | ${SEDBINARY} 's/vmlinuz-//' | ${SEDBINARY} 's/generic.//' | ${SEDBINARY} 's/huge.//' | ${SEDBINARY} 's/\.[a-z].*.//g' | ${SEDBINARY} 's/-[a-z].*.//g' | ${SEDBINARY} 's./boot/..' | ${SEDBINARY} 's/-/./g' | ${SORTBINARY} -n -k1,1 -k2,2 -k3,3 -k4,4 -k5,5 -k6,6 -t \.)
-                        KERNELS_ONE_LINE=$(echo ${KERNELS} | ${TRBINARY} '\n' ' ')
+                        KERNELS_ONE_LINE=$(${ECHOCMD} ${KERNELS} | ${TRBINARY} '\n' ' ')
                         LogText "Output: ${KERNELS_ONE_LINE}"
                     elif [ ! "$(ls ${ROOTDIR}boot/kernel* 2> /dev/null)" = "" ]; then
                         LogText "Output: Found a kernel file in ${ROOTDIR}boot"


### PR DESCRIPTION
Hi,

I noticed the "ToDo" comment in the tests_kernel regarding the checks for disabled coredumps. So I added the checks.

I just hope I wrote the checks like had them in mind. Please let me know if you would like to have some changes.

**Edit:** Forget to mention, that it was tested on/ with:
- Manjaro 18.1
- ArchLinux 4.79
- RedHat 6
- bash 4.1.2
- bash 5.0
- dash (on RedHat 6 and on Arch)

Various commands have been verified on AIX, HPUX and Solaris as well (couldn't upload and run the full script on these servers though).

----------------------

In addition I fixed a few issues I came across. For example:
```
FIND1=$(${GREPBINARY} -r -v "^#" ${ROOTDIR}etc/security/limits.conf ${LIMITS_DIRECTORY} | ${AWKBINARY} -F ":" '{print $2}' ...
```
The option "-r" for grep doesn't exist on older AIX and HPUX systems. Furthermore: this line was not working when the LIMITS_DIRECTORY does not exist. In that case "grep -r" doesn't output like:
```
/etc/security/limits.conf:*    soft     core      0
```
but instead:
```
*    soft     core      0
```
and consequently the awk command with ":" as separator doesn't output anything.