### PR TITLE
added additional php folders to check, plus added PHP72 and PHP73

### DIFF
--- a/include/tests_php
+++ b/include/tests_php
@@ -29,25 +29,60 @@
 
     # Possible locations of php.ini
     PHPINILOCS="${ROOTDIR}etc/php.ini ${ROOTDIR}etc/php.ini.default \
-                ${ROOTDIR}etc/php/php.ini ${ROOTDIR}etc/php5.5/php.ini ${ROOTDIR}etc/php5.6/php.ini ${ROOTDIR}etc/php7.0/php.ini ${ROOTDIR}etc/php7.1/php.ini ${ROOTDIR}etc/php7.2/php.ini \
-                ${ROOTDIR}etc/php/cgi-php5/php.ini ${ROOTDIR}etc/php/cli-php5/php.ini ${ROOTDIR}etc/php/apache2-php5/php.ini \
-                ${ROOTDIR}etc/php/apache2-php5.5/php.ini ${ROOTDIR}etc/php/apache2-php5.6/php.ini ${ROOTDIR}etc/php/apache2-php7.0/php.ini ${ROOTDIR}etc/php/apache2-php7.1/php.ini \
-                ${ROOTDIR}etc/php/cgi-php7.1/php.ini ${ROOTDIR}etc/php/apache2-php7.1/php.ini ${ROOTDIR}etc/php/cgi-php5.5/php.ini ${ROOTDIR}etc/php/cgi-php5.6/php.ini ${ROOTDIR}etc/php/cgi-php7.0/php.ini \
-                ${ROOTDIR}etc/php/cli-php7.1/php.ini ${ROOTDIR}etc/php/cli-php5.5/php.ini ${ROOTDIR}etc/php/cli-php5.6/php.ini ${ROOTDIR}etc/php/cli-php7.0/php.ini \
-                ${ROOTDIR}etc/php/embed-php7.1/php.ini ${ROOTDIR}etc/php/embed-php5.5/php.ini ${ROOTDIR}etc/php/embed-php5.6/php.ini ${ROOTDIR}etc/php/embed-php7.0/php.ini \
-                ${ROOTDIR}etc/php/fpm-php7.1/php.ini ${ROOTDIR}etc/php/fpm-php5.5/php.ini ${ROOTDIR}etc/php/fpm-php5.6/php.ini ${ROOTDIR}etc/php/fpm-php7.0/php.ini \
+                ${ROOTDIR}etc/php/php.ini \
+                ${ROOTDIR}etc/php5.5/php.ini \
+                ${ROOTDIR}etc/php5.6/php.ini \
+                ${ROOTDIR}etc/php7.0/php.ini \
+                ${ROOTDIR}etc/php7.1/php.ini \
+                ${ROOTDIR}etc/php7.2/php.ini \
+                ${ROOTDIR}etc/php7.3/php.ini \
+                ${ROOTDIR}etc/php/cgi-php5/php.ini \
+                ${ROOTDIR}etc/php/cli-php5/php.ini \
+                ${ROOTDIR}etc/php/apache2-php5/php.ini \
+                ${ROOTDIR}etc/php/apache2-php5.5/php.ini \
+                ${ROOTDIR}etc/php/apache2-php5.6/php.ini \
+                ${ROOTDIR}etc/php/apache2-php7.0/php.ini \
+                ${ROOTDIR}etc/php/apache2-php7.1/php.ini \
+                ${ROOTDIR}etc/php/apache2-php7.2/php.ini \
+                ${ROOTDIR}etc/php/apache2-php7.3/php.ini \
+                ${ROOTDIR}etc/php/cgi-php5.5/php.ini \
+                ${ROOTDIR}etc/php/cgi-php5.6/php.ini \
+                ${ROOTDIR}etc/php/cgi-php7.0/php.ini \
+                ${ROOTDIR}etc/php/cgi-php7.1/php.ini \
+                ${ROOTDIR}etc/php/cgi-php7.2/php.ini \
+                ${ROOTDIR}etc/php/cgi-php7.3/php.ini \
+                ${ROOTDIR}etc/php/cli-php5.5/php.ini \
+                ${ROOTDIR}etc/php/cli-php5.6/php.ini \
+                ${ROOTDIR}etc/php/cli-php7.0/php.ini \
+                ${ROOTDIR}etc/php/cli-php7.1/php.ini \
+                ${ROOTDIR}etc/php/cli-php7.2/php.ini \
+                ${ROOTDIR}etc/php/cli-php7.3/php.ini \
+                ${ROOTDIR}etc/php/embed-php5.5/php.ini \
+                ${ROOTDIR}etc/php/embed-php5.6/php.ini \
+                ${ROOTDIR}etc/php/embed-php7.0/php.ini \
+                ${ROOTDIR}etc/php/embed-php7.1/php.ini \
+                ${ROOTDIR}etc/php/embed-php7.2/php.ini \
+                ${ROOTDIR}etc/php/embed-php7.3/php.ini \
+                ${ROOTDIR}etc/php/fpm-php7.3/php.ini \
+                ${ROOTDIR}etc/php/fpm-php7.2/php.ini \
+                ${ROOTDIR}etc/php/fpm-php7.1/php.ini \
+                ${ROOTDIR}etc/php/fpm-php7.0/php.ini \
+                ${ROOTDIR}etc/php/fpm-php5.5/php.ini \
+                ${ROOTDIR}etc/php/fpm-php5.6/php.ini \
                 ${ROOTDIR}etc/php5/cgi/php.ini \
                 ${ROOTDIR}etc/php5/cli/php.ini \
                 ${ROOTDIR}etc/php5/cli-php5.4/php.ini ${ROOTDIR}etc/php5/cli-php5.5/php.ini ${ROOTDIR}etc/php5/cli-php5.6/php.ini \
                 ${ROOTDIR}etc/php5/apache2/php.ini \
                 ${ROOTDIR}etc/php5/fpm/php.ini \
                 ${ROOTDIR}private/etc/php.ini \
-                ${ROOTDIR}etc/php/7.2/apache2/php.ini \
-                ${ROOTDIR}etc/php/7.1/apache2/php.ini \
                 ${ROOTDIR}etc/php/7.0/apache2/php.ini \
-                ${ROOTDIR}etc/php/7.2/cli/php.ini ${ROOTDIR}etc/php/7.2/fpm/php.ini \
-                ${ROOTDIR}etc/php/7.1/cli/php.ini ${ROOTDIR}etc/php/7.1/fpm/php.ini \
+                ${ROOTDIR}etc/php/7.1/apache2/php.ini \
+                ${ROOTDIR}etc/php/7.2/apache2/php.ini \
+                ${ROOTDIR}etc/php/7.3/apache2/php.ini \
                 ${ROOTDIR}etc/php/7.0/cli/php.ini ${ROOTDIR}etc/php/7.0/fpm/php.ini \
+                ${ROOTDIR}etc/php/7.1/cli/php.ini ${ROOTDIR}etc/php/7.1/fpm/php.ini \
+                ${ROOTDIR}etc/php/7.2/cli/php.ini ${ROOTDIR}etc/php/7.2/fpm/php.ini \
+                ${ROOTDIR}etc/php/7.3/cli/php.ini ${ROOTDIR}etc/php/7.3/fpm/php.ini \
                 ${ROOTDIR}var/www/conf/php.ini \
                 ${ROOTDIR}usr/local/etc/php.ini ${ROOTDIR}usr/local/lib/php.ini \
                 ${ROOTDIR}usr/local/etc/php5/cgi/php.ini \
@@ -55,6 +90,8 @@
                 ${ROOTDIR}usr/local/php56/lib/php.ini \
                 ${ROOTDIR}usr/local/php70/lib/php.ini \
                 ${ROOTDIR}usr/local/php71/lib/php.ini \
