### PR TITLE
Mageia got /etc/os-release and add Mageia EOL dates

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -68,6 +68,16 @@ os:Linux Mint 18:2021-04-01:1617228000:
 os:Linux Mint 19:2023-04-01:1680300000:
 os:Linux Mint 20:2025-04-01:1743458400:
 #
+# Mageia - https://www.mageia.org/en/support/
+#
+os:Mageia 1:2012-12-01:1354316400
+os:Mageia 2:2013-11-22:1385074800
+os:Mageia 3:2014-11-26:1416956400
+os:Mageia 4:2015-09-19:1442613600
+os:Mageia 5:2017-12-31:1514674800
+os:Mageia 6:2019-09-30:1569794400
+os:Mageia 7:2020-12-30:1609282800
+#
 # NetBSD - https://www.netbsd.org/support/security/release.html and
 #          https://www.netbsd.org/releases/formal.html
 #

--- a/include/osdetection
+++ b/include/osdetection
@@ -212,6 +212,12 @@
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
+                        "mageia")
+                            LINUX_VERSION="Mageia"
+                            OS_NAME="Mageia"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "manjaro")
                             LINUX_VERSION="Manjaro"
                             OS_FULLNAME="Manjaro Linux"
@@ -396,13 +402,6 @@
                     LINUX_VERSION="Fedora"
                 fi
 
-                # Mageia (/etc/redhat-release -> /etc/mageia-release link)
-                FIND=$(grep "Mageia" /etc/mageia-release)
-                if [ ! "${FIND}" = "" ]; then
-                    OS_FULLNAME=$(grep "^Mageia" /etc/mageia-release)
-                    OS_VERSION=$(grep "^Mageia" /etc/mageia-release | awk '{ if ($2=="release") { print $3 } }')
-                    LINUX_VERSION="Mageia"
-                fi
 
                 # Oracle Enterprise Linux
                 FIND=$(grep "Enterprise Linux Enterprise Linux Server" /etc/redhat-release)

--- a/include/osdetection
+++ b/include/osdetection
@@ -396,11 +396,11 @@
                     LINUX_VERSION="Fedora"
                 fi
 
-                # Mageia (has also /etc/megaia-release)
-                FIND=$(grep "Mageia" /etc/redhat-release)
+                # Mageia (/etc/redhat-release -> /etc/mageia-release link)
+                FIND=$(grep "Mageia" /etc/mageia-release)
                 if [ ! "${FIND}" = "" ]; then
-                    OS_FULLNAME=$(grep "^Mageia" /etc/redhat-release)
-                    OS_VERSION=$(grep "^Mageia" /etc/redhat-release | awk '{ if ($2=="release") { print $3 } }')
+                    OS_FULLNAME=$(grep "^Mageia" /etc/mageia-release)
+                    OS_VERSION=$(grep "^Mageia" /etc/mageia-release | awk '{ if ($2=="release") { print $3 } }')
                     LINUX_VERSION="Mageia"
                 fi
 


### PR DESCRIPTION
Add Mageia EOL dates and `/etc/redhat-release` is a link to `/etc/mageia-release`.

Ref https://github.com/CISOfy/lynis/issues/1034

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>