### PR TITLE
Use X/Open grep, nawk and GNU echo on Solaris

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -233,7 +233,7 @@
                             osiris)                 OSIRISBINARY="${BINARY}";          LogText "  Found known binary: osiris - ${BINARY}" ;;
                             openssl)                OPENSSLBINARY="${BINARY}";         OPENSSLVERSION=$(${BINARY} version 2> /dev/null | head -n 1 | awk '{ print $2 }' | xargs); LogText "Found ${BINARY} (version ${OPENSSLVERSION})" ;;
                             pacman)
-                                if [ -z "$(echo "${BINARY}" | grep -E "/usr(/local)?/games")" ]; then
+                                if [ -z "$(echo "${BINARY}" | egrep "/usr(/local)?/games")" ]; then
                                     PACMANBINARY="${BINARY}"
                                     LogText "  Found known binary: pacman (package manager) - ${BINARY}"
                                 fi
@@ -338,7 +338,7 @@
         [ "${AWKBINARY:-}" ] || ExitFatal "awk binary not found"
         [ "${CAT_BINARY:-}" ] || ExitFatal "cat binary not found"
         [ "${CUTBINARY:-}" ] || ExitFatal "cut binary not found"
-        [ "${EGREPBINARY:-}" ] || ExitFatal "grep binary not found"
+        [ "${EGREPBINARY:-}" ] || ExitFatal "egrep binary not found"
         [ "${FINDBINARY:-}" ] || ExitFatal "find binary not found"
         [ "${GREPBINARY:-}" ] || ExitFatal "grep binary not found"
         [ "${HEADBINARY:-}" ] || ExitFatal "head binary not found"

--- a/include/binaries
+++ b/include/binaries
@@ -322,9 +322,17 @@
             fi
         done
 
-        if [ $OS = "Solaris" ] && [ "${AWKBINARY:-}" = /usr/bin/awk ] && [ -f /usr/bin/nawk ]; then
-            LogText "Result: Using nawk instead of awk, because the default Solaris awk is not sufficient for Lynis."
-            AWKBINARY=/usr/bin/nawk
+        if [ $OS = "Solaris" ]; then
+            # awk is the simple awk by default
+            if [ "${AWKBINARY:-}" = /usr/bin/awk ] && [ -f /usr/bin/nawk ]; then
+                LogText "Result: Using nawk instead of awk, because the default Solaris awk is not sufficient for Lynis."
+                AWKBINARY=/usr/bin/nawk
+            fi
+
+            # Use grep that supports -E
+            if [ "${GREPBINARY:-}" = /usr/bin/grep ] [ -f /usr/xpg4/bin/grep ]; then
+                GREPBINARY=/usr/xpg4/bin/grep
+            fi
         fi
 
         # unset SORTED_BIN_PATHS

--- a/include/binaries
+++ b/include/binaries
@@ -322,6 +322,11 @@
             fi
         done
 
+        if [ $OS = "Solaris" ] && [ "${AWKBINARY:-}" = /usr/bin/awk ] && [ -f /usr/bin/nawk ]; then
+            LogText "Result: Using nawk instead of awk, because the default Solaris awk is not sufficient for Lynis."
+            AWKBINARY=/usr/bin/nawk
+        fi
+
         # unset SORTED_BIN_PATHS
         BINARY_SCAN_FINISHED=1
         BINARY_PATHS_FOUND=$(echo ${BINARY_PATHS_FOUND} | sed 's/^, //g' | sed 's/, /,/g')

--- a/include/consts
+++ b/include/consts
@@ -408,6 +408,11 @@ ETC_PATHS="/etc /usr/local/etc"
     OK="${GREEN}"
     BAD="${RED}"
 
+    # Early initialization needed, profiles file needs a -E capable grep
+    if [ $(uname) == "SunOS" ] && [ -f /usr/xpg4/bin/grep ]; then
+        GREPBINARY=/usr/xpg4/bin/grep
+    fi
+
 #
 #################################################################################
 #

--- a/include/functions
+++ b/include/functions
@@ -150,7 +150,7 @@
                 CreateTempFile
                 SETTINGS_FILE="${TEMP_FILE}"
             fi
-            FIND=$(egrep "^${SETTING};" ${SETTINGS_FILE})
+            FIND=$("${GREPBINARY}" -E "^${SETTING};" ${SETTINGS_FILE})
             if [ -z "${FIND}" ]; then
                 echo "${SETTING};${VALUE};${DESCRIPTION};" >> ${SETTINGS_FILE}
             else
@@ -228,7 +228,7 @@
             if [ ! "${REPORTFILE}" = "/dev/null" ]; then
                 # Check if we can find the main type (with or without brackets)
                 LogText "Test: search string $2 in earlier discovered results"
-                FIND=$(egrep "^$1(\[\])?=" ${REPORTFILE} | egrep "$2")
+                FIND=$("${GREPBINARY}" -E "^$1(\[\])?=" ${REPORTFILE} | "${GREPBINARY}" -E "$2")
                 if HasData "${FIND}"; then
                     RETVAL=0
                     LogText "Result: found search string (result: $FIND)"
@@ -311,7 +311,7 @@
     ContainsString() {
         RETVAL=1
         if [ $# -ne 2 ]; then ReportException "ContainsString" "Incorrect number of arguments for ContainsStrings function"; fi
-        FIND=$(echo "$2" | egrep "$1")
+        FIND=$(echo "$2" | "${GREPBINARY}" -E "$1")
         if [ ! "${FIND}" = "" ]; then RETVAL=0; fi
         return ${RETVAL}
     }
@@ -411,7 +411,7 @@
         VALUE=$1
         LogText "Value is now: ${VALUE}"
         if [ ! "${AWKBINARY}" = "" ]; then
-            VALUE=$(echo ${VALUE} | egrep -o '[0-9]{1,}')
+            VALUE=$(echo ${VALUE} | "${GREPBINARY}" -Eo '[0-9]{1,}')
         fi
         LogText "Returning value: ${VALUE}"
     }
