### PR TITLE
AUTH-9229 Do not use long options for sort

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -374,7 +374,7 @@
                     echo "Unknown password hashing method ${METHOD}. Please report to lynis-dev@cisofy.com"
                     ;;
             esac
-        done | ${SORTBINARY} --unique | ${TRBINARY} '\n' ' ')
+        done | ${SORTBINARY} -u | ${TRBINARY} '\n' ' ')
         if [ -z "${FIND}" ]; then
             Display --indent 2 --text "- Password hashing methods" --result "${STATUS_OK}" --color GREEN
             LogText "Result: no poor password hashing methods found"


### PR DESCRIPTION
Use the standard `sort(1)` short option `-u` rather than `--unique`,
since not all versions support long options.