### PR TITLE
Skip the PHP cli configuration file when looking for expose_php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - NAME-4404 - improved screen and log output
 - NAME-4408 - corrected Report function call
 - NETW-3032 - small rewrite of test and extended with addrwatch
+- PHP-2372 - don't look in the cli configuration files
 - PKGS-7410 - use multiple package managers when available
 - PKGS-7410 - added support for Zypper to test number of kernels
 - PROC-3602 - allow different root directory

--- a/include/tests_php
+++ b/include/tests_php
@@ -291,6 +291,8 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0
         for FILE in ${PHPINI_ALLFILES}; do
+            # Don't look at this setting in cli configuration
+            if [[ ${FILE} == *"/cli/"* ]]; then continue; fi
             LogText "Test: Checking file ${FILE}"
             FIND=$(${EGREPBINARY} -i 'expose_php.*(on|yes|1)' ${FILE} | ${GREPBINARY} -v '^;')
             if HasData "${FIND}"; then

--- a/include/tests_php
+++ b/include/tests_php
@@ -292,7 +292,11 @@
         FOUND=0
         for FILE in ${PHPINI_ALLFILES}; do
             # Don't look at this setting in cli configuration
-            if [[ ${FILE} == *"/cli/"* ]]; then continue; fi
+            case "${FILE}" in
+                */cli/*)
+                    continue
+                    ;;
+            esac
             LogText "Test: Checking file ${FILE}"
             FIND=$(${EGREPBINARY} -i 'expose_php.*(on|yes|1)' ${FILE} | ${GREPBINARY} -v '^;')
             if HasData "${FIND}"; then


### PR DESCRIPTION
The expose_php configuration option is only relevant for non-cli PHP and
thus lynis should not look for it in config files that are for cli

Fix #849