### PR TITLE
Adds uppercase option to the hostname validation regex

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -70,7 +70,7 @@
                 LogText "Result: hostnamed is defined and not longer than 63 characters"
             fi
             # Test valid characters (normally a dot should not be in the name, but we can't be 100% sure we have short name)
-            FIND=$(echo "${HOSTNAME}" | ${TRBINARY} -d '[a-z0-9\.\-]')
+            FIND=$(echo "${HOSTNAME}" | ${TRBINARY} -d '[a-zA-Z0-9\.\-]')
             if [ -z "${FIND}" ]; then
                 LogText "Result: good, no unexpected characters discovered in hostname"
                 if IsVerbose; then Display --indent 2 --text "- Hostname (allowed characters)" --result "${STATUS_OK}" --color GREEN; fi


### PR DESCRIPTION
This PR updates the hostname test in `NETW-2400` to allow uppercase characters in the validation regex.

# How I tested
* Created a virtual machine (vagrant & virtualbox)
* Set the VM's hostname to include uppercase characters: `sudo hostname ASDF`
* Cloned repo, entered the `lynis` directory, and checked out the `master` branch
* Ran `lynis`: `./lynis audit sytem`
* Parsed the output for `Hostname contains invalid characters [NETW-2400]`
* Checked `/var/log/lynis.log` for error log:
```
2020-06-02 14:53:32 Result: unexpected characters discovered in hostname (characters: ASDF), which may impact network connectivity
```
---
* Checked out the bugfix branch
* Ran `lynis`: `./lynis audit sytem`
* Noted the warnings count has reduced by 1 and NETW-2400 is not reported as an issue

# References
* https://github.com/CISOfy/lynis/commit/032bb6988e7b94415cbe202dd26177e94803859f#r39605790 (initial discussion)
* https://tools.ietf.org/html/rfc1123#page-13
* https://tools.ietf.org/html/rfc952#page-1 (Assumptions)

# Notes
If this PR is accepted, I'm happy to be included in the CONTRIBUTOR file thus: Iain Cuthbertson iain.cuthbertson@siftware.com