### PR TITLE
don't fail relative paths check with spaces in PATH

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -50,7 +50,7 @@
         # Test if our PATH variable provides a set of paths. If so, reverse the order. If we discover the same binary
         # multiple times, the one first in PATH should be used.
         if [ -n "${PATH}" ]; then
-            PATH_REVERSED=$(echo ${PATH} | awk -F: '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
+            PATH_REVERSED=$(echo "${PATH}" | sed 's/ /!!space!!/g' | awk -F: '{ for (i=NF; i>1; i--) printf("%s ",$i); print $1; }')
             BIN_PATHS=$(echo "${PATH_REVERSED}" | tr ':' ' ')
         fi
 
@@ -59,8 +59,8 @@
             FOUND=0
             if [ "${SCANDIR}" = "." ]; then FOUND=1; MSG="Found single dot (.) in PATH"
             elif [ "${SCANDIR}" = ".." ]; then FOUND=1; MSG="Found double dot (..) in PATH"
-            elif echo ${SCANDIR} | grep '^\.\.' > /dev/null; then FOUND=1; MSG="Found path starting with double dot (..) in PATH"
-            elif echo ${SCANDIR} | grep '^[a-zA-Z]' > /dev/null; then FOUND=1; MSG="Found relative path in PATH"
+            elif echo "${SCANDIR}" | grep '^\.\.' > /dev/null; then FOUND=1; MSG="Found path starting with double dot (..) in PATH"
+            elif echo "${SCANDIR}" | grep '^[a-zA-Z]' > /dev/null; then FOUND=1; MSG="Found relative path in PATH"
             fi
             if [ ${FOUND} -eq 1 ]; then
                 # Stop execution if privileged, otherwise continue but warn user
@@ -76,11 +76,12 @@
 
         # Now perform binary detection
         for SCANDIR in ${BIN_PATHS}; do
+            SCANDIR=$(echo "$SCANDIR" | sed 's/!!space!!/ /g')
             LogText "Test: Checking binaries in directory ${SCANDIR}"
             ORGPATH=""
-            if [ -d ${SCANDIR} ]; then
+            if [ -d "${SCANDIR}" ]; then
                 SKIPDIR=0
-                if [ -L ${SCANDIR} ]; then
+                if [ -L "${SCANDIR}" ]; then
                     LogText "Result: directory exists, but is actually a symlink"
                     ShowSymlinkPath ${SCANDIR}
                     if [ ${FOUNDPATH} -eq 1 ]; then
@@ -109,7 +110,7 @@
                     LogText "Directory ${SCANDIR} exists. Starting directory scanning..."
 
                     # Show the contents of the directory with binaries, ignore directories
-                    FIND=$(ls -p ${SCANDIR} | grep -v '/$')
+                    FIND=$(ls -p "${SCANDIR}" | grep -v '/$')
                     for FILENAME in ${FIND}; do
                         COUNT=$((COUNT + 1))
                         BINARY="${SCANDIR}/${FILENAME}"
@@ -186,7 +187,7 @@
                             logrotate)              LOGROTATEBINARY="${BINARY}";       LogText "  Found known binary: logrotate (log rotation tool) - ${BINARY}" ;;
                             ls)                     LSBINARY="${BINARY}";              LogText "  Found known binary: ls (file listing) - ${BINARY}" ;;
                             lsattr)                 LSATTRBINARY="${BINARY}";          LogText "  Found known binary: lsattr (file attributes) - ${BINARY}" ;;
-			    lsblk)		    LSBLKBINARY="${BINARY}";	       LogText "  Found known binary: lsblk (block devices) - ${BINARY}" ;;
+                            lsblk)		            LSBLKBINARY="${BINARY}";	       LogText "  Found known binary: lsblk (block devices) - ${BINARY}" ;;
                             lsmod)                  LSMODBINARY="${BINARY}";           LogText "  Found known binary: lsmod (kernel modules) - ${BINARY}" ;;
                             lsof)
                                 LSOFBINARY="${BINARY}"
@@ -293,7 +294,7 @@
 
         # unset SORTED_BIN_PATHS
         BINARY_SCAN_FINISHED=1
-        BINARY_PATHS_FOUND=$(echo ${BINARY_PATHS_FOUND} | sed 's/^, //g' | sed 's/ //g')
+        BINARY_PATHS_FOUND=$(echo ${BINARY_PATHS_FOUND} | sed 's/^, //g' | sed 's/, /,/g')
         LogText "Discovered directories: ${BINARY_PATHS_FOUND}"
         LogText "Result: found ${COUNT} binaries"
         Report "binaries_count=${COUNT}"


### PR DESCRIPTION
This could fix #768
I'll request a test in the issue. With my tests everything was alright, but could be different in a real world scenario.

Anyway: tested with bash and dash again.