### PR TITLE
add RHEL 6,7,8 EOL dates

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -103,6 +103,12 @@ os:NetBSD 9.0::-1:
 os:OpenBSD 5.8:2016-09-01:0:
 os:OpenBSD 5.9:2017-04-11:0:
 #
+# Red Hat Enterprise Linux - https://access.redhat.com/labs/plcc/
+#
+os:Red Hat Enterprise Linux Server release 6:2020-11-30:1606690800:
+os:Red Hat Enterprise Linux 7:2024-06-30:1719698400:
+os:Red Hat Enterprise Linux 8:2029-05-07:1872799200:
+#
 # Ubuntu - https://wiki.ubuntu.com/Kernel/LTSEnablementStack
 #
 os:Ubuntu 14.04:2019-05-01:1556661600:


### PR DESCRIPTION
Adds the general EOL dates (End of Maintenance Support or Maintenance Support 2) for Red Hat Enterprise Linux releases 6.x, 7.x and 8.x to the EOL database.

Note that there are more detailed EUS dates for the .x releases. I'm working on those for a future PR.