### PR TITLE
Do not suggest upgrading if no update is available

### DIFF
--- a/lynis
+++ b/lynis
@@ -777,7 +777,7 @@ ${NORMAL}
     RELEASE_PLUS_TIMEDIFF=$((PROGRAM_RELEASE_TIMESTAMP + TIME_DIFFERENCE_CHECK))
     if [ ${NOW} -gt ${RELEASE_PLUS_TIMEDIFF} ]; then
         # Show if release is old, only if we didn't show it with normal update check
-        if [ ${UPDATE_AVAILABLE} -eq 0 ]; then
+        if [ ${UPDATE_AVAILABLE} -eq 1 ]; then
             ReportSuggestion "LYNIS" "This release is more than 4 months old. Consider upgrading"
         fi
         OLD_RELEASE=1


### PR DESCRIPTION
Lynis 3.0.0 reports the following:
```
  * This release is more than 4 months old. Consider upgrading [LYNIS] 
      https://cisofy.com/lynis/controls/LYNIS/
```

yet lynis.log indicates that no update is available:
```
2020-07-24 10:09:21 Test: Checking for program update...
2020-07-24 10:09:21 Current installed version  : 300
2020-07-24 10:09:21 Latest stable version      : 300
2020-07-24 10:09:21 No Lynis update available.
2020-07-24 10:09:21 Suggestion: This release is more than 4 months old. Consider upgrading [test:LYNIS] [details:-] [solution:-]
```

This pull request omits the suggestion if no update is available.

Related to https://github.com/CISOfy/lynis/issues/892