### PR TITLE
AUTH-9268 Add DragonFly

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -817,13 +817,8 @@
     # Test        : AUTH-9268
     # Description : Searching available PAM files
     # Notes       : PAM is used on AIX, FreeBSD, Linux, HPUX, NetBSD, Solaris
-    case "${OS}" in
-        "AIX"|"FreeBSD"|"Linux"|"HPUX"|"NetBSD"|"Solaris")
-            PREQS_MET="YES" ;;
-        *)
-            PREQS_MET="NO" ;;
-    esac
-    Register --test-no AUTH-9268 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking presence pam.d files"
+    OS_USES_PAM="AIX DragonFly FreeBSD Linux HPUX NetBSD Solaris"
+    Register --test-no AUTH-9268 --os "${OS_USES_PAM}" --weight L --network NO --category security --description "Checking presence pam.d files"
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0
         LogText "Test: Searching pam modules"


### PR DESCRIPTION
DragonFly also supports PAM. Rework to use the `--os` option of `Register`
rather than `--preqs-met` as the former can support a list.