### PR TITLE
Simplify tr hostname checking expression

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -70,7 +70,7 @@
                 LogText "Result: hostnamed is defined and not longer than 63 characters"
             fi
             # Test valid characters (normally a dot should not be in the name, but we can't be 100% sure we have short name)
-            FIND=$(echo "${HOSTNAME}" | ${TRBINARY} -d '[a-zA-Z0-9\.\-]')
+            FIND=$(echo "${HOSTNAME}" | ${TRBINARY} -d '[:alpha:]' | ${TRBINARY} -d '.-')
             if [ -z "${FIND}" ]; then
                 LogText "Result: good, no unexpected characters discovered in hostname"
                 if IsVerbose; then Display --indent 2 --text "- Hostname (allowed characters)" --result "${STATUS_OK}" --color GREEN; fi

--- a/include/tests_networking
+++ b/include/tests_networking
@@ -70,7 +70,7 @@
                 LogText "Result: hostnamed is defined and not longer than 63 characters"
             fi
             # Test valid characters (normally a dot should not be in the name, but we can't be 100% sure we have short name)
-            FIND=$(echo "${HOSTNAME}" | ${TRBINARY} -d '[:alpha:]' | ${TRBINARY} -d '.-')
+            FIND=$(echo "${HOSTNAME}" | ${TRBINARY} -d '[:alnum:]\.\-')
             if [ -z "${FIND}" ]; then
                 LogText "Result: good, no unexpected characters discovered in hostname"
                 if IsVerbose; then Display --indent 2 --text "- Hostname (allowed characters)" --result "${STATUS_OK}" --color GREEN; fi


### PR DESCRIPTION
Solaris' tr does not support full regular expressions.