### PR TITLE
AUTH-9218 Improvements

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -49,7 +49,6 @@ AUTH-9406:test:security:authentication::Query LDAP servers in client configurati
 AUTH-9408:test:security:authentication::Logging of failed login attempts via /etc/login.defs:
 AUTH-9409:test:security:authentication:OpenBSD:Check for doas file:
 AUTH-9410:test:security:authentication:OpenBSD:Check for doas file permissions:
-AUTH-9489:test:security:authentication:DragonFly:Check login shells for passwordless accounts:
 BANN-7113:test:security:banners:FreeBSD:Check COPYRIGHT banner file:
 BANN-7124:test:security:banners::Check issue banner file:
 BANN-7126:test:security:banners::Check issue banner file contents:

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -157,51 +157,7 @@
     # Test        : AUTH-9218
     # Description : Check login shells for passwordless accounts
     # Notes       : Results should be checked
-    Register --test-no AUTH-9218 --os FreeBSD --weight L --network NO --category security --description "Check login shells for passwordless accounts"
-    if [ ${SKIPTEST} -eq 0 ]; then
-        FOUND=0
-        LogText "Test: Checking login shells"
-        if [ -f ${ROOTDIR}etc/master.passwd ]; then
-            # Check for all shells, except: (/usr)/sbin/nologin /nonexistent
-            FIND=$(${GREPBINARY} "[a-z]:\*:" /etc/master.passwd | ${EGREPBINARY} -v '^#|/sbin/nologin|/usr/sbin/nologin|/nonexistent' | ${SEDBINARY} 's/ /!space!/g')
-            if [ "${FIND}" = "" ]; then
-                Display --indent 2 --text "- Login shells" --result "${STATUS_OK}" --color GREEN
-            else
-                Display --indent 2 --text "- Login shells" --result "${STATUS_WARNING}" --color RED
-                for LINE in ${FIND}; do
-                    LINE=$(echo ${LINE} | ${SEDBINARY} 's/!space!/ /g')
-                    SHELL=$(echo ${LINE} | ${AWKBINARY} -F: '{ print $10 }')
-                    LogText "Output: ${LINE}"
-                    if [ -z "${SHELL}" ]; then
-                        LogText "Result: found no shell on line"
-                    else
-                        LogText "Result: found possible harmful shell ${SHELL}"
-                        if [ -f ${SHELL} ]; then
-                            LogText "Result: shell ${SHELL} does exist"
-                            FOUND=1
-                        else
-                            LogText "Result: shell ${SHELL} does not exist"
-                            ReportSuggestion "${TEST_NO}" "Determine if account is needed, as shell ${SHELL} does not exist"
-                        fi
-                    fi
-                done
-                if [ ${FOUND} -eq 1 ]; then
-                    ReportWarning "${TEST_NO}" "Possible harmful shell found (for passwordless account!)"
-                fi
-            fi
-          else
-            Display --indent 2 --text "- Login shells" --result "${STATUS_SKIPPED}" --color WHITE
-            LogText "Result: No /etc/master.passwd file found"
-        fi
-        unset LINE SHELL
-    fi
-#
-#################################################################################
-#
-    # Test        : AUTH-9489
-    # Description : Check login shells for passwordless accounts
-    # Notes       : Results should be checked
-    Register --test-no AUTH-9489 --os DragonFly --weight L --network NO --category security --description "Check login shells for passwordless accounts"
+    Register --test-no AUTH-9218 --os "DragonFly FreeBSD"  --weight L --network NO --category security --description "Check login shells for passwordless accounts"
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0
         LogText "Test: Checking login shells"

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -157,7 +157,7 @@
     # Test        : AUTH-9218
     # Description : Check login shells for passwordless accounts
     # Notes       : Results should be checked
-    Register --test-no AUTH-9218 --os "DragonFly FreeBSD"  --weight L --network NO --category security --description "Check login shells for passwordless accounts"
+    Register --test-no AUTH-9218 --os "DragonFly FreeBSD" --root-only YES --weight L --network NO --category security --description "Check login shells for passwordless accounts"
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0
         LogText "Test: Checking login shells"

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -157,7 +157,7 @@
     # Test        : AUTH-9218
     # Description : Check login shells for passwordless accounts
     # Notes       : Results should be checked
-    Register --test-no AUTH-9218 --os "DragonFly FreeBSD" --root-only YES --weight L --network NO --category security --description "Check login shells for passwordless accounts"
+    Register --test-no AUTH-9218 --os "DragonFly FreeBSD NetBSD OpenBSD" --root-only YES --weight L --network NO --category security --description "Check login shells for passwordless accounts"
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0
         LogText "Test: Checking login shells"


### PR DESCRIPTION
All of the BSD based OSes have `/etc/master.passwd`. Make AUTH-9218 work for all removing
redundant AUTH-9489 for DragonFly. For all BSD OSes `/etc/master.passwd` is only readable
by root so additional condition to test registration.