### PR TITLE
Test for LINUX_VERSION before setting it again

### DIFF
--- a/include/consts
+++ b/include/consts
@@ -140,6 +140,7 @@ ETC_PATHS="/etc /usr/local/etc"
     LICENSE_KEY=""
     LICENSE_SERVER=""
     LINUX_VERSION=""
+    LINUX_VERSION_LIKE=""
     LINUXCONFIGFILE=""
     LMDBINARY=""
     LMDFOUND=0

--- a/include/osdetection
+++ b/include/osdetection
@@ -197,11 +197,13 @@
                         ;;
                         "kali")
                             LINUX_VERSION="Kali"
+                            LINUX_VERSION_LIKE="Debian"
                             OS_NAME="Kali Linux"
                             OS_VERSION="Rolling release"
                         ;;
                         "linuxmint")
                             LINUX_VERSION="Linux Mint"
+                            LINUX_VERSION_LIKE="Ubuntu"
                             OS_NAME="Linux Mint"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
@@ -231,18 +233,21 @@
                         ;;
                         "pop")
                             LINUX_VERSION="Pop!_OS"
+                            LINUX_VERSION_LIKE="Ubuntu"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="Pop!_OS"
                         ;;
                         "pureos")
                             LINUX_VERSION="PureOS"
+                            LINUX_VERSION_LIKE="Debian"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="PureOS"
                         ;;
                         "raspbian")
                             LINUX_VERSION="Raspbian"
+                            LINUX_VERSION_LIKE="Debian"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="Raspbian"
@@ -324,6 +329,7 @@
                         LINUX_VERSION="Ubuntu"
                     elif [ "${FIND}" = "elementary OS" ]; then
                         LINUX_VERSION="elementary OS"
+                        LINUX_VERSION_LIKE="Ubuntu"
                         OS_VERSION=$(grep "^DISTRIB_RELEASE=" /etc/lsb-release | cut -d '=' -f2)
                         OS_FULLNAME=$(grep "^DISTRIB_DESCRIPTION=" /etc/lsb-release | cut -d '=' -f2 | sed 's/"//g')
                     else
@@ -340,6 +346,8 @@
                 FIND=$(lsb_release --id | awk -F: '{ print $2 }' | awk '{ print $1 }')
                 if [ "${FIND}" = "LinuxMint" ]; then
                     LINUX_VERSION="Linux Mint"
+                    # LMDE (Linux Mint Debian Edition) should be detected as Debian
+                    LINUX_VERSION_LIKE="Ubuntu"
                     OS_VERSION=$(lsb_release --release | awk '{ print $2 }')
                     OS_FULLNAME="Linux Mint ${OS_VERSION}"
                 fi

--- a/include/osdetection
+++ b/include/osdetection
@@ -308,31 +308,31 @@
             # CPUBuilders Linux
             if [ -e "/etc/cpub-release" ]; then OS_FULLNAME=$(cat /etc/cpub-release); fi
 
-            # Debian/Ubuntu (***) - Set first to Debian
-            if [ -e "/etc/debian_version" ]; then
+            if [ -z "${LINUX_VERSION}" ] && [ -e "/etc/debian_version" ]; then
+                # Debian/Ubuntu (***) - Set first to Debian
                 OS_VERSION=$(cat /etc/debian_version)
                 OS_FULLNAME="Debian ${OS_VERSION}"
                 LINUX_VERSION="Debian"
-            fi
 
