### PR TITLE
accept more restrictive file permissions

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1286,7 +1286,7 @@
                 CHECK_PERMISSION=$(echo "${CHECK_PERMISSION}" | ${AWKBINARY} '{printf "%03d",$1}')
 
                 # First try stat command
-                LogText "Test: checking if file ${CHECKFILE} is ${CHECK_PERMISSION}"
+                LogText "Test: checking if file ${CHECKFILE} has the permissions set to ${CHECK_PERMISSION} or more restrictive"
                 if [ -n "${STATBINARY}" ]; then
 
                     case ${OS} in
@@ -1344,7 +1344,7 @@
                 DATA=$(echo "${DATA}" | ${AWKBINARY} '{printf "%03d",$1}')
 
                 if [ -n "${DATA}" ]; then
-                    if [ "${DATA}" = "${CHECK_PERMISSION}" ]; then
+                    if [ "${DATA}" -le "${CHECK_PERMISSION}" ]; then
                         LogText "Outcome: correct permissions (${DATA})"
                         return 0
                     fi


### PR DESCRIPTION
Lynis currently doesn't accept stricter file permissions.

E.g.:

```
~/lynis$ sudo ./lynis show details FILE-7524 | grep -i grub
2020-04-22 07:54:06 Test: checking file/directory /boot/grub/grub.cfg
2020-04-22 07:54:06 Test: checking if file /boot/grub/grub.cfg is 600
2020-04-22 07:54:06 Outcome: permissions of file /boot/grub/grub.cfg are not matching expected value (400 != 0600)
2020-04-22 07:54:06 Test: checking file/directory /boot/grub2/grub.cfg
2020-04-22 07:54:06 Skipping file/directory /boot/grub2/grub.cfg as it does not exist on this system
2020-04-22 07:54:06 Test: checking file/directory /boot/grub2/user.cfg
2020-04-22 07:54:06 Skipping file/directory /boot/grub2/user.cfg as it does not exist on this system
```

After change:

```
~/lynis$ sudo ./lynis show details FILE-7524 | grep -A1 -i grub
2020-04-22 08:28:24 Test: checking file/directory /boot/grub/grub.cfg
2020-04-22 08:28:24 Test: checking if file /boot/grub/grub.cfg has the permissions set to 600 or more restrictive
2020-04-22 08:28:24 Outcome: correct permissions (400)
2020-04-22 08:28:24 Test: checking file/directory /boot/grub2/grub.cfg
2020-04-22 08:28:24 Skipping file/directory /boot/grub2/grub.cfg as it does not exist on this system
2020-04-22 08:28:24 Test: checking file/directory /boot/grub2/user.cfg
2020-04-22 08:28:24 Skipping file/directory /boot/grub2/user.cfg as it does not exist on this system
2020-04-22 08:28:24 Test: checking file/directory /etc/at.allow
~/lynis$
```


Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>