### PR TITLE
Check if system uses encrypted swap devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - New test: BOOT-5109 - test presence rEFInd boot loader
 - New test: BOOT-5264 - run systemd-analyze security
 - New test: CRYP-7930 - test for LUKS encryption
+- New test: CRYP-7931 - determine if system uses encrypted swap
 - New test: CRYP-8004 - presence of hardware random number generator
 - New test: CRYP-8005 - presence of software random number generator
 - New test: DBS-1828  - PostgreSQL configuration files

--- a/db/tests.db
+++ b/db/tests.db
@@ -89,6 +89,7 @@ CONT-8108:test:security:containers::Check file permissions for Docker files:
 CORE-1000:test:performance:system_integrity::Check all system binaries:
 CRYP-7902:test:security:crypto::Check expire date of SSL certificates:
 CRYP-7930:test:security:crypto:Linux:Determine if system uses LUKS encryption:
+CRYP-7931:test:security:crypto:Linux:Determine if system uses encrypted swap:
 CRYP-8002:test:security:crypto:Linux:Gather kernel entropy:
 CRYP-8004:test:security:crypto:Linux:Presence of hardware random number generators:
 CRYP-8005:test:security:crypto:Linux:Presence of software pseudo random number generators:

--- a/include/binaries
+++ b/include/binaries
@@ -271,6 +271,7 @@
                             sha256|sha256sum)       SHA256SUMBINARY="${BINARY}";       LogText "  Found known binary: sha256/sha256sum (crypto hashing) - ${BINARY}" ;;
                             ssh-keyscan)            SSHKEYSCANBINARY="${BINARY}";      LogText "  Found known binary: ssh-keyscan (scanner for SSH keys) - ${BINARY}" ;;
                             suricata)               SURICATABINARY="${BINARY}";        LogText "  Found known binary: suricata (IDS) - ${BINARY}" ;;
+                            swapon)                 SWAPONBINARY="${BINARY}";          LogText "  Found known binary: swapon (swap device tool) - ${BINARY}" ;;
                             swupd)                  SWUPDBINARY="${BINARY}";           LogText "  Found known binary: swupd (package manager) - ${BINARY}" ;;
                             sysctl)                 SYSCTLBINARY="${BINARY}";          LogText "  Found known binary: sysctl (kernel parameters) - ${BINARY}" ;;
                             syslog-ng)              SYSLOGNGBINARY="${BINARY}";        SYSLOGNGVERSION=$(${BINARY} -V 2>&1 | grep "^syslog-ng" | awk '{ print $2 }'); LogText "Found ${BINARY} (version ${SYSLOGNGVERSION})" ;;

--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -174,6 +174,31 @@
 #
 #################################################################################
 #
+    # Test        : CRYP-7931
+    # Description : Determine if system uses encrypted swap
+    if [ -e "${SWAPONBINARY}" -a -e "${CRYPTSETUPBINARY}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no CRYP-7931 --preqs-met ${PREQS_MET} --os Linux --weight L --network NO --root-only YES --category security --description "Determine if system uses encrypted swap"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        ENCRYPTED_SWAPS=0
+        UNENCRYPTED_SWAPS=0
+        SWAPS=$(${SWAPONBINARY} --show=NAME --noheadings)
+        for BLOCK_DEV in ${SWAPS}; do
+            if ${CRYPTSETUPBINARY} isLuks "${BLOCK_DEV}" 2> /dev/null; then
+                LogText "Result: Found LUKS encrypted swap device: ${BLOCK_DEV}"
+                ENCRYPTED_SWAPS=$((ENCRYPTED_SWAPS +1))
+            elif ${CRYPTSETUPBINARY} status "${BLOCK_DEV}" | ${GREPBINARY} --quiet "cipher:"; then
+                LogText "Result: Found non-LUKS encrypted swap device: ${BLOCK_DEV}"
+                ENCRYPTED_SWAPS=$((ENCRYPTED_SWAPS +1))
+            else
+                LogText "Result: Found unencrypted swap device: ${BLOCK_DEV}"
+                UNENCRYPTED_SWAPS=$((UNENCRYPTED_SWAPS +1))
+            fi
+        done
+        Display --indent 2 --text "- Found ${ENCRYPTED_SWAPS} encrypted and ${UNENCRYPTED_SWAPS} unencrypted swap devices in use." --result OK --color WHITE
+    fi
+#
+#################################################################################
+#
     # Test        : CRYP-8002
     # Description : Gather available kernel entropy
     Register --test-no CRYP-8002 --os Linux --weight L --network NO --root-only NO --category security --description "Gather available kernel entropy"


### PR DESCRIPTION
Add test CRYP-7931 to check if the system uses any encrypted swap
devices.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>