### PR TITLE
rsh host file permissions

### DIFF
--- a/default.prf
+++ b/default.prf
@@ -303,6 +303,9 @@ permfile=/etc/motd:rw-r--r--:root:root:WARN:
 permfile=/etc/passwd:rw-r--r--:root:-:WARN:
 permfile=/etc/passwd-:rw-r--r--:root:-:WARN:
 permfile=/etc/ssh/sshd_config:rw-------:root:-:WARN:
+permfile=/etc/hosts.equiv:rw-r--r--:root:root:WARN:
+permfile=/root/.rhosts:rw-------:root:root:WARN:
+permfile=/root/.rlogin:rw-------:root:root:WARN:
 
 # These permissions differ by OS
 #permfile=/etc/gshadow:---------:root:-:WARN:

--- a/default.prf
+++ b/default.prf
@@ -304,8 +304,10 @@ permfile=/etc/passwd:rw-r--r--:root:-:WARN:
 permfile=/etc/passwd-:rw-r--r--:root:-:WARN:
 permfile=/etc/ssh/sshd_config:rw-------:root:-:WARN:
 permfile=/etc/hosts.equiv:rw-r--r--:root:root:WARN:
+permfile=/etc/shosts.equiv:rw-r--r--:root:root:WARN:
 permfile=/root/.rhosts:rw-------:root:root:WARN:
 permfile=/root/.rlogin:rw-------:root:root:WARN:
+permfile=/root/.shosts:rw-------:root:root:WARN:
 
 # These permissions differ by OS
 #permfile=/etc/gshadow:---------:root:-:WARN:


### PR DESCRIPTION
The old rsh (remote shell) authorizes users and hosts in the files `/etc/hosts.equiv`, `.rlogin`and `.rhosts`. If attackers can write to those files, he can logon as a different to the system. While the rsh daemon usually checks for non-root owners or write permission, this may not be the case on any system.

Those files are also used by SSH if host based authentication is enabled. In addition to the files used by rsh, `.shosts` and `shosts.equiv` are used.

While the use of rsh is highly discouraged, it may still be in running on legacy systems. As those files are also used by OpenSSH, they are even relevant today.

This PR adds those files to the list of checked files.