### PR TITLE
Check if /vmlinuz is missing due to /etc/kernel-img.conf

### DIFF
--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -395,6 +395,9 @@
             elif [ -e ${ROOTDIR}etc/rpi-issue ]; then
                 FINDKERNEL=raspberrypi-kernel
                 LogText "Result: ${ROOTDIR}vmlinuz missing due to Raspbian"
+            elif `${EGREPBINARY} -q 'do_symlinks.*=.*No' ${ROOTDIR}etc/kernel-img.conf`; then
+                FINDKERNEL=linux-image-$(uname -r)
+                LogText "Result: ${ROOTDIR}vmlinuz missing due to /etc/kernel-img.conf item do_symlinks = No"
             else
                 LogText "This system is missing ${ROOTDIR}vmlinuz or ${ROOTDIR}boot/vmlinuz.  Unable to check whether kernel is up-to-date."
                 ReportSuggestion "${TEST_NO}" "Determine why ${ROOTDIR}vmlinuz or ${ROOTDIR}boot/vmlinuz is missing on this Debian/Ubuntu system." "/vmlinuz or /boot/vmlinuz"


### PR DESCRIPTION
If /etc/kernel-img.conf has the line do_symlinks=No, Debian (probably
also Ubuntu) kernel packages will not update /vmlinuz
etc. symlinks. In that case, guess the kernel from uname -r.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>