-            # /etc/lsb-release does not exist on Debian
-            if [ -e "/etc/debian_version" -a -e /etc/lsb-release ]; then
-                OS_VERSION=$(cat /etc/debian_version)
-                FIND=$(grep "^DISTRIB_ID=" /etc/lsb-release | cut -d '=' -f2 | sed 's/"//g')
-                if [ "${FIND}" = "Ubuntu" ]; then
-                    OS_VERSION=$(grep "^DISTRIB_RELEASE=" /etc/lsb-release | cut -d '=' -f2)
-                    OS_FULLNAME="Ubuntu ${OS_VERSION}"
-                    LINUX_VERSION="Ubuntu"
-                elif [ "${FIND}" = "elementary OS" ]; then
-                    LINUX_VERSION="elementary OS"
-                    OS_VERSION=$(grep "^DISTRIB_RELEASE=" /etc/lsb-release | cut -d '=' -f2)
-                    OS_FULLNAME=$(grep "^DISTRIB_DESCRIPTION=" /etc/lsb-release | cut -d '=' -f2 | sed 's/"//g')
-                else
-                    # Catch all, in case it's unclear what specific release this is.
-                    OS_FULLNAME="Debian ${OS_VERSION}"
-                    LINUX_VERSION="Debian"
+                # /etc/lsb-release does not exist on Debian
+                if [ -e /etc/lsb-release ]; then
+                    OS_VERSION=$(cat /etc/debian_version)
+                    FIND=$(grep "^DISTRIB_ID=" /etc/lsb-release | cut -d '=' -f2 | sed 's/"//g')
+                    if [ "${FIND}" = "Ubuntu" ]; then
+                        OS_VERSION=$(grep "^DISTRIB_RELEASE=" /etc/lsb-release | cut -d '=' -f2)
+                        OS_FULLNAME="Ubuntu ${OS_VERSION}"
+                        LINUX_VERSION="Ubuntu"
+                    elif [ "${FIND}" = "elementary OS" ]; then
+                        LINUX_VERSION="elementary OS"
+                        OS_VERSION=$(grep "^DISTRIB_RELEASE=" /etc/lsb-release | cut -d '=' -f2)
+                        OS_FULLNAME=$(grep "^DISTRIB_DESCRIPTION=" /etc/lsb-release | cut -d '=' -f2 | sed 's/"//g')
+                    else
+                        # Catch all, in case it's unclear what specific release this is.
+                        OS_FULLNAME="Debian ${OS_VERSION}"
+                        LINUX_VERSION="Debian"
+                    fi
+                    # Ubuntu test (optional) $(grep "[Uu]buntu" /proc/version)
                 fi
-                # Ubuntu test (optional) $(grep "[Uu]buntu" /proc/version)
             fi
 
             # Override for Linux Mint, as that is initially detected as Debian or Ubuntu

--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -656,7 +656,13 @@
     # Test        : BOOT-5180
     # Description : Check for Linux boot services (Debian style)
     # Notes       : Debian 8+ shows runlevel 5
-    if [ "${LINUX_VERSION}" = "Debian" -o "${LINUX_VERSION}" = "Ubuntu" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ "${LINUX_VERSION}" = "Debian" ] || [ "${LINUX_VERSION}" = "Ubuntu" ] ||
+           [ "${LINUX_VERSION_LIKE}" = "Debian" ] || [ "${LINUX_VERSION_LIKE}" = "Ubuntu" ]; then
+        PREQS_MET="YES"
+    else
+        PREQS_MET="NO"
+    fi
+
     Register --test-no BOOT-5180 --os Linux --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check for Linux boot services (Debian style)"
     if [ ${SKIPTEST} -eq 0 ]; then
         # Runlevel check

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -81,7 +81,7 @@
                 fi
             else
                 LogText "Result: file ${ROOTDIR}etc/inittab not found"
-                if [ "${LINUX_VERSION}" = "Debian" -o "${LINUX_VERSION}" = "Ubuntu" ]; then
+                if [ "${LINUX_VERSION}" = "Debian" ] || [ "${LINUX_VERSION}" = "Ubuntu" ] || [ "${LINUX_VERSION_LIKE}" = "Debian" ] || [ "${LINUX_VERSION_LIKE}" = "Ubuntu" ]; then
                     LogText "Test: Checking run level with who -r, for Debian based systems"
                     FIND=$(who -r | ${AWKBINARY} '{ if ($1=="run-level") { print $2 } }')
                     if HasData "${FIND}"; then
@@ -368,7 +368,12 @@
 #
     # Test        : KRNL-5788
     # Description : Checking availability new kernel
-    if [ "${LINUX_VERSION}" = "Debian" -o "${LINUX_VERSION}" = "Ubuntu" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ "${LINUX_VERSION}" = "Debian" ] || [ "${LINUX_VERSION}" = "Ubuntu" ] ||
+           [ "${LINUX_VERSION_LIKE}" = "Debian" ] || [ "${LINUX_VERSION_LIKE}" = "Ubuntu" ]; then
+        PREQS_MET="YES"
+    else
+        PREQS_MET="NO"
+    fi
     Register --test-no KRNL-5788 --os Linux --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking availability new Linux kernel"
     if [ ${SKIPTEST} -eq 0 ]; then
         HAS_VMLINUZ=0

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -600,8 +600,8 @@
 #
     # Test        : PKGS-7366
     # Description : Checking if debsecan is installed and enabled on Debian systems
