### PR TITLE
add Synology Antivirus Essential malware scanner

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -287,6 +287,7 @@
                             suricata)               SURICATABINARY="${BINARY}";        LogText "  Found known binary: suricata (IDS) - ${BINARY}" ;;
                             swapon)                 SWAPONBINARY="${BINARY}";          LogText "  Found known binary: swapon (swap device tool) - ${BINARY}" ;;
                             swupd)                  SWUPDBINARY="${BINARY}";           LogText "  Found known binary: swupd (package manager) - ${BINARY}" ;;
+                            synoavd)                SYNOAVDBINARY=${BINARY};           LogText "  Found known binary: synoavd (Synology AV scanner) - ${BINARY}" ;;
                             sysctl)                 SYSCTLBINARY="${BINARY}";          LogText "  Found known binary: sysctl (kernel parameters) - ${BINARY}" ;;
                             syslog-ng)              SYSLOGNGBINARY="${BINARY}";        SYSLOGNGVERSION=$(${BINARY} -V 2>&1 | grep "^syslog-ng" | awk '{ print $2 }'); LogText "Found ${BINARY} (version ${SYSLOGNGVERSION})" ;;
                             systemctl)              SYSTEMCTLBINARY="${BINARY}";       LogText "  Found known binary: systemctl (client to systemd) - ${BINARY}" ;;

--- a/include/tests_malware
+++ b/include/tests_malware
@@ -39,6 +39,7 @@
     MALWARE_SCANNER_INSTALLED=0
     SOPHOS_SCANNER_RUNNING=0
     SYMANTEC_SCANNER_RUNNING=0
+    SYNOLOGY_DAEMON_RUNNING=0
 #
 #################################################################################
 #
@@ -237,6 +238,17 @@
             MALWARE_SCANNER_INSTALLED=1
             FOUND=1
             Report "malware_scanner[]=symantec"
+        fi
+
+        # Synology Antivirus Essential
+        LogText "Test: checking process synoavd"
+        if IsRunning "synoavd"; then
+            FOUND=1
+            SYNOLOGY_DAEMON_RUNNING=1
+            MALWARE_SCANNER_INSTALLED=1
+            if IsVerbose; then Display --indent 2 --text "- ${GEN_CHECKING} Synology Antivirus Essential" --result "${STATUS_FOUND}" --color GREEN; fi
+            LogText "Result: found Synology Antivirus Essential"
+            Report "malware_scanner[]=synoavd"
         fi
 
         # TrendMicro (macOS)


### PR DESCRIPTION
Catch the Synology Antivirus Essential malware scanner.

Closes #1050 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>