### PR TITLE
Fix KRNL-5730 to properly check /proc/config.gz

### DIFF
--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -235,12 +235,13 @@
     Register --test-no KRNL-5728 --os Linux --weight L --network NO --category security --description "Checking Linux kernel config"
     if [ ${SKIPTEST} -eq 0 ]; then
         CHECKFILE="${ROOTDIR}boot/config-$(uname -r)"
+        CHECKFILE_ZIPPED="${ROOTDIR}proc/config.gz"
         if [ -f ${CHECKFILE} ]; then
             LINUXCONFIGFILE="${CHECKFILE}"
             LogText "Result: found config (${LINUXCONFIGFILE})"
             Display --indent 2 --text "- Checking Linux kernel configuration file" --result "${STATUS_FOUND}" --color GREEN
-        elif [ -f ${ROOTDIR}proc/config.gz ]; then
-            LINUXCONFIGFILE="${CHECKFILE}"
+        elif [ -f ${CHECKFILE_ZIPPED} ]; then
+            LINUXCONFIGFILE="${CHECKFILE_ZIPPED}"
             LINUXCONFIGFILE_ZIPPED=1
             LogText "Result: found config: ${ROOTDIR}proc/config.gz (compressed)"
             Display --indent 2 --text "- Checking Linux kernel configuration file" --result "${STATUS_FOUND}" --color GREEN


### PR DESCRIPTION
When KRNL-5728 locates the kernel config it does not properly set LINUXCONFIGFILE
if config is found as /proc/config.gz. This causes KRNL-5730 to fail due to missing prereqs,
despite a kernel config existing.