### PR TITLE
Add macOS Big Sur (11.0)

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -62,6 +62,7 @@
                     10.13 | 10.13.[0-9]*) OS_FULLNAME="macOS High Sierra (${OS_VERSION})" ;;
                     10.14 | 10.14.[0-9]*) OS_FULLNAME="macOS Mojave (${OS_VERSION})" ;;
                     10.15 | 10.15.[0-9]*) OS_FULLNAME="macOS Catalina (${OS_VERSION})" ;;
+                    11.0 | 11.0[0-9]*) OS_FULLNAME="macOS Big Sur (${OS_VERSION})" ;;
                     *) echo "Unknown macOS version. Do you know what version it is? Create an issue at ${PROGRAM_SOURCE}" ;;
                 esac
             else


### PR DESCRIPTION
Added the new [macOS Big Sur (11.0)](https://www.apple.com/newsroom/2020/06/apple-introduces-macos-big-sur-with-a-beautiful-new-design/) to osdetection. 