### PR TITLE
restructered test and fixed vmlinuz detection

### DIFF
--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -624,7 +624,7 @@
         fi
 
         # Check if /boot exists
-        if [ ${PRIVILEGED} -eq 1 -a -d "${ROOTDIR}boot" ]; then
+        if [ -d "${ROOTDIR}boot" ]; then
             LogText "Result: /boot exists, performing more tests from here"
             FIND=$(${LSBINARY} ${ROOTDIR}boot/* 2> /dev/null)
             if [ -n "${FIND}" ]; then
@@ -650,18 +650,17 @@
                     else
                         ReportException "${TEST_NO}:1" "Can't determine kernel version on disk, need debug data"
                     fi
-                elif [ -f ${ROOTDIR}boot/vmlinuz-linux -o -f ${ROOTDIR}boot/vmlinuz-linux-lts -o -f $(ls -t ${ROOTDIR}boot/vm[l-]* 2> /dev/null | head -1) ]; then
-                    if [ -L ${ROOTDIR}boot/vmlinuz-linux ]; then
-                        LogText "Result: found symlink ${ROOTDIR}boot/vmlinuz-linux"
-                        FOUND_VMLINUZ=$(readlink ${ROOTDIR}boot/vmlinuz-linux)
-                        LogText "Result: symlinked target is ${FOUND_VMLINUZ}"
-                        VERSION_ON_DISK=$(echo ${FOUND_VMLINUZ} | ${SEDBINARY} 's/^vmlinuz-//')
+                elif [ -f ${ROOTDIR}boot/vmlinuz-linux ] || [ -f ${ROOTDIR}boot/vmlinuz-linux-lts ] || [ -f "$(${LSBINARY} -t ${ROOTDIR}boot/vm[l0-9]* 2> /dev/null | ${HEADBINARY} -1)" ]; then
+                    if [ -f ${ROOTDIR}boot/vmlinuz-linux ]; then
+                        LogText "Result: found ${ROOTDIR}boot/vmlinuz-linux"
+                        FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux
                     elif [ -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
-                        LogText "Result: found boot/vmlinuz-linux-lts"
+                        LogText "Result: found ${ROOTDIR}boot/vmlinuz-linux-lts"
                         FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux-lts
                     else
                         # Match on /boot/vm5.3.7 or /boot/vmlinuz-5.3.7-1-default
-                        FOUND_VMLINUZ=$(ls -t ${ROOTDIR}boot/vm[l-]* 2> /dev/null | head -1)
+                        FOUND_VMLINUZ=$(${LSBINARY} -t ${ROOTDIR}boot/vm[l0-9]* 2> /dev/null | ${HEADBINARY} -1)
+                        LogText "Result: found ${FOUND_VMLINUZ}"
                     fi
 
                     if [ -L "${FOUND_VMLINUZ}" ]; then
@@ -673,7 +672,6 @@
                     fi
 
                     if [ -z "${VERSION_ON_DISK}" ]; then
-                        LogText "Result: found ${FOUND_VMLINUZ}"
                         LogText "Test: checking kernel version on disk"
                         NEXTLINE=0
                         VERSION_ON_DISK=""
@@ -686,6 +684,11 @@
                                 if [ "${I}" = "version" ]; then NEXTLINE=1; fi
                             fi
                         done
+                    fi
+
+                    if [ -z "${VERSION_ON_DISK}" ]; then
+                        LogText "Result: could not find the version on disk"
+                        ReportException "${TEST_NO}:4" "Could not find the kernel version"
                     else
                         LogText "Result: found version ${VERSION_ON_DISK}"
                         ACTIVE_KERNEL=$(uname -r)
@@ -697,10 +700,6 @@
                             REBOOT_NEEDED=1
                             LogText "Result: reboot needed, as there is a difference between active kernel and the one on disk"
                         fi
-                    fi
-                    if [ -z "${VERSION_ON_DISK}" ]; then
-                        LogText "Result: could not find the version on disk"
-                        ReportException "${TEST_NO}:4" "Could not find the kernel version"
                     fi
                 else
                     if [ -L ${ROOTDIR}boot/vmlinuz ]; then


### PR DESCRIPTION
Hi,

I noticed one issue at first and when I attempted to fix that, I discovered other issues as well, which should be fixed by my changes.

### 1. 
**Problem:**
The check for the kernel version fails with an error output on Raspbian and probably also on other unix systems where vmlinuz image is missing.

The output from lynis 3.0.0 master (latest version per Jan 26th):
```
    - Checking setuid core dumps configuration                [ DISABLED ]
Usage: file [-bcCdEhikLlNnprsvzZ0] [--apple] [--extension] [--mime-encoding]
            [--mime-type] [-e <testname>] [-F <separator>]  [-f <namefile>]
            [-m <magicfiles>] [-P <parameter=value>] <file> ...
       file -C [-m <magicfiles>]
       file [--help]

=================================================================

  Exception found!

  Function/test:  [KRNL-5830:4]
  Message:        Could not find the kernel version

  Help improving the Lynis community with your feedback!
  ...
=================================================================

  - Check if reboot is needed                                 [ UNKNOWN ]
```

The changes from https://github.com/CISOfy/lynis/commit/4e255617d37c54ef1d55fcdbde5baa85f380bcb0#diff-ab88f117cf951ebc33c3884ae17248ce to match on /boot/vm5.3.7 or /boot/vmlinuz-5.3.7-1-default (as stated in the comment) brought the if clause 
`if [ ... -o -f $(ls -t ${ROOTDIR}boot/vm[l-]* 2> /dev/null | head -1) ];`. 
If there is no vml* file, the test for a file has no string to test against.

**Solution:** 
added quotation marks around => "$(ls ...)":
`|| [ -f "$(${LSBINARY} -t ${ROOTDIR}boot/vm[l0-9]* 2> /dev/null | ${HEADBINARY} -1)" ];`

----------------------------------

### 2. 
**Problem:**
The check `if [ ... -o -f $(ls -t ${ROOTDIR}boot/vm[l-]* 2> /dev/null | head -1) ];` to match on /boot/vm5.3.7 (or /boot/vmlinuz-5.3.7-1-default as stated in the comment) didn't match on /boot/vm5.3.7.

```
root@raspberrypi:~/lynis_CISOfy# touch /boot/vm5.3.7
root@raspberrypi:~/lynis_CISOfy# ls -t /boot/vm[l-]*
ls: cannot access '/boot/vm[l-]*': No such file or directory
root@raspberrypi:~/lynis_CISOfy#
```

**Solution:** 
changed to 
`$(${LSBINARY} -t ${ROOTDIR}boot/vm[l0-9]* 2> /dev/null | ${HEADBINARY} -1)`

**Result:**
```
# ls -t ${ROOTDIR}boot/vm[l0-9]*
/boot/vmlinuz  /boot/vm5.3.7
root@raspberrypi:~#
```

----------------------------------

### 3.
**Problem:**
If the kernel files are: "/boot/vmlinuz-linux", "/boot/vmlinuz-linux-lts", "/boot/vmlinuz-5.3.7-1-default", ... 
then the kernel version of these files is not determined (variable VERSION_ON_DISK not written) if these kernel files are not also symbolic links.

**Solution:**
I restructured the code a bit, so that the following block is executed for all files written to "$FOUND_VMLINUZ" and not only for some of the files.

```
            if [ -z "${VERSION_ON_DISK}" ]; then
                LogText "Test: checking kernel version on disk"
                NEXTLINE=0
                VERSION_ON_DISK=""
                for I in $(file ${FOUND_VMLINUZ}); do
                    if [ ${NEXTLINE} -eq 1 ]; then
                        VERSION_ON_DISK="${I}"
                        break
                    else
                        # Searching for the Linux kernel after the keyword 'version'
                        if [ "${I}" = "version" ]; then NEXTLINE=1; fi
                    fi
                done
            fi
```

----------------------------

While already in the code I removed the check if the executing user is a privileged user. That way even a non-privileged user can determine if a reboot is required.
The test doesn't fail when permissions are missing, because of the already existing block
```
            FIND=$(${LSBINARY} ${ROOTDIR}boot/* 2> /dev/null)
            if [ -n "${FIND}" ]; then
```

======================================================================

Tested on (all root and non-root):
- Raspberian 4.19.75-v7+
- ArchLinux 4.19
- Manjaro 5.4
- Ubuntu 19.10

Tested with:
- bash 5.0.011-2
- dash 0.5.10.2

