### PR TITLE
Add FreeBSD and NetBSD to AUTH-9268

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -691,8 +691,13 @@
 #
     # Test        : AUTH-9268
     # Description : Searching available PAM files
-    # Notes       : PAM is used on AIX, FreeBSD, Linux, HPUX, Solaris
-    if [ ${OS} = "AIX" -o ${OS} = "Linux" -o ${OS} = "HPUX" -o ${OS} = "Solaris" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    # Notes       : PAM is used on AIX, FreeBSD, Linux, HPUX, NetBSD, Solaris
+    case "${OS}" in
+        "AIX"|"FreeBSD"|"Linux"|"HPUX"|"NetBSD"|"Solaris")
+            PREQS_MET="YES" ;;
+        *)
+            PREQS_MET="NO" ;;
+    esac
     Register --test-no AUTH-9268 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking presence pam.d files"
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0


### PR DESCRIPTION
Add FreeBSD and NetBSD as both support PAM. Simplify the `PREQS_MET`
set test by using a case rather than a long if or.