### PR TITLE
Fix journalctl output parsing for recent journalctls

### DIFF
--- a/plugins/plugin_systemd_phase1
+++ b/plugins/plugin_systemd_phase1
@@ -176,7 +176,7 @@
     if [ ! "${JOURNALCTLBINARY}" = "" -a ${SYSTEMD_RUNNING} -eq 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PLGN-3816 --preqs-met ${PREQS_MET} --weight L --network NO --description "Query journal for boot related information" --progress
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=`${JOURNALCTLBINARY} --disk-usage | awk '{ if ($1=="Journals") { print $4 }}'`
+        FIND=`${JOURNALCTLBINARY} --disk-usage | awk '{ if ($1=="Journals") { print $4 } else if ($1=="Archived") { print $7 }}'`
         Report "journal_disk_size=${FIND}"
         LogText "Result: journals are ${FIND} in size"
     fi


### PR DESCRIPTION
Process output from journalctl (v245) like: "Archived and active
journals take up xxx.xM in the file system."

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>