### PR TITLE
FILE-6310 for HP-UX

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -50,6 +50,7 @@
                 LogText "Result: directory ${I} exists"
                 case "${OS}" in
                     "AIX") FIND=$(${MOUNTBINARY} | ${AWKBINARY} -v MP=${I} '{ if ($2==MP) { print $2 }}') ;;
+                    "HP-UX") FIND=$(${MOUNTBINARY} | ${AWKBINARY} -v MP=${I} '{ if ($1==MP) { print $1 }}') ;;
                     *) FIND=$(${MOUNTBINARY} | ${AWKBINARY} -v MP=${I} '{ if ($3==MP) { print $3 }}') ;;
                 esac
 


### PR DESCRIPTION
HP-UX: /usr/sbin/mount reports "/home on /dev/…", so $1 has to be used