### PR TITLE
Fix uses of non-standard find not operator

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -677,7 +677,7 @@
             LogText "Result: directory /etc/pam.d exists"
             Display --indent 2 --text "- PAM configuration files (pam.d)" --result "${STATUS_FOUND}" --color GREEN
             LogText "Test: searching PAM configuration files"
-            FIND=$(${FINDBINARY} ${ROOTDIR}etc/pam.d -not -name "*.pam-old" -type f -print | sort)
+            FIND=$(${FINDBINARY} ${ROOTDIR}etc/pam.d \! -name "*.pam-old" -type f -print | sort)
             for FILE in ${FIND}; do
                 LogText "Found file: ${FILE}"
             done

--- a/plugins/plugin_pam_phase1
+++ b/plugins/plugin_pam_phase1
@@ -77,12 +77,12 @@
         if [ -d ${PAM_DIRECTORY} ]; then
             LogText "Result: ${PAM_DIRECTORY} exists"
             if [ ! "${OS}" = "FreeBSD" -a ! "${OS}" = "NetBSD" ]; then
-                FIND_FILES=$(find ${PAM_DIRECTORY} -not -name "*.pam-old" -type f -print)
+                FIND_FILES=$(find ${PAM_DIRECTORY} \! -name "*.pam-old" -type f -print)
             else
                 if [ -f ${PAM_DIRECTORY}/README ]; then
                     LogText "Skipped checking ${OS} ${PAM_DIRECTORY}/README as a PAM file"
                 fi
-                FIND_FILES=$(find ${PAM_DIRECTORY} -not -name "README" -not -name "*.pam-old" -type f -print)
+                FIND_FILES=$(find ${PAM_DIRECTORY} \! -name "README" \! -name "*.pam-old" -type f -print)
             fi
 
             for PAM_FILE in ${FIND_FILES}; do


### PR DESCRIPTION
Use `!` rather than the non-standard `find(1) -not` operator.