### PR TITLE
Added OS detection for Oracle Linux

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -195,6 +195,12 @@
                             OS_NAME="Manjaro"
                             OS_VERSION="Rolling release"
                         ;;
+                        "ol")
+                            LINUX_VERSION="Oracle Linux"
+                            OS_NAME="Oracle Linux"
+                            OS_REDHAT_OR_CLONE=1
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "opensuse-tumbleweed")
                             LINUX_VERSION="openSUSE Tumbleweed"
                             # It's rolling release but has a snapshot version (the date of the snapshot)


### PR DESCRIPTION
This pull request adds support for Oracle Linux, an EL derivative. closes #924