### PR TITLE
Remove the test for ssh config VerifyReverseMapping

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -151,7 +151,6 @@
                 StrictModes:YES,,NO:=\
                 TCPKeepAlive:NO,,YES:=\
                 UseDNS:NO,,YES:=\
-                VerifyReverseMapping:YES,,NO:=\
                 X11Forwarding:NO,,YES:=\
                 AllowAgentForwarding:NO,,YES:="
 


### PR DESCRIPTION
This option is deprecated since 2003. Having it in a config file raises
a warning and UseDNS (that is on by default) includes the
VerifyReverseMapping check.

See
https://github.com/openssh/openssh-portable/commit/3a961dc0d36c1f87788b707130f6d07709822d38

See #528

--------
I believe it's safe to remove a check for something deprecated for 17 years ;)

Cheers,
~Nico