### PR TITLE
Correctly split lines of /etc/passwd

### DIFF
--- a/include/tests_homedirs
+++ b/include/tests_homedirs
@@ -57,7 +57,8 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check if users' home directories permissions are 750 or more restrictive
         FOUND=0
-        for LINE in $(${EGREPBINARY} -v '^(daemon|git|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }'); do
+        USERDATA=$(${EGREPBINARY} -v '^(daemon|git|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }')
+	while read -r LINE; do
             USER=$(echo ${LINE} | ${CUTBINARY} -d: -f1)
             DIR=$(echo ${LINE} | ${CUTBINARY} -d: -f6)
             if [ -d "${DIR}" ]; then
@@ -70,7 +71,9 @@
                     LogText "Result: permissions of home directory ${DIR} of user ${USER} are fine"
                 fi
             fi
-        done
+        done << EOF
+$USERDATA
+EOF
 
         if [ ${FOUND} -eq 1 ]; then
             Display --indent 2 --text "- Permissions of home directories" --result "${STATUS_WARNING}" --color RED
@@ -89,7 +92,8 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check if users own their home directories
         FOUND=0
-        for LINE in $(${EGREPBINARY} -v '^(daemon|git|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }'); do
+	USERDATA=$(${EGREPBINARY} -v '^(daemon|git|halt|root|shutdown|sync)' ${ROOTDIR}etc/passwd | ${AWKBINARY} -F: '($7 !~ "/(false|nologin)$") { print }')
+	while read -r LINE; do
             USER=$(echo ${LINE} | ${CUTBINARY} -d: -f1)
             DIR=$(echo ${LINE} | ${CUTBINARY} -d: -f6)
             if [ -d ${DIR} ]; then
@@ -101,7 +105,9 @@
                     LogText "Result: ownership of home directory ${DIR} for user ${USER} looks to be correct"
                 fi
             fi
-        done
+        done << EOF
+$USERDATA
+EOF
 
         if [ ${FOUND} -eq 1 ]; then
             Display --indent 2 --text "- Ownership of home directories" --result "${STATUS_WARNING}" --color RED


### PR DESCRIPTION
Fixes #773

```
# cat /etc/passwd

ec2-user:x:501:501:EC2 Default User:/home/ec2-user:/bin/bash


# for LINE in $(grep -v '^(daemon|git|halt|root|shutdown|sync)' /etc/passwd | awk -F: '($7 !~ "/(false|nologin)$") { print }'); do echo $LINE; done  

[...]  
ec2-user:x:501:501:EC2  
Default  
User:/home/ec2-user:/bin/bash  
```