@@ -1025,10 +1025,10 @@
 
                     elif [ -n "${IPBINARY}" ]; then
                         # Determine if we have the common available eth0 interface
-                        FIND=$(${IPBINARY} addr show eth0 2> /dev/null | egrep "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                        FIND=$(${IPBINARY} addr show eth0 2> /dev/null | "${GREPBINARY}" -E "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                         if IsEmpty "${FIND}"; then
                             # Determine the MAC address of first interface with the ip command
-                            FIND=$(${IPBINARY} addr show 2> /dev/null | egrep "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                            FIND=$(${IPBINARY} addr show 2> /dev/null | "${GREPBINARY}" -E "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                             if IsEmpty "${FIND}"; then
                                 ReportException "GetHostID" "Can't create hostid (no MAC addresses found)"
                             fi
@@ -1834,7 +1834,7 @@
             # FreeBSD: hw.hv_vendor (remains empty for VirtualBox)
             # NetBSD: machdep.dmi.system-product
             # OpenBSD: hw.product
-            FIND=$(sysctl -a 2> /dev/null | egrep "(hw.product|machdep.dmi.system-product)" | head -1 | sed 's/ = /=/' | awk -F= '{ print $2 }')
+            FIND=$(sysctl -a 2> /dev/null | "${GREPBINARY}" -E "(hw.product|machdep.dmi.system-product)" | head -1 | sed 's/ = /=/' | awk -F= '{ print $2 }')
             if [ ! "${FIND}" = "" ]; then
                 SHORT="${FIND}"
             fi
@@ -2782,7 +2782,7 @@
             # Clean up temp files
             for FILE in ${TEMP_FILES}; do
                 # Temporary files should be in /tmp
-                TMPFILE=$(echo ${FILE} | egrep "^/tmp/lynis" | grep -v "\.\.")
+                TMPFILE=$(echo ${FILE} | "${GREPBINARY}" -E "^/tmp/lynis" | grep -v "\.\.")
                 if [ -n "${TMPFILE}" ]; then
                     if [ -f "${TMPFILE}" ]; then
                         LogText "Action: removing temporary file ${TMPFILE}"
@@ -3196,7 +3196,7 @@
             if [ -f ${FILE} ]; then
                 # Check if we can find the main type (with or without brackets)
                 LogText "Test: search string ${STRING} in file ${FILE}"
-                FIND=$(egrep "${STRING}" ${FILE})
+                FIND=$("${GREPBINARY}" -E "${STRING}" ${FILE})
                 if [ -n "${FIND}" ]; then
                     LogText "Result: found search string '${STRING}'"
                     if [ ${MASK_LOG} -eq 0 ]; then LogText "Full string returned: ${FIND}"; fi
@@ -3563,7 +3563,7 @@
         # Apply the related function
         case ${FUNCTION} in
               "contains")
-                  FIND=$(echo ${VALUE} | egrep "${SEARCH}")
+                  FIND=$(echo ${VALUE} | "${GREPBINARY}" -E "${SEARCH}")
                   if [ "${FIND}" = "" ]; then RETVAL=1; else RETVAL=0; fi
               ;;
               #"gt" | "greater-than")   COLOR=$GREEN   ;;

--- a/include/functions
+++ b/include/functions
@@ -150,7 +150,7 @@
                 CreateTempFile
                 SETTINGS_FILE="${TEMP_FILE}"
             fi
-            FIND=$(grep -E "^${SETTING};" ${SETTINGS_FILE})
+            FIND=$(egrep "^${SETTING};" ${SETTINGS_FILE})
             if [ -z "${FIND}" ]; then
                 echo "${SETTING};${VALUE};${DESCRIPTION};" >> ${SETTINGS_FILE}
             else
@@ -228,7 +228,7 @@
             if [ ! "${REPORTFILE}" = "/dev/null" ]; then
                 # Check if we can find the main type (with or without brackets)
                 LogText "Test: search string $2 in earlier discovered results"
-                FIND=$(grep -E "^$1(\[\])?=" ${REPORTFILE} | grep -E "$2")
+                FIND=$(egrep "^$1(\[\])?=" ${REPORTFILE} | egrep "$2")
                 if HasData "${FIND}"; then
                     RETVAL=0
                     LogText "Result: found search string (result: $FIND)"
@@ -311,7 +311,7 @@
     ContainsString() {
         RETVAL=1
         if [ $# -ne 2 ]; then ReportException "ContainsString" "Incorrect number of arguments for ContainsStrings function"; fi
-        FIND=$(echo "$2" | grep -E "$1")
+        FIND=$(echo "$2" | egrep "$1")
         if [ ! "${FIND}" = "" ]; then RETVAL=0; fi
         return ${RETVAL}
     }
@@ -411,7 +411,7 @@
         VALUE=$1
         LogText "Value is now: ${VALUE}"
         if [ ! "${AWKBINARY}" = "" ]; then
-            VALUE=$(echo ${VALUE} | grep -Eo '[0-9]{1,}')
+            VALUE=$(echo ${VALUE} | egrep -o '[0-9]{1,}')
         fi
         LogText "Returning value: ${VALUE}"
     }
@@ -1025,10 +1025,10 @@
 
                     elif [ -n "${IPBINARY}" ]; then
                         # Determine if we have the common available eth0 interface
-                        FIND=$(${IPBINARY} addr show eth0 2> /dev/null | grep -E "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                        FIND=$(${IPBINARY} addr show eth0 2> /dev/null | egrep "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                         if IsEmpty "${FIND}"; then
                             # Determine the MAC address of first interface with the ip command
-                            FIND=$(${IPBINARY} addr show 2> /dev/null | grep -E "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                            FIND=$(${IPBINARY} addr show 2> /dev/null | egrep "link/ether " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                             if IsEmpty "${FIND}"; then
                                 ReportException "GetHostID" "Can't create hostid (no MAC addresses found)"
                             fi
@@ -1834,7 +1834,7 @@
             # FreeBSD: hw.hv_vendor (remains empty for VirtualBox)
             # NetBSD: machdep.dmi.system-product
             # OpenBSD: hw.product
-            FIND=$(sysctl -a 2> /dev/null | grep -E "(hw.product|machdep.dmi.system-product)" | head -1 | sed 's/ = /=/' | awk -F= '{ print $2 }')
+            FIND=$(sysctl -a 2> /dev/null | egrep "(hw.product|machdep.dmi.system-product)" | head -1 | sed 's/ = /=/' | awk -F= '{ print $2 }')
             if [ ! "${FIND}" = "" ]; then
                 SHORT="${FIND}"
             fi
@@ -2782,7 +2782,7 @@
             # Clean up temp files
             for FILE in ${TEMP_FILES}; do
                 # Temporary files should be in /tmp
-                TMPFILE=$(echo ${FILE} | grep -E "^/tmp/lynis" | grep -v "\.\.")
+                TMPFILE=$(echo ${FILE} | egrep "^/tmp/lynis" | grep -v "\.\.")
                 if [ -n "${TMPFILE}" ]; then
                     if [ -f "${TMPFILE}" ]; then
                         LogText "Action: removing temporary file ${TMPFILE}"
@@ -3196,7 +3196,7 @@
             if [ -f ${FILE} ]; then
                 # Check if we can find the main type (with or without brackets)
                 LogText "Test: search string ${STRING} in file ${FILE}"
-                FIND=$(grep -E "${STRING}" ${FILE})
+                FIND=$(egrep "${STRING}" ${FILE})
                 if [ -n "${FIND}" ]; then
                     LogText "Result: found search string '${STRING}'"
                     if [ ${MASK_LOG} -eq 0 ]; then LogText "Full string returned: ${FIND}"; fi
@@ -3563,7 +3563,7 @@
         # Apply the related function
         case ${FUNCTION} in
               "contains")
-                  FIND=$(echo ${VALUE} | grep -E "${SEARCH}")
+                  FIND=$(echo ${VALUE} | egrep "${SEARCH}")
                   if [ "${FIND}" = "" ]; then RETVAL=1; else RETVAL=0; fi
               ;;
               #"gt" | "greater-than")   COLOR=$GREEN   ;;

--- a/include/osdetection
+++ b/include/osdetection
@@ -608,7 +608,16 @@
         "AIX")                           ECHOCMD="echo"; ECHONB="printf" ;;
         "DragonFly"|"FreeBSD"|"NetBSD")  ECHOCMD="echo -e"; ECHONB="echo -n" ;;
         "macOS" | "Mac OS X")                         ECHOCMD="echo"; ECHONB="/bin/echo -n" ;;
