### PR TITLE
[KRNL-6000] Check more sysctls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Using the relevant options, the scan will change base on the intended goal.
 - KRNL-5820 - extended check to include limits.d directory
 - KRNL-5830 - skip test partially when running non-privileged
 - KRNL-5830 - detect required reboots on Raspbian
+- KRNL-6000 - check more sysctls
 - LOGG-2154 - added support for rsyslog configurations
 - LOGG-2190 - skip mysqld related entries
 - MACF-6234 - SELinux tests extended

--- a/default.prf
+++ b/default.prf
@@ -182,7 +182,9 @@ config-data=sysctl;security.bsd.unprivileged_read_msgbuf;0;1;Unprivileged proces
 
 # Kernel
 config-data=sysctl;fs.suid_dumpable;0;1;Restrict core dumps;sysctl -a;url:https;//www.kernel.org/doc/Documentation/sysctl/fs.txt;category:security;
+config-data=sysctl;fs.protected_fifos;2;1;Restrict FIFO special device creation behavior;sysctl -a;url:https;//www.kernel.org/doc/Documentation/sysctl/fs.txt;category:security;
 config-data=sysctl;fs.protected_hardlinks;1;1;Restrict hardlink creation behavior;sysctl -a;url:https;//www.kernel.org/doc/Documentation/sysctl/fs.txt;category:security;
+config-data=sysctl;fs.protected_regular;2;1;Restrict regular files creation behavior;sysctl -a;url:https;//www.kernel.org/doc/Documentation/sysctl/fs.txt;category:security;
 config-data=sysctl;fs.protected_symlinks;1;1;Restrict symlink following behavior;sysctl -a;url:https;//www.kernel.org/doc/Documentation/sysctl/fs.txt;category:security;
 #config-data=sysctl;kern.randompid=2345;Randomize PID numbers with a specific modulus;sysctl -a;-;category:security;
 config-data=sysctl;kern.sugid_coredump;0;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
@@ -194,13 +196,17 @@ config-data=sysctl;kernel.exec-shield-randomize;1;1;No description;sysctl -a;url
 config-data=sysctl;kernel.exec-shield;1;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.kptr_restrict;2;1;Restrict access to kernel symbols;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.maps_protect;1;1;Restrict access to /proc/[pid]/maps;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
+config-data=sysctl;kernel.modules_disabled;1;1;Restrict module loading once this sysctl value is loaded;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
+config-data=sysctl;kernel.perf_event_paranoid;3;1;Restrict unprivileged access to the perf_event_open() system call.;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.randomize_va_space;2;1;Randomize of memory address locations (ASLR);sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.suid_dumpable;0;1;Restrict core dumps;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.sysrq;0;1;Disable magic SysRQ;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
+config-data=sysctl;kernel.unprivileged_bpf_disabled;1;1;Restrict BPF for unprivileged users;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.use-nx;0;1;No description;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;kernel.yama.ptrace_scope;1|2|3;1;Disable process tracing for everyone;-;category:security;
 
 # Network
+config-data=sysctl;net.core.bpf_jit_harden;2;1;Hardened BPF JIT compilation;sysctl -a;url:https;//kernel.org/doc/Documentation/sysctl/kernel.txt;category:security;
 config-data=sysctl;net.inet.ip.linklocal.in.allowbadttl;0;
 config-data=sysctl;net.inet.tcp.always_keepalive;0;1;Disable TCP keep alive detection for dead peers as the keepalive can be spoofed;-;category:security;
 #config-data=sysctl;net.inet.tcp.fast_finwait2_recycle;1;1;Recycle FIN/WAIT states more quickly (DoS mitigation step, with risk of false RST);-;category:security;
@@ -250,6 +256,7 @@ config-data=sysctl;net.ipv6.conf.default.accept_redirects;0;1;Disable/Ignore ICM
 config-data=sysctl;net.ipv6.conf.default.accept_source_route;0;1;Disable IP source routing;-;category:security;
 
 # Other
+config-data=sysctl;dev.tty.ldisc_autoload;0;1;Disable loading of TTY line disciplines;-;category:security;
 config-data=sysctl;hw.kbd.keymap_restrict_change;4;1;Disable changing the keymap by non-privileged users;-;category:security;
 #sysctl;kern.securelevel;1^2^3;1;FreeBSD security level;
 #security.jail.jailed; 0


### PR DESCRIPTION
Add checks for sysctls recommended by CLIP OS (vanilla kernel sysctls
only):
https://docs.clip-os.org/clipos/kernel.html#sysctl-security-tuning

Signed-off-by: Topi Miettinen <toiwoton@gmail.com>