### PR TITLE
Add support for Flatcar Container Linux

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -190,6 +190,12 @@
                             OS_REDHAT_OR_CLONE=1
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
+                        "flatcar")
+                            LINUX_VERSION="Flatcar"
+                            LINUX_VERSION_LIKE="CoreOS"
+                            OS_NAME="Flatcar Linux"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "gentoo")
                             LINUX_VERSION="Gentoo"
                             OS_NAME="Gentoo Linux"


### PR DESCRIPTION
Fixes cisofy/lynis#1014.

Flatcar is a fork of CoreOS. Thus the variable LINUX_VERSION_LIKE
(introduced with #1004) for Flatcar is CoreOS.