### PR TITLE
KRNL-5840: add detection for proxmox and raspi kernel

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -1248,7 +1248,8 @@
         LogText "Test: Checking how many kernel packages are installed"
 
         if [ -n "${DPKGBINARY}" ]; then
-            KERNELS=$(${DPKGBINARY} -l 2> /dev/null | ${GREPBINARY} "linux-image-[0-9]" | ${WCBINARY} -l)
+            KERNEL_PKG_NAMES="linux-image-[0-9]|raspberrypi-kernel|pve-kernel-[0-9]"
+            KERNELS=$(${DPKGBINARY} -l 2> /dev/null | ${EGREPBINARY} "${KERNEL_PKG_NAMES}" | ${WCBINARY} -l)
             if [ ${KERNELS} -eq 0 ]; then
                 LogText "Result: found no kernels from dpkg -l output, which is unexpected"
                 ReportException "KRNL-5840:2" "Could not find any kernel packages from DPKG output"


### PR DESCRIPTION
Hi,

This should resolve  #788 and gets also rid of the same Exception on the Raspi.
I hope the changes make sense.