### PR TITLE
Skip VM detection for show helper

### DIFF
--- a/include/parameters
+++ b/include/parameters
@@ -160,6 +160,7 @@
                 RUN_TESTS=0
                 RUN_UPDATE_CHECK=0
                 SKIP_PLUGINS=1
+                SKIP_VM_DETECTION=1
                 SHOW_PROGRAM_DETAILS=0
                 SHOW_TOOL_TIPS=0
                 shift; HELPER_PARAMS="$@"


### PR DESCRIPTION
No need for VM detection when running the `show` helper. This cleans
up errors caused when `$AWKBINARY` is not set as `show` also does
not check for binaries.