### PR TITLE
Fix quote syntax error in manpage

### DIFF
--- a/lynis.8
+++ b/lynis.8
@@ -122,7 +122,7 @@ line.
 .TP
 .B \-\-tests\-from\-category "<category>"
 Tests are only performed if they belong to the defined category. Use the command
-'show categories' to determine all valid options.
+\ 'show categories' to determine all valid options.
 .TP
 .B \-\-tests\-from\-group "<group>"
 Similar to \-\-tests\-from\-category. Only perform tests from a particular group.


### PR DESCRIPTION
Quotes have a special meaning when used at the start of line.