### PR TITLE
Check for registered non-native binary formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - New test: FINT-4316 - presence of AIDE database and size test
 - New test: FINT-4340 - check dm-integrity status (Linux)
 - New test: FINT-4341 - verify status of dm-verity (Linux)
+- New test: HRDN-7231 - check for registered non-native binary formats
 - New test: INSE-8314 - test for NIS client
 - New test: INSE-8316 - test for NIS server
 - New test: NETW-2400 - test hostname for valid characters and length

--- a/db/tests.db
+++ b/db/tests.db
@@ -168,6 +168,7 @@ HOME-9350:test:security:homedirs::Collecting information from home directories:
 HRDN-7220:test:security:hardening::Check if one or more compilers are installed:
 HRDN-7222:test:security:hardening::Check compiler permissions:
 HRDN-7230:test:security:hardening::Check for malware scanner:
+HRDN-7231:test:security:hardening:Linux:Check for registered non-native binary formats:
 HTTP-6622:test:security:webservers::Checking Apache presence:
 HTTP-6624:test:security:webservers::Testing main Apache configuration file:
 HTTP-6626:test:security:webservers::Testing other Apache configuration file:

--- a/include/tests_hardening
+++ b/include/tests_hardening
@@ -107,6 +107,27 @@
 #
 #################################################################################
 #
+    # Test        : HRDN-7231
+    # Description : Check for registered non-native binary formats
+    Register --test-no HRDN-7231  --os Linux --weight L --network NO --category security --description "Check for registered non-native binary formats"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        LogText "Test: Check for registered non-native binary formats"
+        NFORMATS=0
+        if [ -d /proc/sys/fs/binfmt_misc ]; then
+            NFORMATS=$(${FINDBINARY} /proc/sys/fs/binfmt_misc -type f -not -name register -not -name status | ${WCBINARY} --lines)
+        fi
+        if [ ${NFORMATS} -eq 0 ]; then
+            LogText "Result: no non-native binary formats found"
+            Display --indent 4 --text "- Non-native binary formats" --result "${STATUS_NOT_FOUND}" --color GREEN
+        else
+            FORMATS=$(${FINDBINARY} /proc/sys/fs/binfmt_misc -type f -not -name register -not -name status -printf '%f ')
+            LogText "Result: found ${NFORMATS} non-native binary formats registered: ${FORMATS}"
+            Display --indent 4 --text "- Non-native binary formats" --result "${STATUS_FOUND}" --color RED
+        fi
+    fi
+#
+#################################################################################
+#
 #    LogText "--------------------------------------------------------------------"
 #    LogText "| System part                        | Preferred value | Actual value | Points |"
 #    LogText "| [!] Compiler installed               |              0  | [${COMPILER_INSTALLED}]     | x  |"


### PR DESCRIPTION
Examine /proc/sys/fs/binfmt_misc (Linux) for additional registered
binary formats. Those are probably emulated and their emulation could
be less tested, more buggy and more vulnerable than native binary
formats, so they should be disabled when not needed.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>