### PR TITLE
Fix logging of running and enabled services

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -579,7 +579,7 @@
             LogText "Hint: Run systemctl --full --type=service to see all services"
             Display --indent 2 --text "- Check running services (systemctl)" --result "${STATUS_DONE}" --color GREEN
             Display --indent 8 --text "Result: found ${COUNT} running services"
-            LogText "Result: Found ${COUNT} enabled services"
+            LogText "Result: Found ${COUNT} running services"
 
             # Services at boot
             LogText "Searching for enabled services (systemctl services only)"
@@ -594,7 +594,7 @@
             LogText "Hint: Run systemctl list-unit-files --type=service to see all services"
             Display --indent 2 --text "- Check enabled services at boot (systemctl)" --result "${STATUS_DONE}" --color GREEN
             Display --indent 8 --text "Result: found ${COUNT} enabled services"
-            LogText "Result: Found ${COUNT} running services"
+            LogText "Result: Found ${COUNT} enabled services"
 
         else
 


### PR DESCRIPTION
Log lines for running and enabled services were mixed up, fix.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>