-        "Solaris")                       ECHOCMD="echo" ; test -f /usr/ucb/echo && ECHONB="/usr/ucb/echo -n" ;;
+        "Solaris")
+            ECHOCMD="echo"
+            if [ -f /usr/ucb/echo ]; then
+                ECHONB="/usr/ucb/echo -n"
+            elif [ -f /usr/gnu/bin/echo ]; then
+                ECHONB="/usr/gnu/bin/echo -n"
+            else
+                ECHONB="printf"
+            fi
+        ;;
         "Linux")
             # Check if dash is used (Debian/Ubuntu)
             DEFAULT_SHELL=$(ls -l /bin/sh | awk -F'>' '{print $2}')
@@ -637,6 +646,13 @@
         QNAP_DEVICE=1
     fi
 
+    # Solaris does not have compatible awk
+    if [ $OS = "Solaris" ] && [ -f /usr/bin/nawk ]; then
+        AWK=/usr/bin/nawk
+    else
+        AWK=awk
+    fi
+
     # Check if this OS is end-of-life
     EOL=255
     EOL_DATE=""
@@ -644,9 +660,9 @@
     if [ -n "${OS_VERSION}" ]; then
         if [ -f "${DBDIR}/software-eol.db" ]; then
             FIND="${OS_FULLNAME}"
-            EOL_TIMESTAMP=$(awk -v value="${FIND}" -F: '{if ($1=="os" && value ~ $2){print $4}}' ${DBDIR}/software-eol.db | head -n 1)
+            EOL_TIMESTAMP=$($AWK -v value="${FIND}" -F: '{if ($1=="os" && value ~ $2){print $4}}' ${DBDIR}/software-eol.db | head -n 1)
             if [ -n "${EOL_TIMESTAMP}" ]; then
-                EOL_DATE=$(awk -v value="${FIND}" -F: '{if ($1=="os" && value ~ $2){print $3}}' ${DBDIR}/software-eol.db | head -n 1)
+                EOL_DATE=$($AWK -v value="${FIND}" -F: '{if ($1=="os" && value ~ $2){print $3}}' ${DBDIR}/software-eol.db | head -n 1)
                 if [ -n "${EOL_DATE}" ]; then
                     NOW=$(date "+%s")
                     if [ -n "${NOW}" ]; then
