### PR TITLE
extended test KRNL-5830 to detect required reboots on Raspbian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - KRNL-5788 - don't complain about missing /vmlinuz for Raspi
 - KRNL-5820 - extended check to include limits.d directory
 - KRNL-5830 - skip test partially when running non-privileged
+- KRNL-5830 - detect required reboots on Raspbian
 - LOGG-2154 - added support for rsyslog configurations
 - LOGG-2190 - skip mysqld related entries
 - MACF-6234 - SELinux tests extended

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -31,6 +31,7 @@
     LINUXCONFIGFILE=""
     LINUXCONFIGFILE_ZIPPED=0
     LIMITS_DIRECTORY="${ROOTDIR}etc/security/limits.d"
+    APT_ARCHIVE_DIRECTORY="${ROOTDIR}var/cache/apt/archives"
 #
 #################################################################################
 #
@@ -771,6 +772,107 @@
             fi
         else
             LogText "Result: /boot does not exist or not privileged to read files"
+        fi
+
+        # Attempt to check for Raspbian if reboot is needed
+        # This check searches for apt package "raspberrypi-kernel-[package-date]", trys to extract the date of packaging from the filename
+        # and compares that date with the currently running kernel's build date (uname -v).
+        # Of course there can be a time difference between kernel build and kernel packaging, therefor a time difference of
+        # 3 days is accepted and it is assumed with only 3 days apart, this must be the same kernel version.
+        if [ ${REBOOT_NEEDED} -eq 2 ] && [ -d "${APT_ARCHIVE_DIRECTORY}" ]; then
+            LogText "Result: found folder ${APT_ARCHIVE_DIRECTORY}; assuming this is a debian based distribution"
+            LogText "Check: try to find raspberrypi-kernel file in ${APT_ARCHIVE_DIRECTORY} and extract package date from file name"
+
+            FOUND_KERNEL_DATE=$(${FINDBINARY} ${APT_ARCHIVE_DIRECTORY} -name "raspberrypi-kernel*" -printf "%T@ %Tc %p\n" 2> /dev/null \
+            | ${SORTBINARY} -nr | ${HEADBINARY} -1 | ${GREPBINARY} -o "raspberrypi-kernel.*deb" | ${EGREPBINARY} -o "\.[0-9]+" | ${SEDBINARY} 's/\.//g')
+
+            if [ -n "${FOUND_KERNEL_DATE}" ]; then
+                FOUND_KERNEL_IN_SECONDS=$(date -d "${FOUND_KERNEL_DATE}" "+%s" 2> /dev/null)
+            else
+                LogText "Result: Skipping this test, as there was no package date to extract"
+            fi
+
+            if [ -n "${FOUND_KERNEL_IN_SECONDS}" ] && [ ${FOUND_KERNEL_IN_SECONDS} -gt 1 ]; then
+                LogText "Result: Got package date: ${FOUND_KERNEL_DATE} (= ${FOUND_KERNEL_IN_SECONDS} seconds)"
+                UNAME_OUTPUT="$(${UNAMEBINARY} -v 2> /dev/null)"
+            else
+                LogText "Result: Skipping this test, as extracting the seconds of package date failed"
+            fi
+            
+            if [ -n "${UNAME_OUTPUT}" ]; then
+                LogText "Result: Got an output from 'uname -v'"
+                LogText "Check: Trying to extract kernel build date from 'uname -v' output"
+                next=""
+                for part in ${UNAME_OUTPUT}; do
+                    if [ -z "$next" ]; then
+                        if [ "${part}" = "Mon" ] || [ "${part}" = "Tue" ] || [ "${part}" = "Wed" ] || [ "${part}" = "Thu" ] || [ "${part}" = "Fri" ] || [ "${part}" = "Sat" ] || [ "${part}" = "Sun" ]; then
+                            next="month"
+                        fi
+                    elif [ "$next" = "month" ]; then
+                        if [ $(${ECHOCMD} "${part}" | ${EGREPBINARY} -c "[A-Z][a-z]") -ge 1 ]; then
+                            UNAME_DATE_MONTH="${part}"
+                            next="day"
+                        fi
+                    elif [ "${next}" = "day" ]; then
+                        if [ $(${ECHOCMD} ${part} | ${EGREPBINARY} -c "[0-9][0-9]") -ge 1 ]; then
+                            UNAME_DATE_DAY="${part}"
+                            next="time"
+                        fi
+                    elif [ "${next}" = "time" ]; then
+                        if [ $(${ECHOCMD} ${part} | ${EGREPBINARY} -c ":[0-9][0-9]:") -ge 1 ]; then
+                            next="year"
+                        fi
+                    elif [ "${next}" = "year" ]; then
+                        if [ $(${ECHOCMD} ${part} | ${EGREPBINARY} -c "[0-9][0-9]") -ge 1 ]; then
+                            UNAME_DATE_YEAR="${part}"
+                            break
+                        fi
+                    fi
+                done
+                if [ -n "${UNAME_DATE_MONTH}" ] && [ -n "${UNAME_DATE_DAY}" ] && [ -n "${UNAME_DATE_YEAR}" ]; then
+                    LogText "Result: Extracted kernel build date is: ${UNAME_DATE_DAY} ${UNAME_DATE_MONTH} ${UNAME_DATE_YEAR}"
+                    UNAME_DATE_IN_SECONDS=$(date -d "${UNAME_DATE_DAY} ${UNAME_DATE_MONTH} ${UNAME_DATE_YEAR}" "+%s" 2> /dev/null)
+                    LogText "Check: Comparing kernel build date in seconds (${UNAME_DATE_IN_SECONDS}s) with package date in seconds (${FOUND_KERNEL_IN_SECONDS}s)"
+                    if [ -n "${UNAME_DATE_IN_SECONDS}" ] && [ ${FOUND_KERNEL_IN_SECONDS} -ge ${UNAME_DATE_IN_SECONDS} ]; then
+                        LogText "Result: package creation date is older than running kernel. Hence, this check should be valid."
+                        LogText "Check if package create date and kernel build date are not more than 3 days apart."
+
+                        SECONDS_APART=$(( ${FOUND_KERNEL_IN_SECONDS} - ${UNAME_DATE_IN_SECONDS} ))
+                        if [ ${SECONDS_APART} -ge 60 ]; then
+                            MINUTES_APART=$(( ${SECONDS_APART} / 60 ))
+                            if [ ${MINUTES_APART} -ge 60 ]; then
+                                DAYS_APART=$(( ${MINUTES_APART} / 60 ))
+                                if [ ${DAYS_APART} -ge 24 ]; then DAYS_APART=$(( ${DAYS_APART} / 24 )); else DAYS_APART=0; fi
+                            else
+                                DAYS_APART=0
+                            fi
+                        else
+                            DAYS_APART=0
+                        fi
+                        # assuming kernels are packaged definitely within 3 days. ACCEPTED_TIME_DIFF needs a value in seconds
+                        ACCEPTED_TIME_DIFF=$((3 * 24 * 60 * 60))
+                        if [ ${FOUND_KERNEL_IN_SECONDS} -le $((${UNAME_DATE_IN_SECONDS} + ${ACCEPTED_TIME_DIFF})) ]; then
+                            LogText "Result: package create date and kernel build date are only ${DAYS_APART} day(s) apart."
+                            LogText "Result: Assuming no reboot needed."
+                            REBOOT_NEEDED=0
+                        else
+                            LogText "Result: package create date and kernel build date are ${DAYS_APART} day(s) apart."
+                            LogText "Result: Assuming reboot is needed."
+                            REBOOT_NEEDED=1
+                        fi
+                    else
+                        LogText "Result: Package's create date is older than running kernel, which is unexpected. Might not be a valid test. Skipping..."
+                    fi
+                else
+                    LogText "Result: Could not extract Day, Month and Year from 'uname -v' output"
+                fi
+            else
+                LogText "Result: Did not get output from 'uname -v'. Skipping test."
+            fi
+                
+            
+        else
+            LogText "Result: /var/cache/apt/archives/ does not exist"
         fi
 
         # Display discovered status


