### PR TITLE
Updated permissions checks

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1281,6 +1281,9 @@
                     CHECK_PERMISSION=$(echo "-${CHECK_PERMISSION}" | ${AWKBINARY} '{k=0;for(i=0;i<=8;i++)k+=((substr($1,i+2,1)~/[rwx]/)*2^(8-i));if(k)printf("%0o",k)}')
                 fi
 
+                # Add leading zeros if necessary
+                CHECK_PERMISSION=$(echo "${CHECK_PERMISSION}" | ${AWKBINARY} '{printf "%03d",$1}')
+
                 # First try stat command
                 LogText "Test: checking if file ${CHECKFILE} is ${CHECK_PERMISSION}"
                 if [ -n "${STATBINARY}" ]; then
@@ -1299,7 +1302,11 @@
                         *)
                             # Only use find when OS is NOT AIX and binaries are NOT busybox
                             if [ ${SHELL_IS_BUSYBOX} -eq 0 ]; then
-                                DATA=$(${FINDBINARY} ${CHECKFILE} -printf "%m")
+                                if [ -d ${CHECKFILE} ]; then
+                                    DATA=$(${FINDBINARY} ${CHECKFILE} -maxdepth 0 -printf "%m")
+                                else
+                                    DATA=$(${FINDBINARY} ${CHECKFILE} -printf "%m")
+                                fi
                             fi
                         ;;
                     esac
@@ -1317,12 +1324,15 @@
 
                 # Convert permissions to octal when needed
                 case ${DATA} in
-                    "r"|"w"|"x"|"-")
+                    [-r][-w][-x][-r][-w][-x][-r][-w][-x] )
                         LogText "Converting value ${DATA} to octal"
-                        DATA=$(echo ${DATA} | ${AWKBINARY} '{k=0;for(i=0;i<=8;i++)k+=((substr($1,i+2,1)~/[rwx]/)*2^(8-i));if(k)printf("%0o",k)}')
-                        if [ "${DATA}" = "0" ]; then DATA="000"; fi
+                        # add a dummy character as first character so it looks like output is a normal file
+                        DATA=$(echo "-${DATA}" | ${AWKBINARY} '{k=0;for(i=0;i<=8;i++)k+=((substr($1,i+2,1)~/[rwx]/)*2^(8-i));if(k)printf("%0o",k)}')
                     ;;
                 esac
+
+                # Add leading zeros if necessary
+                DATA=$(echo "${DATA}" | ${AWKBINARY} '{printf "%03d",$1}')
 
                 if [ -n "${DATA}" ]; then
                     if [ "${DATA}" = "${CHECK_PERMISSION}" ]; then


### PR DESCRIPTION
A few changes to the HasCorrectFilePermissions function:

1.  Added a call to awk for CHECK_PERMISSION that verifies that the value is 3 digits long and appropriately padded with leading zeros.  This could be an issue if you ever wanted to check a file that did not have any permissions for owner or group.  Now this is an very rare occurrence but its now handled.

2.  Using the find binary needed to be called in a slightly different way for directories and files.  Much like ls.

3.  For the case statement for converting the ls output to octal, I found two issues.  First the existing check was looking for a single letter and would commonly fail.  I expanded it to look for the full string that it is mostly likely to see.  I have not included sticky bits because it looks like the awk command to convert to octal doesn't handle them either.  Second, I added a dummy character when DATA is passed to awk as it is above for CHECK_PERMISSION.

4.  Last I passed the DATA variable through the same awk command that CHECK_PERMISSION goes through to verify that it is 3 digits long and appropriately padded with leading zeros when necessary.  

I've tested these patches on a Debian system with both dash and ash (busybox).  So I'm fairly confident that they will work.  What do you think?

Dave