### PR TITLE
Updated tests for file permissions to case statements

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -478,10 +478,10 @@
         done
         if [ ${FOUND} -eq 1 ]; then
             LogText "Result: sudoers file found (${SUDOERS_FILE})"
-            Display --indent 2 --text "- sudoers file" --result "${STATUS_FOUND}" --color GREEN
+            Display --indent 2 --text "- Sudoers file(s)" --result "${STATUS_FOUND}" --color GREEN
         else
             LogText "Result: sudoers file NOT found"
-            Display --indent 2 --text "- sudoers file" --result "${STATUS_NOT_FOUND}" --color YELLOW
+            Display --indent 2 --text "- Sudoers file" --result "${STATUS_NOT_FOUND}" --color YELLOW
         fi
     fi
 #
@@ -499,13 +499,27 @@
             FIND=$(${LSBINARY} -ld ${SUDOERS_D} | ${CUTBINARY} -c 2-10)
             FIND2=$(${LSBINARY} -nd ${SUDOERS_D} | ${AWKBINARY} '{print $3$4}')
             LogText "Result: Found directory permissions: ${FIND} and owner UID GID: ${FIND2}"
-            if [ "${FIND}" = "rwxrwx---" -o "${FIND}" = "rwxr-x---" -o "${FIND}" = "rwx------" ] && [ "${FIND2}" = "00" ]; then
-                LogText "Result: directory ${SUDOERS_D} permissions/ownership OK"
-                Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_OK}" --color GREEN
-            else
-                LogText "Result: directory has possibly unsafe permissions/ownership"
-                Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_WARNING}" --color RED
-            fi
+            case "${FIND}" in
+                rwx[r-][w-][x-]--- )
+                    LogText "Result: directory ${SUDOERS_D} permissions OK"
+                    if [ "${FIND2}" = "00" ]; then
+                        LogText "Result: directory ${SUDOERS_D} ownership OK"
+                        Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_OK}" --color GREEN
+                    else
+                        LogText "Result: directory ${SUDOERS_D} has possibly unsafe ownership"
+                        Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_WARNING}" --color RED
+                    fi
+                    ;;
+                * )
+                    LogText "Result: directory ${SUDOERS_D} has possibly unsafe permissions"
+                    if [ "${FIND2}" = "00" ]; then
+                        LogText "Result: directory ${SUDOERS_D} ownership OK"
+                    else
+                        LogText "Result: directory ${SUDOERS_D} has possibly unsafe ownership"
+                    fi
+                    Display --indent 4 --text "- Permissions for directory: ${SUDOERS_D}" --result "${STATUS_WARNING}" --color RED
+                    ;;
+            esac
             SUDO_CONFIG_FILES="${SUDO_CONFIG_FILES} $(${FINDBINARY} ${SUDOERS_D} -type f -print)"
         fi
         for f in ${SUDO_CONFIG_FILES}; do
@@ -513,13 +527,27 @@
             FIND=$(${LSBINARY} -l ${f} | ${CUTBINARY} -c 2-10)
             FIND2=$(${LSBINARY} -n ${f} | ${AWKBINARY} '{print $3$4}')
             LogText "Result: Found file permissions: ${FIND} and owner UID GID: ${FIND2}"
-            if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ] && [ "${FIND2}" = "00" ]; then
-                LogText "Result: file ${f} permissions/ownership OK"
-                Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_OK}" --color GREEN
-            else
-                LogText "Result: file has possibly unsafe permissions/ownership"
-                Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_WARNING}" --color RED
-            fi
+            case "${FIND}" in
+                r[w-]-[r-][w-]---- )
+                    LogText "Result: file ${f} permissions OK"
+                    if [ "${FIND2}" = "00" ]; then
+                        LogText "Result: file ${f} ownership OK"
+                        Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_OK}" --color GREEN
+                    else
+                        LogText "Result: file ${f} has possibly unsafe ownership"
+                        Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_WARNING}" --color RED
+                    fi
+                    ;;
+                * )
+                    LogText "Result: file ${f} has possibly unsafe permissions"
+                    if [ "${FIND2}" = "00" ]; then
+                        LogText "Result: file ${f} ownership OK"
+                    else
+                        LogText "Result: file ${f} has possibly unsafe ownership"
+                    fi
+                    Display --indent 4 --text "- Permissions for: ${f}" --result "${STATUS_WARNING}" --color RED
+                    ;;
+            esac
         done
     fi
 #
@@ -1469,13 +1497,16 @@
         LogText "Test: checking /etc/doas.conf permissions"
         FIND=$(ls -l ${DOAS_FILE} | ${CUTBINARY} -c 2-10)
         LogText "Result: Found /etc/doas.conf file permissions: ${FIND}"
-        if [ "${FIND}" = "rw-------" -o "${FIND}" = "rw-rw----" -o "${FIND}" = "r--r-----" ]; then
-            LogText "Result: file /etc/doas.conf has correct permissions"
-            Display --indent 4 --text "- Check doas file permissions" --result "${STATUS_OK}" --color GREEN
-        else
-            LogText "Result: file has possibly unsafe file permissions"
-            Display --indent 4 --text "- Check doas file permissions" --result "${STATUS_WARNING}" --color RED
-        fi
+        case "${FIND}" in
+            r[w-]-[r-][w-]---- )
+                LogText "Result: file /etc/doas.conf has correct permissions"
+                Display --indent 4 --text "- Check doas file permissions" --result "${STATUS_OK}" --color GREEN
+                ;;
+            * )
+                LogText "Result: file has possibly unsafe file permissions"
+                Display --indent 4 --text "- Check doas file permissions" --result "${STATUS_WARNING}" --color RED
+                ;;
+        esac
     fi
 #
 #################################################################################

--- a/include/tests_printers_spools
+++ b/include/tests_printers_spools
@@ -117,14 +117,17 @@
         LogText "Test: Checking CUPS configuration file permissions"
         FIND=$(${LSBINARY} -l ${CUPSD_CONFIG_FILE} | ${CUTBINARY} -c 2-10)
         LogText "Result: found ${FIND}"
-        if [ "${FIND}" = "r--------" -o "${FIND}" = "rw-------" -o "${FIND}" = "rw-r-----" -o "${FIND}" = "rw-rw----" ]; then
-            Display --indent 4 --text "- File permissions" --result "${STATUS_OK}" --color GREEN
-            AddHP 1 1
-        else
-            Display --indent 4 --text "- File permissions" --result "${STATUS_WARNING}" --color RED
-            ReportSuggestion ${TEST_NO} "Access to CUPS configuration could be more strict."
-            AddHP 1 2
-        fi
+        case "${FIND}" in
+            r[w-]-[r-][w-]---- )
+                Display --indent 4 --text "- File permissions" --result "${STATUS_OK}" --color GREEN
+                AddHP 1 1
+                ;;
+            * )
+                Display --indent 4 --text "- File permissions" --result "${STATUS_WARNING}" --color RED
+                ReportSuggestion ${TEST_NO} "Access to CUPS configuration could be more strict."
+                AddHP 1 2
+                ;;
+        esac
     fi
 #
 #################################################################################


### PR DESCRIPTION
Converted file permission tests from if statements to case statements.  This allows us to forgo the need to a chain of 'and/or' conditions and use some basic regular expressions.  Formatted the sudoers file tests so that the progress display looks the same but the log file will give the user a little bit more information on what needs to be updated.

This method seems easier to read to me, what do you think?

Dave