+                ${ROOTDIR}usr/local/php72/lib/php.ini \
+                ${ROOTDIR}usr/local/php73/lib/php.ini \
                 ${ROOTDIR}usr/local/zend/etc/php.ini \
                 ${ROOTDIR}usr/pkg/etc/php.ini \
                 ${ROOTDIR}opt/cpanel/ea-php54/root/etc/php.ini \
@@ -62,6 +99,8 @@
                 ${ROOTDIR}opt/cpanel/ea-php56/root/etc/php.ini \
                 ${ROOTDIR}opt/cpanel/ea-php70/root/etc/php.ini \
                 ${ROOTDIR}opt/cpanel/ea-php71/root/etc/php.ini \
+                ${ROOTDIR}opt/cpanel/ea-php72/root/etc/php.ini \
+                ${ROOTDIR}opt/cpanel/ea-php73/root/etc/php.ini \
                 ${ROOTDIR}opt/alt/php44/etc/php.ini \
                 ${ROOTDIR}opt/alt/php51/etc/php.ini \
                 ${ROOTDIR}opt/alt/php52/etc/php.ini \
@@ -71,24 +110,29 @@
                 ${ROOTDIR}opt/alt/php56/etc/php.ini \
                 ${ROOTDIR}opt/alt/php70/etc/php.ini \
                 ${ROOTDIR}opt/alt/php71/etc/php.ini \
