### PR TITLE
KRNL-5788 in Raspi: don't complain about missing /vmlinuz

### DIFF
--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -392,6 +392,9 @@
             elif [ -e ${ROOTDIR}dev/grsec ]; then
                 FINDKERNEL=linux-image-$(uname -r)
                 LogText "Result: ${ROOTDIR}vmlinuz missing due to grsecurity; assuming ${FINDKERNEL}"
+            elif [ -e ${ROOTDIR}etc/rpi-issue ]; then
+                FINDKERNEL=raspberrypi-kernel
+                LogText "Result: ${ROOTDIR}vmlinuz missing due to Raspbian"
             else
                 LogText "This system is missing ${ROOTDIR}vmlinuz or ${ROOTDIR}boot/vmlinuz.  Unable to check whether kernel is up-to-date."
                 ReportSuggestion "${TEST_NO}" "Determine why ${ROOTDIR}vmlinuz or ${ROOTDIR}boot/vmlinuz is missing on this Debian/Ubuntu system." "/vmlinuz or /boot/vmlinuz"


### PR DESCRIPTION
The Raspberry Pi kernels reside within raspberrypi-kernel package[1].

[1] https://www.raspberrypi.org/documentation/linux/kernel/updating.md