### PR TITLE
[AUTH-9284] Feature: gather locked accounts info

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -859,23 +859,27 @@
                     PREQS_MET="YES"
                     FIND_P=$(passwd -a -S 2> /dev/null | ${AWKBINARY} '{ if ($2=="P" && $5=="99999") print $1 }')
                     FIND2=$(passwd -a -S 2> /dev/null | ${AWKBINARY} '{ if ($2=="NP") print $1 }')
+                    FIND3=$(passwd -a -S 2> /dev/null | ${AWKBINARY} '{ if ($2=="L") print $1 }' | sort | uniq)
                     ;;
                 *)
                     PREQS_MET="YES"
                     FIND_P=$(passwd --all --status 2> /dev/null | ${AWKBINARY} '{ if ($2=="P" && $5=="99999") print $1 }')
                     FIND2=$(passwd --all --status 2> /dev/null | ${AWKBINARY} '{ if ($2=="NP") print $1 }')
+                    FIND3=$(passwd --all --status 2> /dev/null | ${AWKBINARY} '{ if ($2=="L") print $1 }' | sort | uniq)
                     ;;
             esac
         elif [ "${OS_REDHAT_OR_CLONE}" -eq 1 ]; then
             PREQS_MET="YES"
             FIND_P=$(for I in $(${AWKBINARY} -F: '{print $1}' "${ROOTDIR}etc/passwd") ; do passwd -S "$I" | ${AWKBINARY} '{ if ($2=="PS" && $5=="99999") print $1 }' ; done)
             FIND2=$(for I in $(${AWKBINARY} -F: '{print $1}' "${ROOTDIR}etc/passwd") ; do passwd -S "$I" | ${AWKBINARY} '{ if ($2=="NP") print $1 }' ; done)
+            FIND3=$(for I in $(${AWKBINARY} -F: '{print $1}' "${ROOTDIR}etc/passwd") ; do passwd -S "$I" | ${AWKBINARY} '{ if ($2=="L") print $1 }' | sort | uniq ; done)
         else
             LogText "Result: skipping test for this Linux version"
             ReportManual "AUTH-9282:01"
             PREQS_MET="NO"
             FIND_P=""
             FIND2=""
+            FIND3=""
         fi
      else
         PREQS_MET="NO"
@@ -917,6 +921,31 @@
             done
             Display --indent 2 --text "- Accounts without password" --result "${STATUS_WARNING}" --color RED
             ReportWarning "${TEST_NO}" "Found accounts without password"
+        fi
+    fi
+#
+#################################################################################
+#
+    # Test        : AUTH-9284
+    # Description : Search locked accounts
+    Register --test-no AUTH-9284 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking locked accounts"
+    if [ "${SKIPTEST}" -eq 0 ]; then
+        LogText "Test: Checking locked accounts"
+        SYSTEM_ACCOUNTS=$(${AWKBINARY} -F : '$3 <= 999 || $3 == 65534 {print $1}' /etc/passwd | sort | uniq)
+        if [ "${FIND3}" = "${SYSTEM_ACCOUNTS}" ]; then
+            LogText "Result: all accounts seem to be unlocked"
+            Display --indent 2 --text "- Locked accounts" --result "${STATUS_OK}" --color GREEN
+        else
+            LogText "Result: found one or more locked accounts"
+            NON_SYSTEM_ACCOUNTS=$(${AWKBINARY} -F : '$3 > 999 && $3 != 65534 {print $1}' /etc/passwd | sort | uniq)
+            for I in ${FIND3}; do
+                if echo "${NON_SYSTEM_ACCOUNTS}" | grep -w "${I}" > /dev/null ; then
+                    LogText "Locked account: ${I}"
+                    Report "locked_account=${I}"
+                fi
+            done
+            Display --indent 2 --text "- Locked accounts" --result "${STATUS_WARNING}" --color RED
+            ReportWarning "${TEST_NO}" "Found locked accounts"
         fi
     fi
 #

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -872,7 +872,7 @@
             PREQS_MET="YES"
             FIND_P=$(for I in $(${AWKBINARY} -F: '{print $1}' "${ROOTDIR}etc/passwd") ; do passwd -S "$I" | ${AWKBINARY} '{ if ($2=="PS" && $5=="99999") print $1 }' ; done)
             FIND2=$(for I in $(${AWKBINARY} -F: '{print $1}' "${ROOTDIR}etc/passwd") ; do passwd -S "$I" | ${AWKBINARY} '{ if ($2=="NP") print $1 }' ; done)
-            FIND3=$(for I in $(${AWKBINARY} -F: '{print $1}' "${ROOTDIR}etc/passwd") ; do passwd -S "$I" | ${AWKBINARY} '{ if ($2=="L") print $1 }' | sort | uniq ; done)
+            FIND3=$(for I in $(${AWKBINARY} -F: '{print $1}' "${ROOTDIR}etc/passwd") ; do passwd -S "$I" | ${AWKBINARY} '{ if ($2=="L" || $2=="LK") print $1 }' | sort | uniq ; done)
         else
             LogText "Result: skipping test for this Linux version"
             ReportManual "AUTH-9282:01"

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -931,17 +931,22 @@
     Register --test-no AUTH-9284 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking locked accounts"
     if [ "${SKIPTEST}" -eq 0 ]; then
         LogText "Test: Checking locked accounts"
-        SYSTEM_ACCOUNTS=$(${AWKBINARY} -F : '$3 <= 999 || $3 == 65534 {print $1}' /etc/passwd | sort | uniq)
-        if [ "${FIND3}" = "${SYSTEM_ACCOUNTS}" ]; then
+        NON_SYSTEM_ACCOUNTS=$(${AWKBINARY} -F : '$3 > 999 && $3 != 65534 {print $1}' /etc/passwd | sort | uniq)
+        LOCKED_NON_SYSTEM_ACCOUNTS=0
+        for account in ${FIND3};do
+            if echo "${NON_SYSTEM_ACCOUNTS}" | grep -w "${account}" > /dev/null ; then
+                LOCKED_NON_SYSTEM_ACCOUNTS=$((LOCKED_NON_SYSTEM_ACCOUNTS+1))
+            fi
+        done
+        if [ $LOCKED_NON_SYSTEM_ACCOUNTS -eq 0 ]; then
             LogText "Result: all accounts seem to be unlocked"
             Display --indent 2 --text "- Locked accounts" --result "${STATUS_OK}" --color GREEN
         else
             LogText "Result: found one or more locked accounts"
-            NON_SYSTEM_ACCOUNTS=$(${AWKBINARY} -F : '$3 > 999 && $3 != 65534 {print $1}' /etc/passwd | sort | uniq)
-            for I in ${FIND3}; do
-                if echo "${NON_SYSTEM_ACCOUNTS}" | grep -w "${I}" > /dev/null ; then
-                    LogText "Locked account: ${I}"
-                    Report "locked_account=${I}"
+            for account in ${FIND3}; do
+                if echo "${NON_SYSTEM_ACCOUNTS}" | grep -w "${account}" > /dev/null ; then
+                    LogText "Locked account: ${account}"
+                    Report "locked_account=${account}"
                 fi
             done
             Display --indent 2 --text "- Locked accounts" --result "${STATUS_WARNING}" --color RED


### PR DESCRIPTION
Hi guys, I am very excited since this is my very first contribution into this project.

I basically added a test to gather information about locked accounts following the guidelines of @chr0mag as mentiones in issue #474. Furthermore, I removed the system locked accounts as @chr0mag and @mboelen consensued in the same issue.

Any feedback is appreciated.