-    if [ -n "${DEBSECANBINARY}" -a "${OS}" = "Linux" -a "${LINUX_VERSION}" = "Debian" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
-    Register --test-no "PKGS-7366" --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking for debsecan utility"
+    if [ -n "${DEBSECANBINARY}" ] && ( [ "${LINUX_VERSION}" = "Debian" ] || [ "${LINUX_VERSION_LIKE}" = "Debian" ] ); then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no "PKGS-7366" --preqs-met ${PREQS_MET} --os Linux --weight L --network NO --category security --description "Checking for debsecan utility"
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ -n "${DEBSECANBINARY}" ]; then
             LogText "Result: debsecan utility is installed"
@@ -986,7 +986,9 @@
     PREQS_MET="NO"
     if [ -f ${ROOTDIR}etc/apt/sources.list -a -d ${ROOTDIR}etc/apt/sources.list.d ]; then
         case "${LINUX_VERSION}" in
-            "Debian" | "Linux Mint" | "Ubuntu")
+            "Debian" | "Linux Mint" | "Ubuntu" | "Pop!_OS")
+                # Todo: PureOS (not rolling) has security repositories
+                # Todo: Debian sid does not have a security repository.
                 PREQS_MET="YES"
             ;;
             *)
@@ -1042,7 +1044,13 @@
 #
     # Test        : PKGS-7390
     # Description : Check Ubuntu database consistency
-    if [ "${LINUX_VERSION}" = "Ubuntu" -a -x ${ROOTDIR}usr/bin/apt-get ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if ([ "${LINUX_VERSION}" = "Debian" ] || [ "${LINUX_VERSION}" = "Ubuntu" ] ||
+           [ "${LINUX_VERSION_LIKE}" = "Debian" ] ||  [ "${LINUX_VERSION_LIKE}" = "Ubuntu" ]) && [ -x "${ROOTDIR}usr/bin/apt-get" ]; then
+        PREQS_MET="YES"
+    else
+        PREQS_MET="NO"
+    fi
+
     Register --test-no PKGS-7390 --os Linux --preqs-met ${PREQS_MET} --root-only YES --weight L --network NO --category security --description "Check Ubuntu database consistency"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Package database consistency by running apt-get check"
@@ -1191,7 +1199,13 @@
 #
     # Test        : PKGS-7394
     # Description : Check Ubuntu upgradeable packages
-    if [ "${LINUX_VERSION}" = "Ubuntu" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if ([ "${LINUX_VERSION}" = "Debian" ] || [ "${LINUX_VERSION}" = "Ubuntu" ] ||
+           [ "${LINUX_VERSION_LIKE}" = "Debian" ] ||  [ "${LINUX_VERSION_LIKE}" = "Ubuntu" ]) && [ -x "${ROOTDIR}usr/bin/apt-get" ]; then
+        PREQS_MET="YES"
+    else
+        PREQS_MET="NO"
+    fi
+
     Register --test-no PKGS-7394 --os Linux --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check for Ubuntu updates"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: checking ${ROOTDIR}usr/bin/apt-show-versions"
@@ -1317,37 +1331,39 @@
 
         case "${OS}" in
             "Linux")
-                case "${LINUX_VERSION}" in
-                    "CentOS" | "Debian" | "Fedora" | "RHEL" | "Ubuntu")
-
+                for DIST in CentOS Debian Fedora RHEL Ubuntu; do
+                    if [ "${LINUX_VERSION}" = "${DIST}" ] || [ "${LINUX_VERSION_LIKE}" = "${DIST}" ]; then
                         UNATTENDED_UPGRADES_OPTION_AVAILABLE=1
