### PR TITLE
Enhance SELinux checks

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -249,7 +249,8 @@
                             samhain)                SAMHAINBINARY="${BINARY}";         LogText "  Found known binary: samhain (integrity tool) - ${BINARY}" ;;
                             service)                SERVICEBINARY="${BINARY}";         LogText "  Found known binary: service (system services) - ${BINARY}" ;;
                             sed)                    SEDBINARY="${BINARY}";             LogText "  Found known binary: sed (text stream editor) - ${BINARY}" ;;
-                            sestatus)               SESTATUSBINARY="${BINARY}";        LogText "  Found known binary: sestatus (SELinux client) - ${BINARY}" ;;
+                            semanage)               SEMANAGEBINARY="${BINARY}";        LogText "  Found known binary: semanage (SELinux policy management tool) - ${BINARY}" ;;
+                            sestatus)               SESTATUSBINARY="${BINARY}";        LogText "  Found known binary: sestatus (SELinux status tool) - ${BINARY}" ;;
                             slocate)                LOCATEBINARY="${BINARY}";          LogText "  Found known binary: slocate (file database) - ${BINARY}" ;;
                             smbd)                   SMBDBINARY="${BINARY}";            if [ "${OS}" = "macOS" ]; then SMBDVERSION="unknown"; else SMBDVERSION=$(${BINARY} -V | grep "^Version" | awk '{ print $2 }'); fi; LogText "Found ${BINARY} (version ${SMBDVERSION})" ;;
                             smtpctl)                SMTPCTLBINARY="${BINARY}";         LogText "  Found known binary: smtpctl (OpenSMTPD client) - ${BINARY}" ;;

--- a/include/tests_mac_frameworks
+++ b/include/tests_mac_frameworks
@@ -152,6 +152,17 @@
                 Display --indent 6 --text "- Checking current mode and config file" --result "${STATUS_WARNING}" --color RED
             fi
             Display --indent 8 --text "Current SELinux mode: ${FIND}"
+            PERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${TRBINARY} '\n' ' ')
+            NPERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${WCBINARY} --lines)
+            Display --indent 8 --text "Found ${NPERMISSIVE} permissive SELinux object types"
+            LogText "Permissive SELinux object types: ${PERMISSIVE}"
+            UNCONFINED=$(${PSBINARY} -eo label,pid,command | ${GREPBINARY} '[u]nconfined_t' | ${TRBINARY} '\n' ' ')
+            INITRC=$(${PSBINARY} -eo label,pid,command | ${GREPBINARY} '[i]nitrc_t' | ${TRBINARY} '\n' ' ')
+            NUNCONFINED=$(${PSBINARY} -eo label | ${GREPBINARY} '[u]nconfined_t' | ${WCBINARY} --lines)
+            NINITRC=$(${PSBINARY} -eo label | ${GREPBINARY} '[i]nitrc_t' | ${WCBINARY} --lines)
+            Display --indent 8 --text "Found ${NUNCONFINED} unconfined and ${NINITRC} initrc_t processes"
+            LogText "Unconfined processes: ${UNCONFINED}"
+            LogText "Processes with initrc_t type: ${INITRC}"
         else
             LogText "Result: SELinux framework is disabled"
             Display --indent 4 --text "- Checking SELinux status" --result "${STATUS_DISABLED}" --color YELLOW


### PR DESCRIPTION
Display and log: permissive types (rules are not enforced), unconfined
processes (not confined by rules) and processes with initrc_t
type (generic type with weak rules).

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>