### PR TITLE
Fix PKGS-7301 message nit

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -38,7 +38,7 @@
     # Test        : PKGS-7301
     # Description : Query FreeBSD pkg
     if [ -x ${ROOTDIR}usr/sbin/pkg ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
-    Register --test-no PKGS-7301 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Query NetBSD pkg"
+    Register --test-no PKGS-7301 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Query FreeBSD pkg"
     if [ ${SKIPTEST} -eq 0 ]; then
         FIND=$(pkg -N 2>&1; echo $?)
         if [ "${FIND}" = "0" ]; then


### PR DESCRIPTION
The comment is correct. It is FreeBSD pkg not NetBSD pkg.