### PR TITLE
Adding Alpine Linux to OSDetection

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -144,6 +144,12 @@
                 OS_ID=$(grep "^ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                 if [ -n "${OS_ID}" ]; then
                     case ${OS_ID} in
+                        "alpine")
+                            LINUX_VERSION="Alpine Linux"
+                            OS_NAME=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "amzn")
                             LINUX_VERSION="Amazon Linux"
                             OS_NAME="Amazon Linux"
@@ -267,6 +273,9 @@
                     esac
                 fi
             fi
+
+            # Alpine
+            if [ -e "/etc/alpine-release" ]; then LINUX_VERSION="Alpine Linux"; OS_VERSION=$(cat /etc/alpine-release); fi
 
             # Amazon
             if [ -z "${LINUX_VERSION}" -a -e "/etc/system-release" ]; then


### PR DESCRIPTION
Added the [Alpine Linux](https://alpinelinux.org/) to osdetection.