### PR TITLE
Fixes for virtual machine dmidecode

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1774,11 +1774,13 @@
         # dmidecode
         # Values: VMware Virtual Platform / VirtualBox
         if [ -z "${SHORT}" ]; then
-            if [ -x /usr/bin/dmidecode ]; then DMIDECODE_BINARY="/usr/bin/dmidecode"
-            elif [ -x /usr/sbin/dmidecode ]; then DMIDECODE_BINARY="/usr/sbin/dmidecode"
-            else
-                DMIDECODE_BINARY=""
-            fi
+            DMIDECODE_BINARY=""
+            for SCANDIR in ${BIN_PATHS}; do
+                if [ -x ${SCANDIR}/dmidecode ]; then
+                    DMIDECODE_BINARY="${SCANDIR}/dmidecode"
+		    break
+                fi
+            done
             if [ ! "${DMIDECODE_BINARY}" = "" -a ${PRIVILEGED} -eq 1 ]; then
                 LogText "Test: trying to guess virtualization with dmidecode"
                 FIND=$(${DMIDECODE_BINARY} -s system-product-name | awk '{ print $1 }')

--- a/include/functions
+++ b/include/functions
@@ -1781,7 +1781,7 @@
             fi
             if [ ! "${DMIDECODE_BINARY}" = "" -a ${PRIVILEGED} -eq 1 ]; then
                 LogText "Test: trying to guess virtualization with dmidecode"
-                FIND=$(/usr/sbin/dmidecode -s system-product-name | awk '{ print $1 }')
+                FIND=$(${DMIDECODE_BINARY} -s system-product-name | awk '{ print $1 }')
                 if [ -n "${FIND}" ]; then
                     LogText "Result: found ${FIND}"
                     SHORT="${FIND}"


### PR DESCRIPTION
Supports systems install `dmidecode` in _other_ locations by expanding the
_search path_ for `dmidecode` to include more than `/usr/bin`
and `/usr/sbin`. Can not use `${DMIDECODEBINARY}` as this test could
run with `${CHECK_BINARIES} or CORE-1000 being disabled.