### PR TITLE
Add pkg_info

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -230,6 +230,7 @@
                             php)                    PHPBINARY="${BINARY}";             PHPVERSION=$(${BINARY} -v | awk '{ if ($1=="PHP") { print $2 }}' | head -1); LogText "Found known binary: php (programming language interpreter) - ${BINARY} (version ${PHPVERSION})" ;;
                             pkg)                    PKG_BINARY="${BINARY}";            LogText "  Found known binary: pkg (software package administration) - ${BINARY}" ;;
                             pkg_admin)              PKGADMINBINARY="${BINARY}";        LogText "  Found known binary: pkg_admin (software package administration) - ${BINARY}" ;;
+                            pkg_info)               PKGINFOBINARY="${BINARY}";         LogText "  Found known binary: pkg_info (software package information) - ${BINARY}" ;;
                             postconf)               POSTCONFBINARY="${BINARY}";        LogText "  Found known binary: postconf (postfix configuration) - ${BINARY}" ;;
                             postfix)                POSTFIXBINARY="${BINARY}";         LogText "  Found known binary: postfix (postfix binary) - ${BINARY}" ;;
                             prelink)                PRELINKBINARY="${BINARY}";         LogText "  Found known binary: prelink (system optimizer) - ${BINARY}" ;;

--- a/include/functions
+++ b/include/functions
@@ -2041,6 +2041,9 @@
         elif [ -n "${PKG_BINARY}" ]; then
             output=$(${PKG_BINARY} -N info ${package} >/dev/null 2>&1)
             exit_code=$?  # 0=package installed, 70=invalid package
+        elif [ -n "${PKGINFOBINARY}" ]; then
+            output=$(${PKGINFOBINARY} -q -e ${package} >/dev/null 2>&1)
+            exit_code=$?  # 0=package installed, 1=package not installed
         elif [ -n "${RPMBINARY}" ]; then
             output=$(${RPMBINARY} --quiet -q ${package} > /dev/null 2>&1)
             exit_code=$?


### PR DESCRIPTION
These changes will remove numerous errors when `PackageIsInstalled` is called on a system using pkgsrc (e.g. NetBSD). It still does not solve the underlying issue with `PackageIsInstalled` doesn't work correctly on BSD systems where the core/base commands/daemons are not tracked as packages but considered part of the (core) OS.