### PR TITLE
New test: KRNL-6001 - check SysV shared memory configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - New test: FINT-4341 - verify status of dm-verity (Linux)
 - New test: INSE-8314 - test for NIS client
 - New test: INSE-8316 - test for NIS server
+- New test: KRNL-6001 - check SysV shared memory configuration
 - New test: NETW-2400 - test hostname for valid characters and length
 - New test: NETW-2706 - check DNSSEC (systemd)
 - New test: NETW-3200 - determine enabled network protocols

--- a/db/tests.db
+++ b/db/tests.db
@@ -216,6 +216,7 @@ KRNL-5820:test:security:kernel:Linux:Checking core dumps configuration:
 KRNL-5830:test:security:kernel:Linux:Checking if system is running on the latest installed kernel:
 KRNL-5831:test:security:kernel:DragonFly:Checking DragonFly loaded kernel modules:
 KRNL-6000:test:security:kernel_hardening::Check sysctl key pairs in scan profile:
+KRNL-6001:test:security:kernel_hardening::Check SysV shared memory configuration:
 LDAP-2219:test:security:ldap::Check running OpenLDAP instance:
 LDAP-2224:test:security:ldap::Check presence slapd.conf:
 LOGG-2130:test:security:logging::Check for running syslog daemon:

--- a/include/binaries
+++ b/include/binaries
@@ -177,6 +177,7 @@
                             g++)                    GPLUSPLUSBINARY="${BINARY}";       COMPILER_INSTALLED=1;  LogText "  Found known binary: g++ (compiler) - ${BINARY}" ;;
                             gcc)                    GCCBINARY="${BINARY}";             COMPILER_INSTALLED=1;  LogText "  Found known binary: gcc (compiler) - ${BINARY}" ;;
                             getcap)                 GETCAPBINARY="${BINARY}";          LogText "  Found known binary: getcap (kernel capabilities) - ${BINARY}" ;;
+                            getconf)                GETCONFBINARY="${BINARY}";         LogText "  Found known binary: getconf (query system configuration) - ${BINARY}" ;;
                             getent)                 GETENT_BINARY="${BINARY}";         LogText "  Found known binary: getent (query tool for name service switch libraries) - ${BINARY}" ;;
                             gradm)                  GRADMBINARY=${BINARY};             LogText "  Found known binary: gradm (Grsecurity Administration Utility) - ${BINARY}" ;;
                             grep)                   GREPBINARY=${BINARY};              LogText "  Found known binary: grep (text search) - ${BINARY}" ;;

--- a/include/tests_kernel_hardening
+++ b/include/tests_kernel_hardening
@@ -112,6 +112,44 @@
 #
 #################################################################################
 #
+    # Test        : KRNL-6001
+    # Description : Check SysV shared memory configuration
+    if [ ! "${SYSCTLBINARY}" = "" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no KRNL-6001 --preqs-met ${PREQS_MET} --os Linux --weight L --network NO --category security --description "Check SysV shared memory configuration"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        FOUND=0
+        # Sysctl option
+        LogText "Test: Read system RAM size"
+        # value is in kB
+        RAM_SIZE=$(${AWKBINARY} '/MemTotal/ { print $2 * 1024 }' /proc/meminfo)
+        LogText "Test: RAM size ${RAM_SIZE} bytes"
+        LogText "Test: Read OS page size"
+        if [ -n "${GETCONFBINARY}" ]; then
+            PAGE_SIZE=$(${GETCONFBINARY} PAGE_SIZE)
+            LogText "Test: Page size is ${PAGE_SIZE}"
+        else
+            PAGE_SIZE=4096
+            LogText "Test: Assuming typical OS page size of 4096"
+        fi
+        LogText "Test: Checking sysctl value of kernel.shmall"
+        # value is in pages (typically 4k)
+        FIND=$(${SYSCTLBINARY} kernel.shmall 2> /dev/null | ${AWKBINARY} -v PAGE_SIZE=${PAGE_SIZE} '{ if ($1=="kernel.shmall") { print $3 * PAGE_SIZE } }')
+        if [ -z "${FIND}" ]; then
+            LogText "Result: sysctl key kernel.shmall not found"
+        else
+            LogText "Result: shared memory limited to ${FIND} bytes"
+            if [ "${FIND}" -lt ${RAM_SIZE} ]; then
+                LogText "Result: programs can't allocate more SysV shared memory than there is RAM"
+                Display --indent 4 --text "- Checking SysV shared memory configuration" --result "${STATUS_OK}" --color GREEN
+            else
+                LogText "Result: programs can allocate more SysV shared memory than there is RAM"
+                Display --indent 4 --text "- Checking SysV shared memory configuration" --result "${STATUS_WARNING}" --color YELLOW
+            fi
+        fi
+    fi
+#
+#################################################################################
+#
 
 WaitForKeyPress
 


### PR DESCRIPTION
Check that Linux sysctl kernel.shmall is less than RAM size to prevent
out of memory situations.

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>