-                        # Test available tools for Linux
-                        if [ -f "${ROOTDIR}bin/auter" ]; then
-                            UNATTENDED_UPGRADES_TOOL="auter"
-                            UNATTENDED_UPGRADES_TOOLKIT=1
-                            LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
-                            Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
-                        fi
-                        if [ -f "${ROOTDIR}sbin/yum-cron" ]; then
-                            UNATTENDED_UPGRADES_TOOL="yum-cron"
-                            UNATTENDED_UPGRADES_TOOLKIT=1
-                            LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
-                            Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
-                        fi
-                        if [ -f "${ROOTDIR}usr/bin/dnf-automatic" ]; then
-                            UNATTENDED_UPGRADES_TOOL="dnf-automatic"
-                            UNATTENDED_UPGRADES_TOOLKIT=1
-                            LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
-                            Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
-                        fi
-                        if [ -f "${ROOTDIR}usr/bin/unattended-upgrade" ]; then
-                            UNATTENDED_UPGRADES_TOOL="unattended-upgrade"
-                            UNATTENDED_UPGRADES_TOOLKIT=1
-                            LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
-                            Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
-                        fi
-                    ;;
-                esac
+                    fi
+                done
+
+                if [ $UNATTENDED_UPGRADES_OPTION_AVAILABLE -eq 1 ]; then
+                    # Test available tools for Linux
+                    if [ -f "${ROOTDIR}bin/auter" ]; then
+                        UNATTENDED_UPGRADES_TOOL="auter"
+                        UNATTENDED_UPGRADES_TOOLKIT=1
+                        LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
+                        Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
+                    fi
+                    if [ -f "${ROOTDIR}sbin/yum-cron" ]; then
+                        UNATTENDED_UPGRADES_TOOL="yum-cron"
+                        UNATTENDED_UPGRADES_TOOLKIT=1
+                        LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
+                        Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
+                    fi
+                    if [ -f "${ROOTDIR}usr/bin/dnf-automatic" ]; then
+                        UNATTENDED_UPGRADES_TOOL="dnf-automatic"
+                        UNATTENDED_UPGRADES_TOOLKIT=1
+                        LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
+                        Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
+                    fi
+                    if [ -f "${ROOTDIR}usr/bin/unattended-upgrade" ]; then
+                        UNATTENDED_UPGRADES_TOOL="unattended-upgrade"
+                        UNATTENDED_UPGRADES_TOOLKIT=1
+                        LogText "Result: found ${UNATTENDED_UPGRADES_TOOL}"
+                        Report "unattended_upgrade_tool[]=${UNATTENDED_UPGRADES_TOOL}"
+                    fi
+                fi
             ;;
         esac
 


### PR DESCRIPTION
Before parsing /etc/debian-release and /etc/lsb-release,
it is now checked if the variable LINUX_VERSION is already set.

This fixes cisofy/lynis#1003.

This will affects Ubuntu and Debian based distributions, like:
 - Pop!_OS (Ubuntu based)
 - Kali (Debian Based)
 - Raspbian
 - ...

Unfortunately this will likely skip/brake a few tests for those distributions, as they are not considered to be Ubuntu or Debian anymore. Linux Mint was already detected properly, but at least some tests already had support for them (will other tests for Ubuntu are skipped). See below for an included fix.

Those are tests I identified that will be skipped incorrectly with 529bcb2a6036718da41ef0bfc52fae7f20bdfcac:
 - BOOT-5180: Check for Linux boot services (Debian style)
     It was already skipped on Linux Mint.
 - KRNL-5622: Check default run level on Linux machines
     This will only be skipped if systemd is not installed. It is already skipped on Linux Mint in this case.
 - KRNL-5788: Checking availability new kernel (sic!)
     This was already skipped on Linux Mint.
 - PKGS-7388: Check security repository (...)
     It will now be skipped for all distributions that do use the Debian / Ubuntu security repositories but are not detected as such
 anymore (like Pop!_OS). It will now be correctly skipped on Raspbian. This test was already aware of Linux Mint.
 - PKGS-7390: Check Ubuntu database consitency
     I am not sure why this test is Ubuntu only, thus it already skipped on Debian and Mint.
 - PKGS-7394: Check Ubuntu upgradeable packages
     I am not sure why this is for Ubuntu only, too. I think this should be feature tested instead, as apt-show-versions can be installed on any Debian based distribution as well.
 - PKGS-7366: Checking if debsecan is installed (...)
     While it may be correct to skip, debsecan remains useful if package versions, patches and vulnerability fixes are very close
     on Debian itself.
     It is the correct behaviour to not do this test on Ubuntu and Ubuntu based distributions, as Canonical does not provide the required databases.
 - PKGS-7420: (Autoupdates)
     Linux Mint was already skipped on this test.

With 4a03c613438d25944680ed22f67276dff755ff3c the variable LINUX_VERSION_LIKE is introduced, that fixes the aforementioned problem: Instead of just checking LINUX_VERSION, the new LINUX_VERSION_LIKE is checked, too.
Tests that previously only ran on the original distribution distribution, will now run on direct clones. Ubuntu and Debian do not have LINUX_VERSION_LIKE set. The listed tests now run on derived distributions. In addition, the test PKGS-7394 now runs on other (Debian based) distributions, as apt-show-versions is available on Debian as well.

Future work: Detect remote rolling releases properly and forks that are very different from the original distribution.
Example: While PureOS is usually a rolling release distribution, it has a "stable" variant with security releases and the proper detection of Linux Mint and Linux Mint Debian Edition (LMDE). But as this was not considered before this PR, it is not changed.