@@ -662,6 +678,7 @@
             fi
         fi
     fi
+    unset AWK
 
 
 #================================================================================

--- a/include/profiles
+++ b/include/profiles
@@ -29,13 +29,14 @@
 #
 #################################################################################
 #
+
     for PROFILE in ${PROFILES}; do
 
         LogText "Reading profile/configuration ${PROFILE}"
 
         # Show deprecation message for old config entries such as 'config:' and 'apache:'
         FOUND=0
-        DATA=$(egrep "^[a-z-]{1,}:" ${PROFILE} | od -An -ta | sed 's/ /!space!/g')  # od -An (no file offset), -ta (named character, to be on safe side)
+        DATA=$("${GREPBINARY}" -E "^[a-z-]{1,}:" ${PROFILE} | od -An -ta | sed 's/ /!space!/g')  # od -An (no file offset), -ta (named character, to be on safe side)
         if ! IsEmpty "${DATA}"; then FOUND=1; fi
 
         if [ ${FOUND} -eq 1 ]; then
@@ -46,7 +47,7 @@
             Display --indent 2 --text "Your profile has one or more lines that are in an old format (key:value). They need to be converted into the new format (key=value) or disabled."
             Display --text " "
             Display --indent 2 --text "* ${GREEN}HOW TO RESOLVE${NORMAL}"
-            Display --indent 2 --text "Use grep to see the relevant matches (egrep \"^[a-z-]{1,}:\" custom.prf)"
+            Display --indent 2 --text "Use grep to see the relevant matches (grep -E \"^[a-z-]{1,}:\" custom.prf)"
             Display --text " "
             Display --text "=================================================================================================="
             Display --text " "
@@ -56,7 +57,7 @@
         fi
 
         # Security check for unexpected and possibly harmful escape characters (hyphen should be listed as first or last character)
-        DATA=$(egrep -v '^$|^ |^#|^config:' "${PROFILE}" | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | od -An -ta | sed 's/ /!space!/g')
+        DATA=$("${GREPBINARY}" -Ev '^$|^ |^#|^config:' "${PROFILE}" | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | od -An -ta | sed 's/ /!space!/g')
         if ! IsEmpty "${DATA}"; then
             DisplayWarning "Your profile '${PROFILE}' contains unexpected characters. See the log file for more information."
             LogText "Found unexpected or possibly harmful characters in profile '${PROFILE}'. See which characters matched in the output below and compare them with your profile."
@@ -69,7 +70,7 @@
         fi
 
         # Now parse the profile and filter out unwanted characters
-        DATA=$(egrep "^config:|^[a-z-].*=" ${PROFILE} | tr -dc '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | sed 's/ /!space!/g')
+        DATA=$("${GREPBINARY}" -E "^config:|^[a-z-].*=" ${PROFILE} | tr -dc '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | sed 's/ /!space!/g')
         for CONFIGOPTION in ${DATA}; do
             if ContainsString "^config:" "${CONFIGOPTION}"; then
                 # Old style configuration
@@ -86,7 +87,7 @@
 
                 # Is Lynis Enterprise allowed to purge this system when it is becomes outdated?
                 allow-auto-purge)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$")
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)$")
                     if [ -n "${FIND}" ]; then
                         Report "allow-auto-purge=1"
                     else
@@ -119,7 +120,7 @@
                 colors)
                     # Quick mode (SKIP_PLUGINS) might already be set outside profile, so store in different variable
                     SETTING_COLORS=1 # default is yes
-                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && COLORS=0
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(0|false|no)$") && COLORS=0
                     if [ -n "${FIND}" ]; then SETTING_COLORS=0; RemoveColors; fi
                     Debug "Colors set to ${SETTING_COLORS}"
                     AddSetting "colors" "${SETTING_COLORS}" "Colored screen output"
@@ -175,27 +176,27 @@
 
                 # Do not check security repository in sources.list (Debian/Ubuntu)
                 debian-skip-security-repository | debian_skip_security_repository)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && OPTION_DEBIAN_SKIP_SECURITY_REPOSITORY=1 
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" "^(1|true|yes)") && OPTION_DEBIAN_SKIP_SECURITY_REPOSITORY=1 
                     AddSetting "debian-skip-security-repository" "OPTION_DEBIAN_SKIP_SECURITY_REPOSITORY" "Skip checking for a security repository (Debian and others)"
                 ;;
 
                 # Debug status to show more details while running program
                 debug)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && DEBUG=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)") && DEBUG=1
                     Debug "Debug mode set to '${DEBUG}'"
                     AddSetting "debug" "${DEBUG}" "Debugging mode"
                 ;;
 
                 # Development mode (--developer)
                 developer-mode)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && DEVELOPER_MODE=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)") && DEVELOPER_MODE=1
                     Debug "Developer mode set to ${DEVELOPER_MODE}"
                     AddSetting "developer" "${DEVELOPER_MODE}" "Developer mode"
                 ;;
 
                 # Show non-zero exit code when errors are found
                 error-on-warnings)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && ERROR_ON_WARNINGS=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)") && ERROR_ON_WARNINGS=1
                     Debug "Exit with different code on warnings is set to ${ERROR_ON_WARNINGS}"
                     AddSetting "error-on-warnings" "${ERROR_ON_WARNINGS}" "Use non-zero exit code if one or more warnings were found"
                 ;;
@@ -248,7 +249,7 @@
 
                 # Do (not) log tests if they have an different operating system
                 log-tests-incorrect-os | log_tests_incorrect_os)
