### PR TITLE
[TIME-3104] Find more time synchronization commands

### DIFF
--- a/include/tests_time
+++ b/include/tests_time
@@ -146,17 +146,20 @@
         # Check crontab for OpenBSD/FreeBSD
         # Check anacrontab for Linux
         CRONTAB_FILES="/etc/anacrontab /etc/crontab"
+        # Regex for matching multiple time synchronisation binaries
+        # Partial sanity check for sntp and ntpdig, but this does not consider all corner cases
+        CRONTAB_REGEX='ntpdate|rdate|sntp.+-(s|j|--adj)|ntpdig.+-(S|s)'
         for I in ${CRONTAB_FILES}; do
             if [ -f ${I} ]; then
-                LogText "Test: checking for ntpdate or rdate in crontab file ${I}"
-                FIND=$(${EGREPBINARY} "ntpdate|rdate" ${I} | ${GREPBINARY} -v '^#')
+                LogText "Test: checking for ntpdate, rdate, sntp or ntpdig in crontab file ${I}"
+                FIND=$(${EGREPBINARY} "${CRONTAB_REGEX}" ${I} | ${GREPBINARY} -v '^#')
                 if [ -n "${FIND}" ]; then
                     FOUND=1; NTP_CONFIG_TYPE_SCHEDULED=1
                     Display --indent 2 --text "- Checking NTP client in crontab file (${I})" --result "${STATUS_FOUND}" --color GREEN
-                    LogText "Result: found ntpdate or rdate reference in crontab file ${I}"
+                    LogText "Result: found ntpdate, rdate, sntp or ntpdig reference in crontab file ${I}"
                 else
                     #Display --indent 2 --text "- Checking NTP client in crontab file (${I})" --result "${STATUS_NOT_FOUND}" --color WHITE
-                    LogText "Result: no ntpdate or rdate reference found in crontab file ${I}"
+                    LogText "Result: no ntpdate, rdate, sntp or ntpdig reference found in crontab file ${I}"
                 fi
             else
                 LogText "Result: crontab file ${I} not found"
@@ -169,31 +172,18 @@
 
         # Check cron jobs
         for I in ${CRON_DIRS}; do
-            if [ -d ${I} ]; then
-                if FileIsReadable ${I}; then
-                    FIND=$(${FINDBINARY} ${I} -type f -a ! -name ".placeholder" -print 2> /dev/null | ${SEDBINARY} 's/ /__space__/g' | ${TRBINARY} '\n' '\0' | ${TRBINARY} -cd '[:print:]\0' | ${TRBINARY} '\0' ' ')
+            for J in "${I}"/*; do  # iterate over folders in a safe way
+                # Check: regular file, readable and not called .placeholder
+                FIND=$(echo "${J}" | ${EGREPBINARY} '/.placeholder$')
+                if [ -f "${J}" ] && [ -r "${J}" ] && [ -z "${FIND}" ]; then
+                    LogText "Test: checking for ntpdate, rdate, sntp or ntpdig in ${J}"
+                    FIND=$("${EGREPBINARY}" "${CRONTAB_REGEX}" "${J}" | "${GREPBINARY}" -v "^#")
                     if [ -n "${FIND}" ]; then
-                        for J in ${FIND}; do
-                            # Place back spaces if needed
-                            J=$(echo ${J} | ${SEDBINARY} 's/__space__/ /g')
-                            LogText "Test: checking for ntpdate or rdate in ${J}"
-                            if FileIsReadable ${J}; then
-                                FIND2=$(${EGREPBINARY} "rdate|ntpdate" "${J}" | ${GREPBINARY} -v "^#")
-                                if [ -n "${FIND2}" ]; then
-                                    LogText "Positive match found: ${FIND2}"
-                                    FOUND=1; FOUND_IN_CRON=1; NTP_CONFIG_TYPE_SCHEDULED=1
-                                fi
-                            else
-                                LogText "Result: could not test in file '${J}' as it is not readable"
-                            fi
-                        done
-                    else
-                        LogText "Result: ${I} is empty, skipping search in directory"
+                        FOUND=1; FOUND_IN_CRON=1; NTP_CONFIG_TYPE_SCHEDULED=1
+                        LogText "Result: found ntpdate, rdate, sntp or ntpdig in ${J}"
                     fi
-                else
-                    LogText "Result: could not search in directory due to permissions"
                 fi
-            fi
+            done
         done
 
         if [ ${FOUND_IN_CRON} -eq 1 ]; then


### PR DESCRIPTION
This pull request detects the use of `sntp` and `ntpdig`.

As I worked at the same area of code discussed in #826, I fixed it as well.