### PR TITLE
require pgrep before usage

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1547,8 +1547,7 @@
 
         if [ -z "${search}" ]; then ExitFatal "Missing process to search for when using IsRunning function"; fi
         RUNNING=0
-        # AIX does not fully support pgrep options, so using ps instead
-        if [ "${OS}" != "AIX" ]; then
+        if [ -x "${PGREPBINARY}" ] && [ "${OS}" != "AIX" ]; then
             # When --user is used, perform a search using the -u option
             # Initialize users for strict mode
             if [ -n "${users:-}" ]; then


### PR DESCRIPTION
Some distributions or OS:es might be missing `pgrep`, besides AIX.

Closes #1041

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>