-                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)") && SETTING_LOG_TESTS_INCORRECT_OS=0
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(0|false|no)") && SETTING_LOG_TESTS_INCORRECT_OS=0
                     Debug "Logging of tests with incorrect operating system set to ${SETTING_LOG_TESTS_INCORRECT_OS}"
                     LOG_INCORRECT_OS=${SETTING_LOG_TESTS_INCORRECT_OS}
                 ;;
@@ -300,7 +301,7 @@
                 quick)
                     # Quick mode might already be set outside profile, so store in different variable
                     SETTING_QUICK_MODE=1 # default is yes
-                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && QUICKMODE=0
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(0|false|no)$") && QUICKMODE=0
                     if [ -n "${FIND}" ]; then SETTING_QUICK_MODE=1; fi
                     Debug "Quickmode set to ${SETTING_QUICK_MODE}"
                     AddSetting "quick" "${SETTING_QUICK_MODE}" "Quick mode (non-interactive)"
@@ -309,7 +310,7 @@
                 # Refresh software repositories
                 refresh-repositories)
                     SETTING_REFRESH_REPOSITORIES=1 # default is yes
-                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && REFRESH_REPOSITORIES=0
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(0|false|no)$") && REFRESH_REPOSITORIES=0
                     if [ -n "${FIND}" ]; then SETTING_REFRESH_REPOSITORIES=0; fi
                     Debug "Refreshing repositories set to ${SETTING_REFRESH_REPOSITORIES}"
                     AddSetting "refresh-repositories" "${SETTING_REFRESH_REPOSITORIES}" "Refresh repositories (for vulnerable package detection)"
@@ -318,7 +319,7 @@
                 # Show more details in report
                 show-report-solution)
                     SETTING_SHOW_REPORT_SOLUTION=${SHOW_REPORT_SOLUTION}
-                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && SHOW_REPORT_SOLUTION=0
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(0|false|no)$") && SHOW_REPORT_SOLUTION=0
                     if [ -n "${FIND}" ]; then SETTING_SHOW_REPORT_SOLUTION=0; fi
                     Debug "Show report details (solution) set to ${SETTING_SHOW_REPORT_SOLUTION}"
                 ;;
@@ -326,7 +327,7 @@
                 # Inline tips about tool (default enabled)
                 show_tool_tips | show-tool-tips)
                     SETTING_SHOW_TOOL_TIPS=1 # default is yes
-                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && SHOW_TOOL_TIPS=0
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(0|false|no)$") && SHOW_TOOL_TIPS=0
                     if [ -n "${FIND}" ]; then SETTING_SHOW_TOOL_TIPS=0; fi
                     Debug "Show tool tips set to ${SETTING_SHOW_TOOL_TIPS}"
                     AddSetting "show-tool-tips" "${SETTING_SHOW_TOOL_TIPS}" "Show tool tips"
@@ -336,7 +337,7 @@
                 show-warnings-only)
                     QUIET=1
                     QUICKMODE=1
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$") && SHOW_WARNINGS_ONLY=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)$") && SHOW_WARNINGS_ONLY=1
                     Debug "Show warnings only set to ${SHOW_WARNINGS_ONLY}"
                     AddSetting "show-warnings-only" "${SHOW_WARNINGS_ONLY}" "Show only warnings"
                 ;;
@@ -345,7 +346,7 @@
                 skip-plugins)
                     # Skip plugins (SKIP_PLUGINS) might already be set, so store in different variable
                     SETTING_SKIP_PLUGINS=0 # default is no
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$") && SKIP_PLUGINS=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)$") && SKIP_PLUGINS=1
                     if [ -n "${FIND}" ]; then SETTING_SKIP_PLUGINS=1; fi
                     Debug "Skip plugins is set to ${SETTING_SKIP_PLUGINS}"
                     AddSetting "skip-plugins" "${SETTING_SKIP_PLUGINS}" "Skip plugins"
@@ -359,7 +360,7 @@
 
                 # Do not check the latest version on the internet
                 skip_upgrade_test | skip-upgrade-test)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && SKIP_UPGRADE_TEST=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)") && SKIP_UPGRADE_TEST=1
                     Debug "Skip upgrade test set to ${SKIP_UPGRADE_TEST}"
                 ;;
 
@@ -379,14 +380,14 @@
 
                 # Check also certificates provided by packages?
                 ssl-certificate-include-packages)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && SSL_CERTIFICATE_INCLUDE_PACKAGES=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)") && SSL_CERTIFICATE_INCLUDE_PACKAGES=1
                     Debug "Check also certificates provided by packages set to ${SSL_CERTIFICATE_INCLUDE_PACKAGES}"
                 ;;
 
 
                 # Set strict mode for development and quality purposes
                 strict)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && SET_STRICT=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)") && SET_STRICT=1
                 ;;
 
                 # The name of the customer/client that uses this system
@@ -415,7 +416,7 @@
                 # Perform upload
                 upload)
                     SETTING_UPLOAD=no # default
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$") && UPLOAD_DATA=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)$") && UPLOAD_DATA=1
                     if [ -n "${FIND}" ]; then SETTING_UPLOAD=1; fi
                     Debug "Upload set to ${SETTING_UPLOAD}"
                     AddSetting "upload" "${SETTING_UPLOAD}" "Data upload after scanning"
@@ -469,7 +470,7 @@
 
                 # Verbose output (--verbose)
                 verbose)
-                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && VERBOSE=1
+                    FIND=$(echo "${VALUE}" | "${GREPBINARY}" -E "^(1|true|yes)") && VERBOSE=1
                     Debug "Verbose set to ${VERBOSE}"
                     AddSetting "verbose" "${VERBOSE}" "Verbose output"
                 ;;

