### PR TITLE
[SSH-7408] fix OpenSSH server version check

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -117,7 +117,7 @@
     # Test        : SSH-7408
     # Description : Check SSH specific defined options
     # Notes       : Instead of parsing the configuration file, we query the SSH daemon itself
-    if [ ${OPENSSHD_RUNNING} -eq 1 -a -n "${SSH_DAEMON_OPTIONS_FILE}" -a ${OPENSSHD_VERSION_MAJOR} -ge 5 -a ${OPENSSHD_VERSION_MINOR} -ge 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ ${OPENSSHD_RUNNING} -eq 1 -a -n "${SSH_DAEMON_OPTIONS_FILE}" -a \( ${OPENSSHD_VERSION_MAJOR} -gt 5 -o ${OPENSSHD_VERSION_MAJOR} -eq 5 -a ${OPENSSHD_VERSION_MINOR} -ge 1 \) ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no SSH-7408 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check SSH specific defined options"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Checking specific defined options in ${SSH_DAEMON_OPTIONS_FILE}"


### PR DESCRIPTION
fix CISOfy/lynis#844

pre: major version >= 5 and minor version >= 1
post: major version > 5 or (major version == 5 and minor version >= 1)