### PR TITLE
Alpine Improvements

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -14,6 +14,14 @@
 # For rolling releases or releases that do not (currently have an EOL date, leave field three empty and set field four to -1.
 # Full string for CentOS can be something like 'CentOS Linux 8 (Core)'. As this does not correctly match, shorter string is used for matching.
 #
+# Alpine - https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases
+#
+os:Alpine 3.12:2022-05-01:1651377600
+os:Alpine 3.11:2021-11-01:1635739200
+os:Alpine 3.10:2021-05-01:1619841600
+os:Alpine 3.9:2020-11-01:1604203200
+os:Alpine 3.8:2020-05-01:1588305600
+#
 # Amazon Linux
 #
 # Note: shortest entry is listed at end due to regular expression matching being used

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -664,6 +664,9 @@
                     elif [ -f ${ROOTDIR}boot/vmlinuz-linux-lts ]; then
                         LogText "Result: found ${ROOTDIR}boot/vmlinuz-linux-lts"
                         FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-linux-lts
+                    elif [ -f ${ROOTDIR}boot/vmlinuz-lts ]; then
+                        LogText "Result: found ${ROOTDIR}boot/vmlinuz-lts"
+                        FOUND_VMLINUZ=${ROOTDIR}boot/vmlinuz-lts
                     else
                         # Match on /boot/vm5.3.7 or /boot/vmlinuz-5.3.7-1-default
                         FOUND_VMLINUZ=$(${LSBINARY} -t ${ROOTDIR}boot/vm[l0-9]* 2> /dev/null | ${HEADBINARY} -1)
@@ -678,7 +681,7 @@
                         VERSION_ON_DISK=$(echo ${FOUND_VMLINUZ} | ${SEDBINARY} 's#^/boot/##' | ${SEDBINARY} 's/^vmlinuz-//')
                         LogText "Result: version derived from file name is '${VERSION_ON_DISK}'"
                     elif [ -f "${FOUND_VMLINUZ}" ]; then
-                        VERSION_ON_DISK=$(echo ${FOUND_VMLINUZ} | ${SEDBINARY} 's#^/boot/##' | ${SEDBINARY} 's/^vmlinuz-//')
+                        VERSION_ON_DISK=$(echo ${FOUND_VMLINUZ} | ${SEDBINARY} 's#^/boot/##' | ${SEDBINARY} 's/^vmlinuz-//' | ${SEDBINARY} '$s/-\?\(linux\)\?-\?\(lts\)\?//')
                         LogText "Result: version derived from file name is '${VERSION_ON_DISK}'"
                     fi
 


### PR DESCRIPTION
Added Alpine Linux EOL dates for current versions with support and most recent version out of support.
Improve detecting kernel version on disk. Alpine uses /boot/vmlinuz-lts which was being detected as version 'lts' which did not match the current version of the kernel in memory. This caused the code to incorrectly identify a reboot as needed. 