--- a/include/profiles
+++ b/include/profiles
@@ -35,7 +35,7 @@
 
         # Show deprecation message for old config entries such as 'config:' and 'apache:'
         FOUND=0
-        DATA=$(grep -E "^[a-z-]{1,}:" ${PROFILE} | od -An -ta | sed 's/ /!space!/g')  # od -An (no file offset), -ta (named character, to be on safe side)
+        DATA=$(egrep "^[a-z-]{1,}:" ${PROFILE} | od -An -ta | sed 's/ /!space!/g')  # od -An (no file offset), -ta (named character, to be on safe side)
         if ! IsEmpty "${DATA}"; then FOUND=1; fi
 
         if [ ${FOUND} -eq 1 ]; then
@@ -46,7 +46,7 @@
             Display --indent 2 --text "Your profile has one or more lines that are in an old format (key:value). They need to be converted into the new format (key=value) or disabled."
             Display --text " "
             Display --indent 2 --text "* ${GREEN}HOW TO RESOLVE${NORMAL}"
-            Display --indent 2 --text "Use grep to see the relevant matches (grep -E \"^[a-z-]{1,}:\" custom.prf)"
+            Display --indent 2 --text "Use grep to see the relevant matches (egrep \"^[a-z-]{1,}:\" custom.prf)"
             Display --text " "
             Display --text "=================================================================================================="
             Display --text " "
@@ -56,7 +56,7 @@
         fi
 
         # Security check for unexpected and possibly harmful escape characters (hyphen should be listed as first or last character)
-        DATA=$(grep -Ev '^$|^ |^#|^config:' "${PROFILE}" | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | od -An -ta | sed 's/ /!space!/g')
+        DATA=$(egrep -v '^$|^ |^#|^config:' "${PROFILE}" | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | od -An -ta | sed 's/ /!space!/g')
         if ! IsEmpty "${DATA}"; then
             DisplayWarning "Your profile '${PROFILE}' contains unexpected characters. See the log file for more information."
             LogText "Found unexpected or possibly harmful characters in profile '${PROFILE}'. See which characters matched in the output below and compare them with your profile."
@@ -69,7 +69,7 @@
         fi
 
         # Now parse the profile and filter out unwanted characters
-        DATA=$(grep -E "^config:|^[a-z-].*=" ${PROFILE} | tr -dc '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | sed 's/ /!space!/g')
+        DATA=$(egrep "^config:|^[a-z-].*=" ${PROFILE} | tr -dc '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | sed 's/ /!space!/g')
         for CONFIGOPTION in ${DATA}; do
             if ContainsString "^config:" "${CONFIGOPTION}"; then
                 # Old style configuration
@@ -86,7 +86,7 @@
 
                 # Is Lynis Enterprise allowed to purge this system when it is becomes outdated?
                 allow-auto-purge)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)$")
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$")
                     if [ -n "${FIND}" ]; then
                         Report "allow-auto-purge=1"
                     else
@@ -119,7 +119,7 @@
                 colors)
                     # Quick mode (SKIP_PLUGINS) might already be set outside profile, so store in different variable
                     SETTING_COLORS=1 # default is yes
-                    FIND=$(echo "${VALUE}" | grep -E "^(0|false|no)$") && COLORS=0
+                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && COLORS=0
                     if [ -n "${FIND}" ]; then SETTING_COLORS=0; RemoveColors; fi
                     Debug "Colors set to ${SETTING_COLORS}"
                     AddSetting "colors" "${SETTING_COLORS}" "Colored screen output"
@@ -175,27 +175,27 @@
 
                 # Do not check security repository in sources.list (Debian/Ubuntu)
                 debian-skip-security-repository | debian_skip_security_repository)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && OPTION_DEBIAN_SKIP_SECURITY_REPOSITORY=1 
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && OPTION_DEBIAN_SKIP_SECURITY_REPOSITORY=1 
                     AddSetting "debian-skip-security-repository" "OPTION_DEBIAN_SKIP_SECURITY_REPOSITORY" "Skip checking for a security repository (Debian and others)"
                 ;;
 
                 # Debug status to show more details while running program
                 debug)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && DEBUG=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && DEBUG=1
                     Debug "Debug mode set to '${DEBUG}'"
                     AddSetting "debug" "${DEBUG}" "Debugging mode"
                 ;;
 
                 # Development mode (--developer)
                 developer-mode)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && DEVELOPER_MODE=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && DEVELOPER_MODE=1
                     Debug "Developer mode set to ${DEVELOPER_MODE}"
                     AddSetting "developer" "${DEVELOPER_MODE}" "Developer mode"
                 ;;
 
                 # Show non-zero exit code when errors are found
                 error-on-warnings)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && ERROR_ON_WARNINGS=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && ERROR_ON_WARNINGS=1
                     Debug "Exit with different code on warnings is set to ${ERROR_ON_WARNINGS}"
                     AddSetting "error-on-warnings" "${ERROR_ON_WARNINGS}" "Use non-zero exit code if one or more warnings were found"
                 ;;
@@ -248,7 +248,7 @@
 
                 # Do (not) log tests if they have an different operating system
                 log-tests-incorrect-os | log_tests_incorrect_os)
-                    FIND=$(echo "${VALUE}" | grep -E "^(0|false|no)") && SETTING_LOG_TESTS_INCORRECT_OS=0
+                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)") && SETTING_LOG_TESTS_INCORRECT_OS=0
                     Debug "Logging of tests with incorrect operating system set to ${SETTING_LOG_TESTS_INCORRECT_OS}"
                     LOG_INCORRECT_OS=${SETTING_LOG_TESTS_INCORRECT_OS}
                 ;;
