### PR TITLE
PROC-3802 Only check for prelink package on Linux

### DIFF
--- a/include/tests_memory_processes
+++ b/include/tests_memory_processes
@@ -118,7 +118,7 @@
 #
     # Test        : PROC-3802
     # Description : Check presence of prelink tooling
-    Register --test-no PROC-3802 --weight L --network NO --category security --description "Check presence of prelink tooling"
+    Register --test-no PROC-3802 --os Linux --weight L --network NO --category security --description "Check presence of prelink tooling"
     if [ ${SKIPTEST} -eq 0 ]; then
         if PackageIsInstalled "prelink"; then
             LogText "Result: prelink packages is installed"


### PR DESCRIPTION
The prelink package is Linux specific no need to check for it on
non-Linux systems.