### PR TITLE
FS module tests: check if modules are blacklisted

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -792,6 +792,12 @@
                     AddHP 3 3
                     if IsDebug; then Display --indent 6 --text "- Module ${FS} not present in the kernel" --result OK --color GREEN; fi
                 fi
+                FIND1=$(${EGREPBINARY} "blacklist ${FS}" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
+                FIND2=$(${EGREPBINARY} "install ${FS} /bin/true" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
+                if [ -n "${FIND1}" ] || [ -n "${FIND2}" ]; then
+                    Display --indent 4 --text "- Module $FS is blacklisted" --result "OK" --color GREEN
+                    LogText "Result: module ${FS} is blacklisted"
+                fi
             done
             if [ ${FOUND} -eq 1 ]; then
                 Display --indent 4 --text "- Discovered kernel modules: ${AVAILABLE_MODPROBE_FS}"


### PR DESCRIPTION
Check if FS modules are blacklisted, also suggest 'blacklist module'
instead of obsolete syntax.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>