+                ${ROOTDIR}opt/alt/php72/etc/php.ini \
+                ${ROOTDIR}opt/alt/php73/etc/php.ini \
                 ${ROOTDIR}etc/opt/remi/php56/php.ini \
                 ${ROOTDIR}etc/opt/remi/php70/php.ini \
                 ${ROOTDIR}etc/opt/remi/php71/php.ini \
-                ${ROOTDIR}etc/opt/remi/php72/php.ini"
+                ${ROOTDIR}etc/opt/remi/php72/php.ini \
+                ${ROOTDIR}etc/opt/remi/php73/php.ini"
     # HEADS-UP: OpenBSD, last two releases are supported, and snapshots of -current
     PHPINILOCS="${PHPINILOCS} \
-                ${ROOTDIR}etc/php-5.6.ini ${ROOTDIR}etc/php-7.0.ini ${ROOTDIR}etc/php-7.1.ini ${ROOTDIR}etc/php-7.2.ini"
+                ${ROOTDIR}etc/php-5.6.ini ${ROOTDIR}etc/php-7.0.ini ${ROOTDIR}etc/php-7.1.ini ${ROOTDIR}etc/php-7.2.ini ${ROOTDIR}etc/php-7.3.ini"
 
     PHPINIDIRS="${ROOTDIR}etc/php5/conf.d \
                 ${ROOTDIR}etc/php/7.0/cli/conf.d \
                 ${ROOTDIR}etc/php/7.1/cli/conf.d \
                 ${ROOTDIR}etc/php/7.2/cli/conf.d \
+                ${ROOTDIR}etc/php/7.3/cli/conf.d \
                 ${ROOTDIR}etc/php/7.0/fpm/conf.d \
                 ${ROOTDIR}etc/php/7.1/fpm/conf.d \
                 ${ROOTDIR}etc/php/7.2/fpm/conf.d \
+                ${ROOTDIR}etc/php/7.3/fpm/conf.d \
                 ${ROOTDIR}etc/php.d \
                 ${ROOTDIR}opt/cpanel/ea-php54/root/etc/php.d ${ROOTDIR}opt/cpanel/ea-php55/root/etc/php.d ${ROOTDIR}opt/cpanel/ea-php56/root/etc/php.d ${ROOTDIR}opt/cpanel/ea-php70/root/etc/php.d \
-                ${ROOTDIR}opt/cpanel/ea-php71/root/etc/php.d \
+                ${ROOTDIR}opt/cpanel/ea-php71/root/etc/php.d ${ROOTDIR}opt/cpanel/ea-php72/root/etc/php.d ${ROOTDIR}opt/cpanel/ea-php73/root/etc/php.d \
                 ${ROOTDIR}opt/alt/php44/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php51/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php52/etc/php.d.all \
@@ -97,10 +141,17 @@
                 ${ROOTDIR}opt/alt/php55/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php56/etc/php.d.all \
                 ${ROOTDIR}opt/alt/php70/etc/php.d.all \
-                ${ROOTDIR}opt/alt/php71/etc/php.d.all"
+                ${ROOTDIR}opt/alt/php71/etc/php.d.all \
+                ${ROOTDIR}opt/alt/php72/etc/php.d.all \
+                ${ROOTDIR}opt/alt/php73/etc/php.d.all \
+                ${ROOTDIR}usr/local/lib/php.conf.d \
+                ${ROOTDIR}usr/local/php70/lib/php.conf.d \
+                ${ROOTDIR}usr/local/php71/lib/php.conf.d \
+                ${ROOTDIR}usr/local/php72/lib/php.conf.d \
+                ${ROOTDIR}usr/local/php73/lib/php.conf.d"
     # HEADS-UP: OpenBSD, last two releases are supported, and snapshots of -current
     PHPINIDIRS="${PHPINIDIRS} \
-                ${ROOTDIR}etc/php-5.6 ${ROOTDIR}etc/php-7.0 ${ROOTDIR}etc/php-7.1 ${ROOTDIR}etc/php-7.2"
+                ${ROOTDIR}etc/php-5.6 ${ROOTDIR}etc/php-7.0 ${ROOTDIR}etc/php-7.1 ${ROOTDIR}etc/php-7.2 ${ROOTDIR}etc/php-7.3"
 #
 #################################################################################
 #


### PR DESCRIPTION
Should fix #780
Added a few more paths to php.ini files and php.conf.d folders - especially the ones reported in that issue.
I noticed that folders have to be added for each new PHP version and that some paths for PHP7.2 were missing and for PHP7.3 there had been no paths yet, so I added that as well.

@mboelen Maybe we (actually hope it is you :stuck_out_tongue: ) should rework the PHP test a bit to avoid the necessity to add new folders for each PHP version?

I'll ask for a test again, but already created this pull request for reference.