### PR TITLE
Make BOOT-5260 Linux only

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -849,7 +849,7 @@
 #
     # Test        : BOOT-5260
     # Description : Check single user mode for systemd
-    Register --test-no BOOT-5260 --weight L --network NO --category security --description "Check single user mode for systemd"
+    Register --test-no BOOT-5260 --os Linux --weight L --network NO --category security --description "Check single user mode for systemd"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Searching /usr/lib/systemd/system/rescue.service"
         if [ -f ${ROOTDIR}usr/lib/systemd/system/rescue.service ]; then


### PR DESCRIPTION
Linux is the only OS with systemd so no need to check for systemd
single user mode on other operatings systems.