### PR TITLE
Fix for Issues #964 - Pop!_OS added to osdetection

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -217,6 +217,12 @@
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="openSUSE"
                         ;;
+                        "pop")
+                            LINUX_VERSION="Pop!_OS"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_NAME="Pop!_OS"
+                        ;;
                         "pureos")
                             LINUX_VERSION="PureOS"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')


### PR DESCRIPTION
Fix for https://github.com/CISOfy/lynis/issues/964 - POP OS added to include/osdetection