### PR TITLE
Check for IOMMU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - New test: FINT-4341 - verify status of dm-verity (Linux)
 - New test: INSE-8314 - test for NIS client
 - New test: INSE-8316 - test for NIS server
+- New test: KRNL-5731 - check if IOMMU is enabled
 - New test: NETW-2706 - check DNSSEC (systemd)
 - New test: NETW-3200 - determine enabled network protocols
 - New test: PHP-2382 - detect listen option in PHP (FPM)

--- a/db/tests.db
+++ b/db/tests.db
@@ -208,6 +208,7 @@ KRNL-5723:test:security:kernel:Linux:Determining if Linux kernel is monolithic:
 KRNL-5726:test:security:kernel:Linux:Checking Linux loaded kernel modules:
 KRNL-5728:test:security:kernel:Linux:Checking Linux kernel config:
 KRNL-5730:test:security:kernel:Linux:Checking disk I/O kernel scheduler:
+KRNL-5731:test:security:kernel:Linux:Check if IOMMU is enabled:
 KRNL-5745:test:security:kernel:FreeBSD:Checking FreeBSD loaded kernel modules:
 KRNL-5770:test:security:kernel:Solaris:Checking active kernel modules:
 KRNL-5788:test:security:kernel:Linux:Checking availability new Linux kernel:

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -284,6 +284,23 @@
 #
 #################################################################################
 #
+    # Test        : KRNL-5731
+    # Description : Check if IOMMU is enabled
+    Register --test-no KRNL-5731 --os Linux --weight L --network NO --category security --description "Check if IOMMU is enabled"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        LogText "Test: Checking /proc/cmdline for any iommu= parameter"
+        LINUX_IOMMU=$(${SEDBINARY} 's/ /\n/g' /proc/cmdline | ${SEDBINARY} -e '/iommu=/s/.*=\(.*\)$/\1/pg')
+        if [ -z "${LINUX_IOMMU}" -o "${LINUX_IOMMU}" = "off" ]; then
+            LogText "Result: no I/O MMU found"
+            Display --indent 2 --text "- Checking if I/O MMU is enabled" --result "${STATUS_NOT_FOUND}" --color WHITE
+        else
+            LogText "Result: found I/O MMU"
+            Display --indent 2 --text "- Checking if I/O MMU is enabled" --result "${STATUS_FOUND}" --color GREEN
+        fi
+   fi
+#
+#################################################################################
+#
     # Test        : KRNL-5745
     # Description : Checking FreeBSD loaded kernel modules
     Register --test-no KRNL-5745 --os FreeBSD --weight L --network NO --category security --description "Checking FreeBSD loaded kernel modules"


### PR DESCRIPTION
Add a new test to check if I/O MMU is enabled in the kernel command
line.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>