@@ -300,7 +300,7 @@
                 quick)
                     # Quick mode might already be set outside profile, so store in different variable
                     SETTING_QUICK_MODE=1 # default is yes
-                    FIND=$(echo "${VALUE}" | grep -E "^(0|false|no)$") && QUICKMODE=0
+                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && QUICKMODE=0
                     if [ -n "${FIND}" ]; then SETTING_QUICK_MODE=1; fi
                     Debug "Quickmode set to ${SETTING_QUICK_MODE}"
                     AddSetting "quick" "${SETTING_QUICK_MODE}" "Quick mode (non-interactive)"
@@ -309,7 +309,7 @@
                 # Refresh software repositories
                 refresh-repositories)
                     SETTING_REFRESH_REPOSITORIES=1 # default is yes
-                    FIND=$(echo "${VALUE}" | grep -E "^(0|false|no)$") && REFRESH_REPOSITORIES=0
+                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && REFRESH_REPOSITORIES=0
                     if [ -n "${FIND}" ]; then SETTING_REFRESH_REPOSITORIES=0; fi
                     Debug "Refreshing repositories set to ${SETTING_REFRESH_REPOSITORIES}"
                     AddSetting "refresh-repositories" "${SETTING_REFRESH_REPOSITORIES}" "Refresh repositories (for vulnerable package detection)"
@@ -318,7 +318,7 @@
                 # Show more details in report
                 show-report-solution)
                     SETTING_SHOW_REPORT_SOLUTION=${SHOW_REPORT_SOLUTION}
-                    FIND=$(echo "${VALUE}" | grep -E "^(0|false|no)$") && SHOW_REPORT_SOLUTION=0
+                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && SHOW_REPORT_SOLUTION=0
                     if [ -n "${FIND}" ]; then SETTING_SHOW_REPORT_SOLUTION=0; fi
                     Debug "Show report details (solution) set to ${SETTING_SHOW_REPORT_SOLUTION}"
                 ;;
@@ -326,7 +326,7 @@
                 # Inline tips about tool (default enabled)
                 show_tool_tips | show-tool-tips)
                     SETTING_SHOW_TOOL_TIPS=1 # default is yes
-                    FIND=$(echo "${VALUE}" | grep -E "^(0|false|no)$") && SHOW_TOOL_TIPS=0
+                    FIND=$(echo "${VALUE}" | egrep "^(0|false|no)$") && SHOW_TOOL_TIPS=0
                     if [ -n "${FIND}" ]; then SETTING_SHOW_TOOL_TIPS=0; fi
                     Debug "Show tool tips set to ${SETTING_SHOW_TOOL_TIPS}"
                     AddSetting "show-tool-tips" "${SETTING_SHOW_TOOL_TIPS}" "Show tool tips"
@@ -336,7 +336,7 @@
                 show-warnings-only)
                     QUIET=1
                     QUICKMODE=1
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)$") && SHOW_WARNINGS_ONLY=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$") && SHOW_WARNINGS_ONLY=1
                     Debug "Show warnings only set to ${SHOW_WARNINGS_ONLY}"
                     AddSetting "show-warnings-only" "${SHOW_WARNINGS_ONLY}" "Show only warnings"
                 ;;
@@ -345,7 +345,7 @@
                 skip-plugins)
                     # Skip plugins (SKIP_PLUGINS) might already be set, so store in different variable
                     SETTING_SKIP_PLUGINS=0 # default is no
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)$") && SKIP_PLUGINS=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$") && SKIP_PLUGINS=1
                     if [ -n "${FIND}" ]; then SETTING_SKIP_PLUGINS=1; fi
                     Debug "Skip plugins is set to ${SETTING_SKIP_PLUGINS}"
                     AddSetting "skip-plugins" "${SETTING_SKIP_PLUGINS}" "Skip plugins"
@@ -359,7 +359,7 @@
 
                 # Do not check the latest version on the internet
                 skip_upgrade_test | skip-upgrade-test)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && SKIP_UPGRADE_TEST=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && SKIP_UPGRADE_TEST=1
                     Debug "Skip upgrade test set to ${SKIP_UPGRADE_TEST}"
                 ;;
 
@@ -379,14 +379,14 @@
 
                 # Check also certificates provided by packages?
                 ssl-certificate-include-packages)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && SSL_CERTIFICATE_INCLUDE_PACKAGES=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && SSL_CERTIFICATE_INCLUDE_PACKAGES=1
                     Debug "Check also certificates provided by packages set to ${SSL_CERTIFICATE_INCLUDE_PACKAGES}"
                 ;;
 
 
                 # Set strict mode for development and quality purposes
                 strict)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && SET_STRICT=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && SET_STRICT=1
                 ;;
 
                 # The name of the customer/client that uses this system
@@ -415,7 +415,7 @@
                 # Perform upload
                 upload)
                     SETTING_UPLOAD=no # default
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)$") && UPLOAD_DATA=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)$") && UPLOAD_DATA=1
                     if [ -n "${FIND}" ]; then SETTING_UPLOAD=1; fi
                     Debug "Upload set to ${SETTING_UPLOAD}"
                     AddSetting "upload" "${SETTING_UPLOAD}" "Data upload after scanning"
@@ -469,7 +469,7 @@
 
                 # Verbose output (--verbose)
                 verbose)
