### PR TITLE
add SUSE Linux Enterprise Server EOL

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -151,6 +151,11 @@ os:Slackware Linux 13.0:2018-07-05:1530738000:
 os:Slackware Linux 13.1:2018-07-05:1530738000:
 os:Slackware Linux 13.37:2018-07-05:1530738000:
 #
+# SuSE - https://www.suse.com/lifecycle/
+#
+os:SUSE Linux Enterprise Server 12:2024-10-31:1730329200:
+os:SUSE Linux Enterprise Server 15:2028-07-31:1848607200:
+#
 # Ubuntu - https://wiki.ubuntu.com/Kernel/LTSEnablementStack and
 #          https://wiki.ubuntu.com/Releases
 #


### PR DESCRIPTION
Add EOL support for SUSE Linux Enterprise Server 12 and SUSE Linux Enterprise Server 15.

I believe this closes #965

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>