### PR TITLE
Added CRYP-8004

### DIFF
--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -195,6 +195,33 @@
 #
 #################################################################################
 #
+    # Test        : CRYP-8004
+    # Description : Test for HWRNG & rngd
+    Register --test-no CRYP-8004 --os Linux --weight L --network NO --root-only NO --category security --description "Test for HWRNG & rngd"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        if [ -f ${ROOTDIR}sys/class/misc/hw_random/rng_current ]; then
+            DATA=$(${CAT_BINARY} ${ROOTDIR}sys/class/misc/hw_random/rng_current)
+            if [ "${DATA}" != "none" ]; then
+                LogText "Result: found HW RNG: ${DATA}"
+                if IsRunning "rngd"; then
+                    Display --indent 2 --text "- HW RNG & rngd" --result "${STATUS_YES}" --color GREEN
+                    LogText "Result: rngd is running"
+                else
+                    Display --indent 2 --text "- HW RNG & rngd" --result "${STATUS_NO}" --color YELLOW
+                    ReportSuggestion "${TEST_NO}" "Utilize HW RNG by running rngd"
+                fi
+            else
+                Display --indent 2 --text "- HW RNG & rngd" --result "${STATUS_NO}" --color RED
+                LogText "Result: no HW RNG available"
+            fi
+        else
+            Display --indent 2 --text "- HW RNG & rngd" --result "${STATUS_NO}" --color RED
+            LogText "Result: could not find ${ROOTDIR}sys/class/misc/hw_random/rng_current"
+        fi
+    fi
+#
+#################################################################################
+#
 
 WaitForKeyPress
 


### PR DESCRIPTION
Initial version of CRYP-8004 (see #793).

There are few shortcomings:

* This will not detect all RNGs (for instance OneRNG registers itself as `/dev/ttyACM0` and not through Linux's HW RNG drivers)
* There is no verification that `rngd` is actually using the found HW RNG. It could as well be using `/dev/zero` etc. This can be implemented, but might require a bit more complex check, as the input can be configured in several places (conf files, cmdline parameters etc.).