-                    FIND=$(echo "${VALUE}" | grep -E "^(1|true|yes)") && VERBOSE=1
+                    FIND=$(echo "${VALUE}" | egrep "^(1|true|yes)") && VERBOSE=1
                     Debug "Verbose set to ${VERBOSE}"
                     AddSetting "verbose" "${VERBOSE}" "Verbose output"
                 ;;

--- a/include/tests_scheduling
+++ b/include/tests_scheduling
@@ -60,7 +60,7 @@
 
         CRONTAB_FILE="${ROOTDIR}etc/crontab"
         if [ -f ${CRONTAB_FILE} ]; then
-            ${EGREPBINARY} -q -s 'lynis audit system' ${CRONTAB_FILE} && LYNIS_CRONJOB="file:/etc/crontab"
+            ${EGREPBINARY} -s 'lynis audit system' ${CRONTAB_FILE} > /dev/null && LYNIS_CRONJOB="file:/etc/crontab"
             if IsWorldWritable ${CRONTAB_FILE}; then LogText "Result: insecure file permissions for cronjob file ${CRONTAB_FILE}"; Report "insecure_fileperms_cronjob[]=${CRONTAB_FILE}"; BAD_FILE_PERMISSIONS=1; AddHP 0 5; fi
             if ! IsOwnedByRoot ${CRONTAB_FILE}; then LogText "Result: incorrect owner found for cronjob file ${CRONTAB_FILE}"; Report "bad_fileowner_cronjob[]=${CRONTAB_FILE}"; BAD_FILE_OWNERSHIP=1; AddHP 0 5; fi
             FindCronJob ${CRONTAB_FILE}
@@ -86,7 +86,7 @@
                             if IsWorldWritable ${FILE}; then LogText "Result: insecure file permissions for cronjob file ${J}"; Report "insecure_fileperms_cronjob[]=${J}"; BAD_FILE_PERMISSIONS=1; AddHP 0 5; fi
                             if ! IsOwnedByRoot ${FILE}; then LogText "Result: incorrect owner found for cronjob file ${J}"; Report "bad_fileowner_cronjob[]=${J}"; BAD_FILE_OWNERSHIP=1; AddHP 0 5; fi
                             FILENAME=$(echo ${FILE} | ${AWKBINARY} -F/ '{print $NF}')
-                            if [ "${FILENAME}" = "lynis" ]; then ${EGREPBINARY} -q -s 'lynis audit system' ${CRONTAB_FILE} && LYNIS_CRONJOB="file:${FILE}"; fi
+                            if [ "${FILENAME}" = "lynis" ]; then ${EGREPBINARY} -s 'lynis audit system' ${CRONTAB_FILE} > /dev/null && LYNIS_CRONJOB="file:${FILE}"; fi
                             FindCronJob ${FILE}
                             if HasData "${sCRONJOBS}"; then
                                 for K in ${sCRONJOBS}; do
@@ -121,7 +121,7 @@
                             if IsWorldWritable ${FILE}; then LogText "Result: insecure file permissions for cronjob file ${FILE}"; Report "insecure_fileperms_cronjob[]=${FILE}"; BAD_FILE_PERMISSIONS=1; AddHP 0 5; fi
                             if ! IsOwnedByRoot ${FILE}; then LogText "Result: incorrect owner found for cronjob file ${FILE}"; Report "bad_fileowner_cronjob[]=${FILE}"; BAD_FILE_OWNERSHIP=1; AddHP 0 5; fi
                             FILENAME=$(echo ${FILE} | ${AWKBINARY} -F/ '{print $NF}')
-                            if [ "${FILENAME}" = "lynis" ]; then ${EGREPBINARY} -q -s 'lynis audit system' ${CRONTAB_FILE} && LYNIS_CRONJOB="file:${FILE}"; fi
+                            if [ "${FILENAME}" = "lynis" ]; then ${EGREPBINARY} -s 'lynis audit system' ${CRONTAB_FILE} > /dev/null && LYNIS_CRONJOB="file:${FILE}"; fi
                             LogText "Result: Found cronjob (${I}): ${FILE}"
                             Report "cronjob[]=${FILE}"
                         done
@@ -141,7 +141,7 @@
             FIND=$(${FINDBINARY} /var/spool/cron/crontabs -xdev -type f -print 2> /dev/null)
             for I in ${FIND}; do
                 if FileIsReadable ${I}; then
-                    ${EGREPBINARY} -q -s 'lynis audit system' ${I} && LYNIS_CRONJOB="file:${I}"
+                    ${EGREPBINARY} -s 'lynis audit system' ${I} > /dev/null && LYNIS_CRONJOB="file:${I}"
                     FindCronJob ${I}
                     for FILE in ${sCRONJOBS}; do
                         LogText "Found cronjob (/var/spool/cron/crontabs): ${I} (${FILE})"
@@ -154,7 +154,7 @@
                 FIND=$(find ${ROOTDIR}var/spool/cron -type f -print)
                 for I in ${FIND}; do
                     if FileIsReadable ${I}; then
-                        ${EGREPBINARY} -q -s 'lynis audit system' ${I} && LYNIS_CRONJOB="file:${I}"
+                        ${EGREPBINARY} -s 'lynis audit system' ${I} > /dev/null && LYNIS_CRONJOB="file:${I}"
                         FindCronJob ${I}
                         for FILE in ${sCRONJOBS}; do
                             LogText "Found cronjob in ${ROOTDIR}var/spool/cron: ${I} (${FILE})"


### PR DESCRIPTION
On Solaris the default grep does not support `-E` and `-q`.  The first issue is fixed by using X/Open grep from `/usr/xpg4/bin/grep` and the latter by using shell redirections instead.

`awk` is replaced by `nawk` on Solaris, too, as only the latter has the required feature set.