### PR TITLE
Additional test for permissions on sudoers files

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -513,7 +513,7 @@
             FIND=$(${LSBINARY} -l ${f} | ${CUTBINARY} -c 2-10)
             FIND2=$(${LSBINARY} -n ${f} | ${AWKBINARY} '{print $3$4}')
             LogText "Result: Found file permissions: ${FIND} and owner UID GID: ${FIND2}"
-            if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ] && [ "${FIND2}" = "00" ]; then
+            if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-r-----" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ] && [ "${FIND2}" = "00" ]; then
                 LogText "Result: file ${f} permissions/ownership OK"
                 Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_OK}" --color GREEN
             else


### PR DESCRIPTION
Noticed that the tests for sudo config files were only testing three acceptable permission combinations.

It tested for one of:
   rw-------
   rw-rw----
   r--r-----

But there was one option missing that I happen to use:  rw-r-----

So I added it in a simple patch.  What do you think?  Or should we also add a condition for only the owner being able to read the file (r--------)?

Dave
