### PR TITLE
Test if loghost is not localhost

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -228,6 +228,7 @@ LOGG-2146:test:security:logging::Checking logrotate.conf and logrotate.d:
 LOGG-2148:test:security:logging::Checking logrotated files:
 LOGG-2150:test:security:logging::Checking directories in logrotate configuration:
 LOGG-2152:test:security:logging::Checking loghost:
+LOGG-2153:test:security:logging::Checking loghost is not localhost:
 LOGG-2154:test:security:logging::Checking syslog configuration file:
 LOGG-2160:test:security:logging::Checking /etc/newsyslog.conf:
 LOGG-2162:test:security:logging::Checking directories in /etc/newsyslog.conf:

--- a/include/tests_logging
+++ b/include/tests_logging
@@ -28,7 +28,9 @@
     METALOG_RUNNING=0
     RFC3195D_RUNNING=0
     RSYSLOG_RUNNING=0
+    SOLARIS_LOGHOST=""
     SOLARIS_LOGHOST_FOUND=0
+    SOLARIS_LOGHOST_LOCALHOST=0
     SYSLOG_DAEMON_PRESENT=0
     SYSLOG_DAEMON_RUNNING=0
     SYSLOG_NG_RUNNING=0
@@ -305,6 +307,7 @@
         LogText "Result: Checking for loghost in /etc/inet/hosts"
         FIND=$(${GREPBINARY} loghost /etc/inet/hosts | ${GREPBINARY} -v "^#")
         if [ -n "${FIND}" ]; then
+            SOLARIS_LOGHOST="${FIND}"
             SOLARIS_LOGHOST_FOUND=1
             LogText "Result: Found loghost entry in /etc/inet/hosts"
         else
@@ -314,6 +317,7 @@
             LogText "Result: Checking for loghost via name resolving"
             FIND=$(getent hosts loghost | ${GREPBINARY} loghost)
             if [ -n "${FIND}" ]; then
+                SOLARIS_LOGHOST="${FIND"
                 SOLARIS_LOGHOST_FOUND=1
                 LogText "Result: name resolving was successful"
                 LogText "Output: ${FIND}"
@@ -332,6 +336,26 @@
             ReportSuggestion "${TEST_NO}" "Add a loghost entry to /etc/inet/hosts or other name services"
         fi
     fi
+#
+#################################################################################
+#
+    # Test        : LOGG-2153
+    # Description : Check Solaris 'loghost' entry is not localhost, meaning
+    #               remote logging is not configured.
+    if [ ${SOLARIS_LOGHOST_FOUND} -eq 1 ] && [ -n "${SOLARIS_LOGHOST}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no LOGG-2153 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Checking loghost is localhost"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        FIND=$(echo "${SOLARIS_LOGHOST}" | ${AWKBINARY} '{ print $1 }' | ${EGREPBINARY} "::1|127.0.0.1|127.1")
+        if [ -n "${FIND}" ]; then
+            SOLARIS_LOGHOST_LOCALHOST=1
+            LogText "Result: loghost entry is localhost (default)"
+            Display --indent 4 --text "- Checking loghost entry is localhost" --result "${STATUS_YES}" --color YELLOW
+            ReportSuggestion "${TEST_NO}" "Set loghost entry to a remote location to enable remote logging."
+        else
+            Display --indent 4 --text "- Checking loghost entry is localhost" --result "${STATUS_NO}" --color GREEN
+        fi
+    fi
+
 #
 #################################################################################
 #
@@ -402,8 +426,13 @@
             LogText "Test: check if logs are also logged to a remote logging host"
             FIND=$(${EGREPBINARY} "@[a-zA-Z0-9]|destination\s.+(udp|tcp).+\sport" ${SYSLOGD_CONF} | ${GREPBINARY} -v "^#" | ${GREPBINARY} -v "[a-zA-Z0-9]@")
             if [ -n "${FIND}" ]; then
-                LogText "Result: remote logging enabled"
-                REMOTE_LOGGING_ENABLED=1
+                FIND2=$(echo "${FIND}" | ${GREPBINARY} -v "@loghost")
+                if [ SOLARIS_LOGHOST_LOCALHOST -eq 1 ] && [ -z "${FIND2}" ]; then
+                    LogText "Result: remote logging enabled to loghost, but loghost is localhost"
+                else
+                    LogText "Result: remote logging enabled"
+                    REMOTE_LOGGING_ENABLED=1
+                fi
             else
                 # Search for configured destinations with an IP address or hostname, then determine which ones are used as a log destination
                 DESTINATIONS=$(${GREPBINARY} "^destination" ${SYSLOGD_CONF} | ${EGREPBINARY} "(udp|tcp)" | ${GREPBINARY} "port" | ${AWKBINARY} '{print $2}')


### PR DESCRIPTION
On Solaris, the name loghost can be used to point to remote log servers.
By default loghost is configured to 127.0.0.1, logging to the local
machine.

Thus a new test - LOGG-2153 - is created to test if loghost is not
localhost and LOGG-2154 is modified to ignore @loghost lines if loghost
is localhost.