### PR TITLE
[FILE-6430] Don't grep nonexistant modprobe.d files

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -830,12 +830,15 @@
                     AddHP 3 3
                     if IsDebug; then Display --indent 6 --text "- Module ${FS} not present in the kernel" --result OK --color GREEN; fi
                 fi
-                FIND1=$(${EGREPBINARY} "blacklist ${FS}" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
-                FIND2=$(${EGREPBINARY} "install ${FS} /bin/true" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
-                if [ -n "${FIND1}" ] || [ -n "${FIND2}" ]; then
-                    Display --indent 4 --text "- Module $FS is blacklisted" --result "OK" --color GREEN
-                    LogText "Result: module ${FS} is blacklisted"
-                fi
+                FIND=$(${LSBINARY} ${ROOTDIR}etc/modprobe.d/* 2> /dev/null)
+                if [ -n "${FIND}" ]; then
+		                FIND1=$(${EGREPBINARY} "blacklist ${FS}" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
+		                FIND2=$(${EGREPBINARY} "install ${FS} /bin/true" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
+                    if [ -n "${FIND1}" ] || [ -n "${FIND2}" ]; then
+                        Display --indent 4 --text "- Module $FS is blacklisted" --result "OK" --color GREEN
+                        LogText "Result: module ${FS} is blacklisted"
+                    fi
+		            fi
             done
             if [ ${FOUND} -eq 1 ]; then
                 Display --indent 4 --text "- Discovered kernel modules: ${AVAILABLE_MODPROBE_FS}"


### PR DESCRIPTION
I think we don't want to grep files in modprobe.d when dir is empty. Uses same approach as in USB-1000.