### PR TITLE
fix stderr output from cryptsetup status

### DIFF
--- a/include/tests_crypto
+++ b/include/tests_crypto
@@ -186,7 +186,7 @@
             if ${CRYPTSETUPBINARY} isLuks "${BLOCK_DEV}" 2> /dev/null; then
                 LogText "Result: Found LUKS encrypted swap device: ${BLOCK_DEV}"
                 ENCRYPTED_SWAPS=$((ENCRYPTED_SWAPS +1))
-            elif ${CRYPTSETUPBINARY} status "${BLOCK_DEV}" | ${GREPBINARY} --quiet "cipher:"; then
+            elif ${CRYPTSETUPBINARY} status "${BLOCK_DEV}" 2> /dev/null | ${GREPBINARY} --quiet "cipher:"; then
                 LogText "Result: Found non-LUKS encrypted swap device: ${BLOCK_DEV}"
                 ENCRYPTED_SWAPS=$((ENCRYPTED_SWAPS +1))
             else


### PR DESCRIPTION
Redirected stderr to /dev/null to silence output of `cryptsetup status /swap.img`
This was causing error output from my cron script.
Otherwise, if the swap file is not encrypted then the following error will be printed:
`Device swap.img not found`