### PR TITLE
Support absolute paths in nginx includes and fix ls warning on empty directories

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2305,7 +2305,8 @@
                     # Check for additional config files included as follows
                     # "include sites-enabled/*.conf"
                     elif [ $(echo ${VALUE} | grep -F -c "*.conf") -gt 0 ]; then
-                        for FOUND_CONF in $(ls ${CONFIG_FILE%nginx.conf}${VALUE%;*}); do
+                        if [ "$(echo ${VALUE} | ${CUTBINARY} -c1)" != "/" ]; then VALUE=${CONFIG_FILE%nginx.conf}; fi
+                        for FOUND_CONF in $(ls ${VALUE%;*}); do
                             FOUND=0
                             for CONF in ${NGINX_CONF_FILES}; do
                                 if [ "${CONF}" = "${FOUND_CONF}" ]; then FOUND=1; LogText "Found this file already in our configuration files array, not adding to queue"; fi

--- a/include/functions
+++ b/include/functions
@@ -2306,7 +2306,7 @@
                     # "include sites-enabled/*.conf"
                     elif [ $(echo ${VALUE} | grep -F -c "*.conf") -gt 0 ]; then
                         if [ "$(echo ${VALUE} | ${CUTBINARY} -c1)" != "/" ]; then VALUE=${CONFIG_FILE%nginx.conf}; fi
-                        for FOUND_CONF in $(ls ${VALUE%;*}); do
+                        for FOUND_CONF in $(ls ${VALUE%;*} 2> /dev/null); do
                             FOUND=0
                             for CONF in ${NGINX_CONF_FILES}; do
                                 if [ "${CONF}" = "${FOUND_CONF}" ]; then FOUND=1; LogText "Found this file already in our configuration files array, not adding to queue"; fi


### PR DESCRIPTION
Includes can be absolute paths too. This is quick fix counting on fact that absolute paths have slash at start.

Second commit is similar to my previous PR, IMHO Lynis should not output ls errors on empty included directories.