### PR TITLE
NETW-3014: Report correct promisc interface

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -489,10 +489,10 @@
                 # Check if this interface was whitelisted
                 if [ ${WHITELISTED} -eq 0 ]; then
                     FOUNDPROMISC=1
-                    ReportWarning "${TEST_NO}" "Found promiscuous interface (${I})"
+                    ReportWarning "${TEST_NO}" "Found promiscuous interface (${ITEM})"
                     LogText "Note: some tools put an interface into promiscuous mode, to capture/log network traffic"
                 else
-                    LogText "Result: Found promiscuous interface ${I} (*whitelisted via profile*)"
+                    LogText "Result: Found promiscuous interface ${ITEM} (*whitelisted via profile*)"
                 fi
             done
         fi


### PR DESCRIPTION
NETW-3014 had its iterator name changed from ${I} to ${ITEM} 3 years ago but the report lines still reference ${I}. This reports the last thing ${I} was set to instead of the actual interface.