### PR TITLE
AUTH-9228 for HP-UX

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -302,7 +302,7 @@
                 FIND=$(${ROOTDIR}usr/sbin/pwck -q -r 2> /dev/null; echo $?)
                 TESTED=1
             ;;
-            "Solaris")
+            "Solaris"|"HP-UX")
                 FIND=$(${ROOTDIR}usr/sbin/pwck 2> /dev/null; echo $?)
                 TESTED=1
             ;;


### PR DESCRIPTION
HP-UX also has /usr/sbin/pwck. For trusted systems, two additional options -s (check inconsistencies with the protected password database) and -l (check encrypted password lengths that are greater than 8 characters) are available.