### PR TITLE
First fix in order make lynis work OK in AIX

### DIFF
--- a/include/profiles
+++ b/include/profiles
@@ -46,7 +46,7 @@
         fi
 
         # Security check for unexpected and possibly harmful escape characters (hyphen should be listed as first or last character)
-        DATA=$(grep -v '^$\|^ \|^#\|^config:' ${PROFILE} | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | od -An -ta | sed 's/ /!space!/g')
+        DATA=$(grep -Ev '^$|^ |^#|^config:' "${PROFILE}" | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | od -An -ta | sed 's/ /!space!/g')
         if ! IsEmpty "${DATA}"; then
             DisplayWarning "Your profile '${PROFILE}' contains unexpected characters. See the log file for more information."
             LogText "Found unexpected or possibly harmful characters in profile '${PROFILE}'. See which characters matched in the output below and compare them with your profile."


### PR DESCRIPTION
grep doesn't work with '\|' in AIX. grep -E is more POSIX compliant.

Without this fix, lynis doesn't work at all