### PR TITLE
[TIME-3180, TIME-3181, TIME-3182] Fix OpenNTPD tests

### DIFF
--- a/include/tests_time
+++ b/include/tests_time
@@ -100,7 +100,7 @@
                 LogText "result: running openntpd not found, but ntpctl is instaalled"
             fi
 
-            if [ "${NTP_DAEMON}" == "openntpd" ]; then
+            if [ "${NTP_DAEMON}" = "openntpd" ]; then
                 Display --indent 2 --text "- NTP daemon found: OpenNTPD" --result "${STATUS_FOUND}" --color GREEN
             fi
         fi

--- a/include/tests_time
+++ b/include/tests_time
@@ -86,9 +86,8 @@
             # Reason: openntpd syncs only if large time corrections are not required or -s is passed.
             #         This might be not intended by the administrator (-s is NOT the default!)
             FIND=$(${PSBINARY} ax | ${GREPBINARY} "ntpd: ntp engine" | ${GREPBINARY} -v "grep")
-            ${NTPCTLBINARY} -s status > /dev/null 2> /dev/null
             # Status code 0 is when communication over the socket is successfull
-            if [ "$?" -eq 0 ]; then
+            if ${NTPCTLBINARY} -s status > /dev/null 2> /dev/null; then
                 FOUND=1; NTP_DAEMON_RUNNING=1; NTP_CONFIG_TYPE_DAEMON=1; NTP_DAEMON="openntpd"
                 LogText "result: found openntpd (method: ntpctl)"
                 OPENNTPD_COMMUNICATION=1

--- a/include/tests_time
+++ b/include/tests_time
@@ -532,7 +532,7 @@
 #
     # Test        : TIME-3180
     # Description : Report if ntpctl cannot communicate with OpenNTPD
-    if [ "${NTPD_RUNNING}" -eq 1 ] && [ -n "${NTPCTLBINARY}" ] && [ "${NTP_DAEMON}" == "openntpd" ]; then
+    if [ "${NTP_DAEMON_RUNNING}" -eq 1 ] && [ -n "${NTPCTLBINARY}" ] && [ "${NTP_DAEMON}" = "openntpd" ]; then
         PREQS_MET="YES"
     else
         PREQS_MET="NO"
@@ -548,7 +548,7 @@
 #
     # Test        : TIME-3181
     # Description : Check status of OpenNTPD time synchronisation
-    if [ "${NTPD_RUNNING}" -eq 1 ] && [ -n "${NTPCTLBINARY}" ] && [ "${NTP_DAEMON}" == "openntpd" ] && [ "${OPENNTPD_COMMUNICATION}" -eq 1 ]; then
+    if [ "${NTP_DAEMON_RUNNING}" -eq 1 ] && [ -n "${NTPCTLBINARY}" ] && [ "${NTP_DAEMON}" = "openntpd" ] && [ "${OPENNTPD_COMMUNICATION}" -eq 1 ]; then
         PREQS_MET="YES"
     else
         PREQS_MET="NO"
@@ -567,7 +567,7 @@
     # Test        : TIME-3182
     # Description : Check OpenNTPD has working peers
 
-    if [ "${NTPD_RUNNING}" -eq 1 ] && [ -n "${NTPCTLBINARY}" ] && [ "${NTP_DAEMON}" == "openntpd" ] && [ "${OPENNTPD_COMMUNICATION}" -eq 1 ]; then
+    if [ "${NTP_DAEMON_RUNNING}" -eq 1 ] && [ -n "${NTPCTLBINARY}" ] && [ "${NTP_DAEMON}" = "openntpd" ] && [ "${OPENNTPD_COMMUNICATION}" -eq 1 ]; then
         PREQS_MET="YES"
     else
         PREQS_MET="NO"

--- a/include/tests_time
+++ b/include/tests_time
@@ -576,8 +576,8 @@
     Register --test-no TIME-3182 --preqs-met "${PREQS_MET}" --weight L --network NO --category security --description "Check OpenNTPD has working peers"
     if [ ${SKIPTEST} -eq 0 ]; then
         # Format is "xx/yy peers valid, ..."
-        FIND=$(${NTPCTLBINARY} -s status | ${EGREPBINARY} -o "[0-9]{1,4}/" | ${EGREPBINARY} -o "[0-9]{1,4}" )
-        if [ -n "${FIND}" ] || [ "${FIND}" -eq 0 ]; then
+        FIND=$(${NTPCTLBINARY} -s status | ${EGREPBINARY} -o '[0-9]+/[0-9]+' | ${CUTBINARY} -d '/' -f 1)
+        if [ -z "${FIND}" ] || [ "${FIND}" -eq 0 ]; then
             ReportWarning "${TEST_NO}" "OpenNTPD has no peers" "${NTPCTLBINARY} -s status"
         fi
     fi


### PR DESCRIPTION
In #824 I made a few mistakes:

 - All tests:
   - To test if the test should run, I checked against `NTPD_RUNNING` instead of `NTP_DAEMON_RUNNING`.
   - Additionally, I used `==` instead of  `=` when testing if the daemon is openntpd. While this works on some systems, this is non standard and does not work at all on BSDs (where OpenNTPD is usually installed).
 - TIME-3182:
   - The regex for the peers was wrong (never matched anything) and instead of checking for an empty string (`-z`) it was checked for non empty (`-n`).

Thus the previous implementations were completely broken (TIME-3180, TIME-3181, TIME-3182). With this pull request I fix my own errors.