### PR TITLE
Fix AUTH-9230 for systems without /etc/login.defs

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -396,7 +396,7 @@
     if [ -f ${ROOTDIR}etc/login.defs ]; then
         PREQS_MET="YES"
     fi
-    Register --test-no AUTH-9230 --root-only NO --weight L --network NO --category security --description "Check group password hashing rounds"
+    Register --test-no AUTH-9230 --preqs-met ${PREQS_MET} --root-only NO --weight L --network NO --category security --description "Check group password hashing rounds"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Checking SHA_CRYPT_MIN_ROUNDS option in ${ROOTDIR}etc/login.defs"
         FIND=$(${GREPBINARY} "^SHA_CRYPT_MIN_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MIN_ROUNDS") { print $2 } }')


### PR DESCRIPTION
This fixes a bug where it was determined that /etc/login.defs didn't
exist as a prerequisite but then wasn't used to skip the test. Prevents
warnings from `grep(1)` for "no such file or directory".