### PR TITLE
[CRYP-7902] Check also certificates in DER format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - BOOT-5122 - check for defined password in all GRUB configuration files
 - CONT-8106 - support newer 'docker info' output
 - CRYP-7902 - optionally check also certificates provided by packages
+- CRYP-7902 - check also certificates in DER format
 - CRYP-8002 - gather kernel entropy on Linux systems
 - FILE-6310 - support for HP-UX
 - FILE-6374 - changed log and allow root location to be changed

--- a/default.prf
+++ b/default.prf
@@ -93,7 +93,7 @@ skip-plugins=no
 #skip-upgrade-test=yes
 
 # Locations where to search for SSL certificates (separate paths with a colon)
-ssl-certificate-paths=/etc/apache2:/etc/dovecot:/etc/httpd:/etc/letsencrypt:/etc/pki:/etc/postfix:/etc/ssl:/opt/psa/var/certificates:/usr/local/psa/var/certificates:/usr/local/share/ca-certificates:/usr/share/ca-certificates:/usr/share/gnupg:/var/www:/srv/www
+ssl-certificate-paths=/etc/apache2:/etc/dovecot:/etc/httpd:/etc/letsencrypt:/etc/pki:/etc/postfix:/etc/refind.d/keys:/etc/ssl:/opt/psa/var/certificates:/usr/local/psa/var/certificates:/usr/local/share/ca-certificates:/usr/share/ca-certificates:/usr/share/gnupg:/var/www:/srv/www
 ssl-certificate-paths-to-ignore=/etc/letsencrypt/archive:
 ssl-certificate-include-packages=no
 

--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -50,7 +50,7 @@
                     LASTSUBDIR=""
                     LogText "Result: found directory ${DIR}"
                     # Search for certificate files
-                    FILES=$(${FINDBINARY} ${DIR} -type f 2> /dev/null | ${EGREPBINARY} ".crt$|.pem$|^cert" | ${SORTBINARY} | ${SEDBINARY} 's/ /__space__/g')
+                    FILES=$(${FINDBINARY} ${DIR} -type f 2> /dev/null | ${EGREPBINARY} ".cer$|.crt$|.der$|.pem$|^cert" | ${SORTBINARY} | ${SEDBINARY} 's/ /__space__/g')
                     for FILE in ${FILES}; do
                         FILE=$(echo ${FILE} | ${SEDBINARY} 's/__space__/ /g')
                         # See if we need to skip this path
@@ -76,16 +76,23 @@
                             if [ ${CANREAD} -eq 1 ]; then
                                 # Only check the files that are not installed by a package, unless enabled by profile
                                 if [ ${SSL_CERTIFICATE_INCLUDE_PACKAGES} -eq 1 ] || ! FileInstalledByPackage "${FILE}"; then
+                                    echo ${FILE} | ${EGREPBINARY} --quiet ".cer$|.der$"
+                                    CER_DER=$?
                                     OUTPUT=$(${GREPBINARY} -q 'BEGIN CERT' "${FILE}")
-                                    if [ $? -eq 0 ]; then
+                                    if [ $? -eq 0 -o ${CER_DER} -eq 0 ]; then
                                         LogText "Result: file is a certificate file"
-                                        FIND=$(${OPENSSLBINARY} x509 -noout -in "${FILE}" -enddate 2> /dev/null | ${GREPBINARY} "^notAfter")
+                                        if [ ${CER_DER} -eq 0 ]; then
+                                            SSL_DER_OPT="-inform der"
+                                        else
+                                            SSL_DER_OPT=
+                                        fi
+                                        FIND=$(${OPENSSLBINARY} x509 -noout ${SSL_DER_OPT} -in "${FILE}" -enddate 2> /dev/null | ${GREPBINARY} "^notAfter")
                                         if [ $? -eq 0 ]; then
                                             # Check certificate where 'end date' has been expired
-                                            FIND=$(${OPENSSLBINARY} x509 -noout -checkend 0 -in "${FILE}" -enddate 2> /dev/null)
+                                            FIND=$(${OPENSSLBINARY} x509 -noout ${SSL_DER_OPT} -checkend 0 -in "${FILE}" -enddate 2> /dev/null)
                                             EXIT_CODE=$?
-                                            CERT_CN=$(${OPENSSLBINARY} x509 -noout -subject -in "${FILE}" 2> /dev/null | ${SEDBINARY} -e 's/^subject.*CN=\([a-zA-Z0-9\.\-\*]*\).*$/\1/')
-                                            CERT_NOTAFTER=$(${OPENSSLBINARY} x509 -noout -enddate -in "${FILE}" 2> /dev/null | ${AWKBINARY} -F= '{if ($1=="notAfter") { print $2 }}')
+                                            CERT_CN=$(${OPENSSLBINARY} x509 -noout ${SSL_DER_OPT} -subject -in "${FILE}" 2> /dev/null | ${SEDBINARY} -e 's/^subject.*CN=\([a-zA-Z0-9\.\-\*]*\).*$/\1/')
+                                            CERT_NOTAFTER=$(${OPENSSLBINARY} x509 -noout ${SSL_DER_OPT} -enddate -in "${FILE}" 2> /dev/null | ${AWKBINARY} -F= '{if ($1=="notAfter") { print $2 }}')
                                             Report "certificate[]=${FILE}|${EXIT_CODE}|cn:${CERT_CN};notafter:${CERT_NOTAFTER};|"
                                             if [ ${EXIT_CODE} -eq 0 ]; then 
                                                 LogText "Result: certificate ${FILE} seems to be correct and still valid"


### PR DESCRIPTION
Check also certificates in DER (*.cer, *.der) format. Add
/etc/refind.d/keys to list of certificate paths.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>