### PR TITLE
[TIME-3185]: Change timesyncd synchronization file

### DIFF
--- a/include/tests_time
+++ b/include/tests_time
@@ -574,7 +574,7 @@
 
 
     Register --test-no TIME-3185 --preqs-met "${PREQS_MET}" --weight L --network NO --category "security" --description "Check systemd-timesyncd synchronized time"
-    SYNCHRONIZED_FILE="/run/systemd/timesync/synchronized"
+    SYNCHRONIZED_FILE="/var/lib/systemd/timesync/clock"
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ -e "${SYNCHRONIZED_FILE}" ]; then
            FIND=$(( $(date +%s) - $(${STATBINARY} -L --format %Y "${SYNCHRONIZED_FILE}") ))

--- a/include/tests_time
+++ b/include/tests_time
@@ -574,8 +574,17 @@
 
 
     Register --test-no TIME-3185 --preqs-met "${PREQS_MET}" --weight L --network NO --category "security" --description "Check systemd-timesyncd synchronized time"
-    SYNCHRONIZED_FILE="/var/lib/systemd/timesync/clock"
+    SYNCHRONIZED_FILE="/run/systemd/timesync/synchronized"
+       
     if [ ${SKIPTEST} -eq 0 ]; then
+        # On earlier systemd versions (237), '/run/systemd/timesync/synchronized' does not exist, so use '/var/lib/systemd/timesync/clock'
+        if [ ! -e "${SYNCHRONIZED_FILE}" ]; then
+            SYNCHRONIZED_FILE="/var/lib/systemd/timesync/clock"
+        fi
+        # DynamicUser=yes moves the clock file to '/var/lib/private/systemd/timesync/clock'
+        if [ ! -e "${SYNCHRONIZED_FILE}" ]; then
+            SYNCHRONIZED_FILE="/var/lib/private/systemd/timesync/clock"
+        fi
         if [ -e "${SYNCHRONIZED_FILE}" ]; then
            FIND=$(( $(date +%s) - $(${STATBINARY} -L --format %Y "${SYNCHRONIZED_FILE}") ))
            # Check if last sync was more than 2048 seconds (= the default of systemd) ago


### PR DESCRIPTION
This PR fixes #1012. As Ubuntu 18.04, which has systemd version 237 does not make a file at `/run/systemd/timesyncd/synchronized` I changed the `SYNCHRONIZED_FILE` to `/var/lib/systemd/timesync/clock`, which **is** created by systemd version 237.

This shouldn't cause any issues for later systemd versions as `/var/lib/systemd/timesync/clock` is still used besides `/run/systemd/timesyncd/synchronized` [(see the manual of the latest systemd version)](https://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html).

**Update**: I have now modified the PR such that it still uses `/run/systemd/timesyncd/synchronized` first and uses `/var/lib/systemd/timesync/clock` and `/var/lib/private/systemd/timesync/clock` as fallback options in case `/run/systemd/timesyncd/synchronized` doesn't exist.