### PR TITLE
pam: ignore leading dash

### DIFF
--- a/plugins/plugin_pam_phase1
+++ b/plugins/plugin_pam_phase1
@@ -96,7 +96,7 @@
                         PAM_CONTROL_OPTIONS="-"
                         PAM_MODULE="-"
                         PAM_MODULE_OPTIONS="-"
-                        PAM_TYPE=$(echo ${LINE} | awk '{ print $1 }')
+                        PAM_TYPE=$(echo ${LINE} | awk '{ print $1 }' | sed 's/^ *-//g')
                         PARSELINE=0
                         case ${PAM_TYPE} in
                             "@include")


### PR DESCRIPTION
PAM rules may have a leading '-' character to indicate that if the
module is missing, the error will be ignored, so let's ignore it in
the check.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>