### PR TITLE
Add NetBSD EOL

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -9,6 +9,9 @@
 #
 # Date can be converted on Linux using: date "+%s" --date=2020-01-01
 #
+# Note: For rolling releases or releases that do not (currently have an
+#       EOL date, leave field three empty and set field four to -1.
+#
 # Amazon Linux
 #
 os:Amazon Linux:2020-06-30:1593468000:
@@ -16,7 +19,7 @@ os:Amazon Linux 2:2023-06-26:1687730400:
 #
 # Arch Linux
 #
-os:Arch Linux:2286-11-20:9999999999:
+os:Arch Linux::-1:
 #
 # CentOS
 #

--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -48,6 +48,55 @@ os:FreeBSD 10.4:2018-10-31:0:
 os:FreeBSD 11.0:2017-11-30:0:
 os:FreeBSD 11.1:2018-09-30:0:
 #
+# NetBSD - https://www.netbsd.org/support/security/release.html and
+#          https://www.netbsd.org/releases/formal.html
+#
+os:NetBSD 2.0:2008-01-19:0:
+os:NetBSD 2.0.1:2008-01-19:0:
+os:NetBSD 2.0.2:2008-01-19:0:
+os:NetBSD 2.0.3:2008-01-19:0:
+os:NetBSD 2.1:2008-01-19:0:
+os:NetBSD 3.0:2009-09-29:0:
+os:NetBSD 3.0.1:2009-09-29:0:
+os:NetBSD 3.0.2:2009-09-29:0:
+os:NetBSD 3.1:2009-09-29:0:
+os:NetBSD 4.0:2012-11-17:0:
+os:NetBSD 4.0.1:2012-11-17:0:
+os:NetBSD 5.0:2015-11-17:0:
+os:NetBSD 5.0.1:2015-10-17:0:
+os:NetBSD 5.0.2:2015-10-17:0:
+os:NetBSD 5.1:2015-10-17:0:
+os:NetBSD 5.1.1:2015-10-17:0:
+os:NetBSD 5.1.2:2015-10-17:0:
+os:NetBSD 5.1.3:2015-10-17:0:
+os:NetBSD 5.1.4:2015-10-17:0:
+os:NetBSD 5.1.5:2015-10-17:0:
+os:NetBSD 5.2.1:2015-10-17:0:
+os:NetBSD 5.2.2:2015-10-17:0:
+os:NetBSD 5.2.3:2015-10-17:0:
+os:NetBSD 6.0:2017-09-17:0:
+os:NetBSD 6.0.1:2017-09-17:0:
+os:NetBSD 6.0.2:2017-09-17:0:
+os:NetBSD 6.0.3:2017-09-17:0:
+os:NetBSD 6.0.4:2017-09-17:0:
+os:NetBSD 6.0.5:2017-09-17:0:
+os:NetBSD 6.1:2017-09-17:0:
+os:NetBSD 6.1.1:2017-09-17:0:
+os:NetBSD 6.1.2:2017-09-17:0:
+os:NetBSD 6.1.3:2017-09-17:0:
+os:NetBSD 6.1.4:2017-09-17:0:
+os:NetBSD 6.1.5:2017-09-17:0:
+os:NetBSD 7.0:2020-03-14:1584162000:
+os:NetBSD 7.0.1:2020-03-14:1584162000:
+os:NetBSD 7.0.2:2020-03-14:1584162000:
+os:NetBSD 7.1:2020-03-14:1584162000:
+os:NetBSD 7.1.1:2020-03-14:1584162000:
+os:NetBSD 7.1.1:2020-03-14:1584162000:
+os:NetBSD 7.2:2020-03-14:1584162000:
+os:NetBSD 8.0::-1:
+os:NetBSD 8.1::-1:
+os:NetBSD 9.0::-1:
+#
 # OpenBSD - https://en.wikipedia.org/wiki/OpenBSD_version_history
 #
 os:OpenBSD 5.8:2016-09-01:0:

--- a/include/osdetection
+++ b/include/osdetection
@@ -575,13 +575,17 @@
             EOL_TIMESTAMP=$(awk -v value="${FIND}" -F: '{if ($1=="os" && value ~ $2){print $4}}' ${DBDIR}/software-eol.db | head -n 1)
             if [ -n "${EOL_TIMESTAMP}" ]; then
                 EOL_DATE=$(awk -v value="${FIND}" -F: '{if ($1=="os" && value ~ $2){print $3}}' ${DBDIR}/software-eol.db | head -n 1)
-                NOW=$(date "+%s")
-                if [ -n "${NOW}" ]; then
-                    if [ ${NOW} -gt ${EOL_TIMESTAMP} ]; then
-                        EOL=1
-                    else
-                        EOL=0
+                if [ -n "${EOL_DATE}" ]; then
+                    NOW=$(date "+%s")
+                    if [ -n "${NOW}" ]; then
+                        if [ ${NOW} -gt ${EOL_TIMESTAMP} ]; then
+                            EOL=1
+                        else
+                            EOL=0
+                        fi
                     fi
+                else
+                    EOL=0
                 fi
             fi
         fi


### PR DESCRIPTION
Slightly modify how the EOL lookup works in osdetection by changing the
semantic meaning of an empty date field (field 3). If this field is empty then
the EOL for the OS is false (0). This is much clearer than setting a date far
in the future. There are some OS that have a rolling upgrade (Arch Linux)
and others that EOL older releases after a certain number of (major) releases
have past (NetBSD).

Add EOL data for NetBSD based on NetBSD's general policy of marking a
release EOL one month after the second succeeding major release.