### PR TITLE
Check DNSSEC status with resolvectl when available

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -283,7 +283,7 @@ NAME-4408:test:security:nameservices::Check localhost to IP mapping:
 NETW-2600:test:security:networking:Linux:Checking IPv6 configuration:
 NETW-2704:test:security:networking::Basic nameserver configuration tests:
 NETW-2705:test:security:networking::Check availability two nameservers:
-NETW-2705:test:security:networking::Check DNSSEC status:
+NETW-2706:test:security:networking::Check DNSSEC status:
 NETW-3001:test:security:networking::Find default gateway (route):
 NETW-3004:test:security:networking::Search available network interfaces:
 NETW-3006:test:security:networking::Get network MAC addresses:

--- a/db/tests.db
+++ b/db/tests.db
@@ -283,6 +283,7 @@ NAME-4408:test:security:nameservices::Check localhost to IP mapping:
 NETW-2600:test:security:networking:Linux:Checking IPv6 configuration:
 NETW-2704:test:security:networking::Basic nameserver configuration tests:
 NETW-2705:test:security:networking::Check availability two nameservers:
+NETW-2705:test:security:networking::Check DNSSEC status:
 NETW-3001:test:security:networking::Find default gateway (route):
 NETW-3004:test:security:networking::Search available network interfaces:
 NETW-3006:test:security:networking::Get network MAC addresses:

--- a/include/binaries
+++ b/include/binaries
@@ -239,6 +239,7 @@
                             python3)                PYTHON3BINARY="${BINARY}";         PYTHON3VERSION=$(${BINARY}  --version 2>&1 | sed 's/^Python //'); LogText "Found known binary: ${FILENAME} (programming language interpreter) - ${BINARY} (version ${PYTHON3VERSION})" ;;
                             rcctl)                  RCCTLBINARY="${BINARY}";           LogText "  Found known binary: rcctl (services and daemons configuration and control) - ${BINARY}" ;;
                             readlink)               READLINKBINARY="${BINARY}";        LogText "  Found known binary: readlink (follows symlinks) - ${BINARY}" ;;
+                            resolvectl)             RESOLVECTLBINARY="${BINARY}";      LogText "  Found known binary: resolvectl (systemd-resolved DNS resolver manager) - ${BINARY}" ;;
                             rkhunter)               RKHUNTERBINARY="${BINARY}";        MALWARE_SCANNER_INSTALLED=1;           LogText "  Found known binary: rkhunter (malware scanner) - ${BINARY}" ;;
                             rootsh)                 ROOTSHBINARY="${BINARY}";          LogText "  Found known binary: rootsh (wrapper for shells) - ${BINARY}" ;;
                             rpcinfo)                RPCINFOBINARY="${BINARY}";         LogText "  Found known binary: rpcinfo (RPC information) - ${BINARY}" ;;

--- a/include/tests_networking
+++ b/include/tests_networking
@@ -190,6 +190,31 @@
 #
 #################################################################################
 #
+    # Test        : NETW-2706
+    # Description : Check systemd-resolved and upstream DNSSEC status
+    if [ -n "${RESOLVECTLBINARY}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no NETW-2706 --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check systemd-resolved and upstream DNSSEC status"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        SKIP=0
+        if [ -n "${RESOLVECTLBINARY}" ]; then
+	    DNSSEC_STATUS=$(${RESOLVECTLBINARY} statistics | ${AWKBINARY} -F ":" '/DNSSEC supported/ { print $2 }' | ${TRBINARY} -d ' ')
+            if [ "${DNSSEC_STATUS}" = "yes" ]; then
+                Display --indent 4 --text "- DNSSEC supported (systemd-resolved)" --result "${STATUS_OK}" --color GREEN
+                LogText "Result: DNSSEC supported by systemd-resolved and upstream DNS servers"
+            else
+                Display --indent 4 --text "- DNSSEC supported (systemd-resolved)" --result "${STATUS_WARNING}" --color RED
+                LogText "Result: DNSSEC not supported by systemd-resolved or upstream DNS servers"
+            fi
+        else
+            Display --indent 4 --text "- DNSSEC supported (systemd-resolved)" --result "${STATUS_SKIPPED}" --color YELLOW
+            LogText "Result: resolvectl not installed, test can't be fully performed"
+        fi
+    else
+        LogText "Result: Test most likely skipped due to not having resolvectl"
+    fi
+#
+#################################################################################
+#
     # Test        : NETW-3001
     # Description : Find default gateway (route)
     # More info   : BSD: ^default   Linux: 0.0.0.0


### PR DESCRIPTION
'resolvectl statistics' shows if DNSSEC is supported by
systemd-resolved and upstream DNS servers.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>