### PR TITLE
fix for #781 - run lsblk without --paths

### DIFF
--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -138,9 +138,9 @@
         FOUND=0
 
         # cryptsetup only works as root
-        if [ -n "${LSBLKBINARY}" -a -n "${CRYPTSETUPBINARY}" -a ${FORENSICS_MODE} -eq 0 ]; then
-            for BLOCK_DEV in $(${LSBLKBINARY} --noheadings --list --paths -o NAME); do
-                if ${CRYPTSETUPBINARY} isLuks ${BLOCK_DEV} 2> /dev/null; then
+        if [ -n "${LSBLKBINARY}" ] && [ -n "${CRYPTSETUPBINARY}" ] && [ ${FORENSICS_MODE} -eq 0 ]; then
+            for BLOCK_DEV in $(${LSBLKBINARY} --noheadings --list -o NAME 2> /dev/null | cut -d' ' -f1); do
+                if ${CRYPTSETUPBINARY} isLuks $(${FINDBINARY} /dev/ -name "${BLOCK_DEV}" 2> /dev/null) 2> /dev/null; then
                     LogText "Result: Found LUKS encrypted block device: ${BLOCK_DEV}"
                     Report "encryption[]=luks,block_device,${BLOCK_DEV}"
                     FOUND=$((FOUND +1))


### PR DESCRIPTION
Hi,

This should fix #781 and allow compatibility with older Linux systems where lsblk doesn't support --paths yet.
Tested with bash and dash on Manjaro and Arch.

I'm going to post this pull request already and could run a test on RedHat 6 next week Mo or Tue if requested.