### PR TITLE
Fix timesyncd detection on systems without dbus.

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -419,6 +419,7 @@ TIME-3170:test:security:time::Check configuration files:
 TIME-3180:test:security:time::Report if ntpctl cannot communicate with OpenNTPD:
 TIME-3181:test:security:time::Check status of OpenNTPD time synchronisation
 TIME-3182:test:security:time::Check OpenNTPD has working peers
+TIME-3185:test:security:time::Check systemd-timesyncd synchronized time
 TOOL-5002:test:security:tooling::Checking for automation tools:
 TOOL-5102:test:security:tooling::Check for presence of Fail2ban:
 TOOL-5104:test:security:tooling::Enabled tests for Fail2ban:

--- a/include/tests_time
+++ b/include/tests_time
@@ -585,11 +585,12 @@
 
 
     Register --test-no TIME-3185 --preqs-met "${PREQS_MET}" --weight L --network NO --category "security" --description "Check systemd-timesyncd synchronized time"
+    SYNCHRONIZED_FILE="/run/systemd/timesync/synchronized"
     if [ ${SKIPTEST} -eq 0 ]; then
-        if [ -e /run/systemd/timesync/synchronized ]; then
-           FIND=$(( $(date +%s) - $(stat -L --format %Y /run/systemd/timesync/synchronized) ))
+        if [ -e "${SYNCHRONIZED_FILE}" ]; then
+           FIND=$(( $(date +%s) - $(${STATBINARY} -L --format %Y "${SYNCHRONIZED_FILE}") ))
            # Check if last sync was more than 2048 seconds (= the default of systemd) ago
-           if [ ${FIND} -ge 2048 ]; then
+           if [ "${FIND}" -ge 2048 ]; then
                COLOR=RED
                ReportWarning "${TEST_NO}" "systemd-timesyncd did not synchronized the time recently."
            else
@@ -602,7 +603,7 @@
            ReportWarning "${TEST_NO}" "systemd-timesyncd never successfully synchronized time"
         fi
     fi
-
+    unset SYNCHRONIZED_FILE
 
 #
 #################################################################################

--- a/include/tests_time
+++ b/include/tests_time
@@ -124,23 +124,11 @@
         fi
 
         # Check timedate daemon (systemd)
-        if [ -n "${TIMEDATECTL}" ]; then
-            FIND=$(${TIMEDATECTL} status | ${EGREPBINARY} "(NTP|System clock) synchronized: yes")
-            if [ -n "${FIND}" ]; then
-                # Check for systemd-timesyncd
-                if [ -f ${ROOTDIR}etc/systemd/timesyncd.conf ]; then
-                    LogText "Result: found ${ROOTDIR}etc/systemd/timesyncd.conf"
-                    FOUND=1; NTP_DAEMON_RUNNING=1; NTP_CONFIG_TYPE_DAEMON=1; NTP_DAEMON="systemd-timesyncd"
-                    Display --indent 2 --text "- NTP daemon found: systemd (timesyncd)" --result "${STATUS_FOUND}" --color GREEN
-                    SYSTEMD_NTP_ENABLED=1
-                else
-                    LogText "Result: ${ROOTDIR}etc/systemd/timesyncd.conf does not exist"
-                fi
-            else
-                LogText "Result: time synchronization not performed according timedatectl command"
-            fi
-        else
-            LogText "Result: timedatectl command not available on this system"
+        FIND=$(${PSBINARY} ax | ${GREPBINARY} "systemd-timesyncd" | ${GREPBINARY} -v "grep")
+        if [  -n "${FIND}" ]; then
+            FOUND=1; NTP_DAEMON_RUNNING=1; NTP_CONFIG_TYPE_DAEMON=1; NTP_DAEMON="systemd-timesyncd"
+            Display --indent 2 --text "- NTP daemon found: systemd (timesyncd)" --result "${STATUS_FOUND}" --color GREEN
+            LogText "Result: Found running systemd-timesyncd in process list"
         fi
 
         # Check crontab for OpenBSD/FreeBSD
@@ -581,6 +569,41 @@
             ReportWarning "${TEST_NO}" "OpenNTPD has no peers" "${NTPCTLBINARY} -s status"
         fi
     fi
+
+#
+#################################################################################
+#
+
+    # Test        : TIME-3185
+    # Description : Check systemd-timesyncd synchronized time
+
+    if [ "${NTP_DAEMON}" = "systemd-timesyncd" ]; then
+        PREQS_MET="YES"
+    else
+        PREQS_MET="NO"
+    fi
+
+
+    Register --test-no TIME-3185 --preqs-met "${PREQS_MET}" --weight L --network NO --category "time" --description "Check systemd-timesyncd synchronized time"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        if [ -e /run/systemd/timesync/synchronized ]; then
+           FIND=$(( $(date +%s) - $(stat -L --format %Y /run/systemd/timesync/synchronized) ))
+           # Check if last sync was more than 2048 seconds (= the default of systemd) ago
+           if [ ${FIND} -ge 2048 ]; then
+               COLOR=RED
+               ReportWarning "${TEST_NO}" "systemd-timesyncd did not synchronized the time recently."
+           else
+               COLOR=GREEN
+           fi
+           Display --indent 2 --text "- Last time synchronization" --result "${FIND}s" --color "${COLOR}"
+           LogText "Result: systemd-timesyncd synchronized time ${FIND} seconds ago."
+        else
+           Display --indent 2 --text "- Last time synchronization" --result "${STATUS_NOT_FOUND}" --color RED
+           ReportWarning "${TEST_NO}" "systemd-timesyncd never successfully synchronized time"
+        fi
+    fi
+
+
 #
 #################################################################################
 #

--- a/include/tests_time
+++ b/include/tests_time
@@ -584,7 +584,7 @@
     fi
 
 
-    Register --test-no TIME-3185 --preqs-met "${PREQS_MET}" --weight L --network NO --category "time" --description "Check systemd-timesyncd synchronized time"
+    Register --test-no TIME-3185 --preqs-met "${PREQS_MET}" --weight L --network NO --category "security" --description "Check systemd-timesyncd synchronized time"
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ -e /run/systemd/timesync/synchronized ]; then
            FIND=$(( $(date +%s) - $(stat -L --format %Y /run/systemd/timesync/synchronized) ))


### PR DESCRIPTION
Detect timesyncd by looking in the process list instead of timedatectl. The check if time was successfully synchronized is in the new test `TIME-3185`.

Closes #953.