### PR TITLE
Run 'systemd-analyze security'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - New profile option: ssl-certificate-paths-to-ignore - ignore a path
 - New test: AUTH-9229 - check used password hashing methods
 - New test: BOOT-5109 - test presence rEFInd boot loader
+- New test: BOOT-5264 - run systemd-analyze security
 - New test: CRYP-7930 - test for LUKS encryption
 - New test: CRYP-8004 - presence of hardware random number generator
 - New test: CRYP-8005 - presence of software random number generator

--- a/db/tests.db
+++ b/db/tests.db
@@ -78,6 +78,7 @@ BOOT-5260:test:security:boot_services::Check single user mode for systemd:
 BOOT-5261:test:security:boot_services:DragonFly:Check for DragonFly boot loader presence:
 BOOT-5262:test:security:boot_services:OpenBSD:Check for OpenBSD boot daemons:
 BOOT-5263:test:security:boot_services:OpenBSD:Check permissions for boot files/scripts:
+BOOT-5264:test:security:boot_services:Linux:Run systemd-analyze security:
 CONT-8004:test:security:containers:Solaris:Query running Solaris zones:
 CONT-8102:test:security:containers::Checking Docker status and information:
 CONT-8104:test:security:containers::Checking Docker info for any warnings:

--- a/include/binaries
+++ b/include/binaries
@@ -274,6 +274,7 @@
                             sysctl)                 SYSCTLBINARY="${BINARY}";          LogText "  Found known binary: sysctl (kernel parameters) - ${BINARY}" ;;
                             syslog-ng)              SYSLOGNGBINARY="${BINARY}";        SYSLOGNGVERSION=$(${BINARY} -V 2>&1 | grep "^syslog-ng" | awk '{ print $2 }'); LogText "Found ${BINARY} (version ${SYSLOGNGVERSION})" ;;
                             systemctl)              SYSTEMCTLBINARY="${BINARY}";       LogText "  Found known binary: systemctl (client to systemd) - ${BINARY}" ;;
+                            systemd-analyze)        SYSTEMDANALYZEBINARY="${BINARY}";  LogText "  Found known binary: systemd-analyze (systemd service analysis tool) - ${BINARY}" ;;
                             tail)                   TAILBINARY="${BINARY}";            LogText "  Found known binary: tail (text filter) - ${BINARY}" ;;
                             timedatectl)            TIMEDATECTL="${BINARY}";           LogText "  Found known binary: timedatectl (timedate client) - ${BINARY}" ;;
                             tomoyo-init)            TOMOYOINITBINARY=${BINARY};        LogText "  Found known binary: tomoyo-init (tomoyo component) - ${BINARY}" ;;

--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -987,6 +987,44 @@
 #
 #################################################################################
 #
+    # Test        : BOOT-5264
+    # Description : Run systemd-analyze security
+    if [ -z "${SYSTEMDANALYZEBINARY}" ]; then SKIPREASON="systemd-analyze not available"; PREQS_MET="NO";
+    else
+        SYSTEMD_VERSION=$("${SYSTEMDANALYZEBINARY}" --version | ${AWKBINARY} '/^systemd / {print $2}')
+        if [ "${SYSTEMD_VERSION}" -ge 240 ]; then PREQS_MET="YES"; else SKIPREASON="systemd-analyze too old (v${SYSTEMD_VERSION}), need at least v240"; PREQS_MET="NO"; fi
+    fi
+    Register --test-no BOOT-5264 --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --os Linux --weight L --network NO --category security --description "Run systemd-analyze security"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        LogText "Test: Run systemd-analyze security"
+        Display --indent 2 --text "- Running 'systemd-analyze security'"
+        ${SYSTEMDANALYZEBINARY} security | while read UNIT EXPOSURE PREDICATE HAPPY; do
+            if [ "${UNIT}" = "UNIT" ]; then
+                continue
+            fi
+            COLOR="BLACK"
+            case ${PREDICATE} in
+                PERFECT | SAFE | OK)
+                    COLOR=GREEN
+                ;;
+                MEDIUM)
+                    COLOR=WHITE
+                ;;
+                EXPOSED)
+                    COLOR=YELLOW
+                ;;
+                UNSAFE | DANGEROUS)
+                    COLOR=RED
+                ;;
+            esac
+            Display --indent 8 --text "- ${UNIT}:" --result "${PREDICATE}" --color "${COLOR}"
+            LogText "Result: ${UNIT}: ${EXPOSURE} ${PREDICATE}"
+        done
+        ReportSuggestion "${TEST_NO}" "Consider hardening system services" "Run '${SYSTEMDANALYZEBINARY} security SERVICE' for each service"
+    fi
+#
+#################################################################################
+#
 
 Report "boot_loader=${BOOT_LOADER}"
 Report "boot_uefi_booted=${UEFI_BOOTED}"


### PR DESCRIPTION
'systemd-analyze security' makes a nice overall evaluation of
hardening levels of services in a system. More details can be found
with 'systemd-analyze security SERVICE' for each service.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>