### PR TITLE
Test if /etc/grub.d is a directory

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -332,7 +332,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         FOUND=0
 
-        if [ "${ROOTDIR}etc/grub.d" ]; then
+        if [ -d "${ROOTDIR}etc/grub.d" ]; then
             CONF_FILES=$(${FINDBINARY} "${ROOTDIR}etc/grub.d" -type f -name "[0-9][0-9]*" -print0 | ${TRBINARY} '\0' ' ' | ${TRBINARY} -d '[:cntrl:]')
             CONF_FILES="${GRUBCONFFILE} ${ROOTDIR}boot/grub/custom.cfg ${CONF_FILES}"
         else


### PR DESCRIPTION
Part of the Solaris fixes of #1007, but is likely relevant for other operating systems as well.