### PR DESCRIPTION
Hello,

I'm not sure if such a feature is wanted in the project. Raspian doesn't have a standard way to inform a user about required reboots yet (as far as I know). That's probably the reason why lynis doesn't detect a required reboot yet.

I wrote a few lines which works around the missing standard way in Raspbian by simply comparing the build date of the current running kernel with the package date of the latest installed kernel package.

This test only starts if the check for a required reboot has no result so far and if there is a raspberrypi-kernel package file. So this test should not interfere with test results on other systems. Running these changes on other OS (Arch) didn't cause any issues.

It is successfully tested on my raspi with bash and dash.

I'm curious what you think about that :)

## A few more details

Current kernel packages on my raspi:
```
pi@raspberrypi:~/lynis_Schmuuu $ find /var/cache/apt/archives/ -name "raspberrypi-kernel*"
/var/cache/apt/archives/raspberrypi-kernel_1.20190925+1-1_armhf.deb
/var/cache/apt/archives/raspberrypi-kernel_1.20200114-1_armhf.deb
/var/cache/apt/archives/raspberrypi-kernel_1.20190517-1_armhf.deb
/var/cache/apt/archives/raspberrypi-kernel_1.20200212-1_armhf.deb
/var/cache/apt/archives/raspberrypi-kernel_1.20190819~stretch-1_armhf.deb
find: ‘/var/cache/apt/archives/partial’: Permission denied
```
The find command which I used to find the latest kernel package on the system:
```
pi@raspberrypi:~/lynis_Schmuuu $ find /var/cache/apt/archives/ -name "raspberrypi-
kernel*" -printf "%T@ %Tc %p\n" 2> /dev/null | sort -nr | head -1
1583830529.0000000000 Tue 10 Mar 2020 09:55:29 AM CET /var/cache/apt/archives/raspberrypi-kernel_1.20200212-1_armhf.deb
```
Currently running kernel:
```
pi@raspberrypi:~/lynis_Schmuuu $ uname -v
#1270 SMP Tue Sep 24 18:45:11 BST 2019
```
The output of show details:
```
pi@raspberrypi:~/lynis_Schmuuu $ ./lynis show details KRNL-5830
2020-04-02 22:19:20 Performing test ID KRNL-5830 (Checking if system is running on the latest installed kernel)
2020-04-02 22:19:20 Test: Checking presence /var/run/reboot-required.pkgs
2020-04-02 22:19:20 Result: file /var/run/reboot-required.pkgs not found
2020-04-02 22:19:20 Result: /boot exists, performing more tests from here
2020-04-02 22:19:20 Result: /boot/vmlinuz not on disk, trying to find /boot/vmlinuz*
2020-04-02 22:19:20 Result: using 4.19.75 as my kernel version (stripped)
2020-04-02 22:19:20 Output: Found a kernel file in /boot
2020-04-02 22:19:20 Result: found folder /var/cache/apt/archives; assuming this is a debian based distribution
2020-04-02 22:19:20 Check: try to find raspberrypi-kernel file in /var/cache/apt/archives and extract package date from file name
2020-04-02 22:19:20 Result: Got package date: 20200212 (= 1581462000 seconds)
2020-04-02 22:19:20 Result: Got an output from 'uname -v'
2020-04-02 22:19:20 Check: Trying to extract kernel build date from 'uname -v' output
2020-04-02 22:19:20 Result: Extracted kernel build date is: 24 Sep 2019
2020-04-02 22:19:20 Check: Comparing kernel build date in seconds (1569276000s) with package date in seconds (1581462000s)
2020-04-02 22:19:20 Result: package creation date is older than running kernel. Hence, this check should be valid.
2020-04-02 22:19:20 Check if package create date and kernel build date are not more than 3 days apart.
2020-04-02 22:19:20 Result: package create date and kernel build date are 141 day(s) apart.
2020-04-02 22:19:20 Result: Assuming reboot is needed.
2020-04-02 22:19:20 Warning: Reboot of system is most likely needed [test:KRNL-5830] [details:] [solution:text:reboot]
2020-04-02 22:19:20 Hardening: assigned partial number of hardening points (0 of 5). Currently having 9 points (out of 14)
```

![DeepinScreenshot_select-area_20200402223939](https://user-images.githubusercontent.com/26191454/78298568-d9bbce80-7532-11ea-840e-27d965bb7e34.png)
