### PR TITLE
Add support for Solaris Image Packaging System (IPS)

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -329,6 +329,10 @@ PKGS-7328:test:security:ports_packages::Querying Zypper for installed packages:
 PKGS-7330:test:security:ports_packages::Querying Zypper for vulnerable packages:
 PKGS-7332:test:security:ports_packages::Detection of macOS ports and packages:
 PKGS-7334:test:security:ports_packages::Detection of available updates for macOS ports:
+PKGS-7338:test:security:ports_packages::Query Solaris IPS (pkg):
+PKGS-7339:test:security:ports_packages::Query Solaris IPS for available updates:
+PKGS-7340:test:security:ports_packages::Check support repository is installed:
+PKGS-7341:test:security:ports_packages::Check patch metadata installed (solaris-11-cpu):
 PKGS-7345:test:security:ports_packages::Querying dpkg:
 PKGS-7346:test:security:ports_packages::Search unpurged packages on system:
 PKGS-7348:test:security:ports_packages:FreeBSD:Check for old distfiles:

--- a/db/tests.db
+++ b/db/tests.db
@@ -329,10 +329,10 @@ PKGS-7328:test:security:ports_packages::Querying Zypper for installed packages:
 PKGS-7330:test:security:ports_packages::Querying Zypper for vulnerable packages:
 PKGS-7332:test:security:ports_packages::Detection of macOS ports and packages:
 PKGS-7334:test:security:ports_packages::Detection of available updates for macOS ports:
-PKGS-7338:test:security:ports_packages::Query Solaris IPS (pkg):
-PKGS-7339:test:security:ports_packages::Query Solaris IPS for available updates:
-PKGS-7340:test:security:ports_packages::Check support repository is installed:
-PKGS-7341:test:security:ports_packages::Check patch metadata installed (solaris-11-cpu):
+PKGS-7338:test:security:ports_packages:Solaris:Query Solaris Image Packaging System (IPS = pkg(5)):
+PKGS-7339:test:security:ports_packages:Solaris:Query Solaris Image Packaging System (IPS) for available updates:
+PKGS-7340:test:security:ports_packages:Solaris:Check support repository is installed:
+PKGS-7341:test:security:ports_packages:Solaris:Check patch metadata installed (solaris-11-cpu):
 PKGS-7345:test:security:ports_packages::Querying dpkg:
 PKGS-7346:test:security:ports_packages::Search unpurged packages on system:
 PKGS-7348:test:security:ports_packages:FreeBSD:Check for old distfiles:

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -445,7 +445,7 @@
 
     # This test is set at this position to have all ips tests directly after each other
     # Future evaluation: Check if PKGS-7326 should be skipped on modern Solaris
-    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7338 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS"
     if [ ${SKIPTEST} -eq 0 ]; then
         Display --indent 4 --text "- Searching IPS (pkg)" --result "${STATUS_FOUND}" --color GREEN
@@ -470,7 +470,7 @@
     # Description : Query Solaris IPS for available updates
     # Note        : Restricted to Solaris 11
 
-    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7339 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS for available updates"
     if [ ${SKIPTEST} -eq 0 ]; then
         FIND=$(${PKG_BINARY} list -u | tail +2 | ${AWKBINARY} '{ print $1 }')
@@ -498,7 +498,7 @@
     # Description : Check support repository is installed
     # Note        : Restricted to Solaris 11
 
-    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7340 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check support repository is installed"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Checking for Solaris support repository"
@@ -520,7 +520,7 @@
     # Description : Check patch metadata is installed (solaris-11-cpu)
     # Note        : Restricted to Solaris 11
 
-    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7341 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check patch metadata is installed (solaris-11-cpu)"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Checking if patch metadata is installed (solaris-11-cpu)"

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -453,7 +453,7 @@
         Display --indent 4 --text "- Searching Image Packaging System (IPS = pkg(5))" --result "${STATUS_FOUND}" --color GREEN
         LogText "Result: Found Solaris Image Packaging System (IPS)"
         Report "package_manager[]=ips"
-        PACKAGE_MGR_PKS=1i
+        PACKAGE_MGR_PKG=1
         IPS_TESTS_INDENT=6
         LogText "Test: Querying IPS to get package list"
         Display --indent 6 --text "- Querying for installed packages"

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -481,7 +481,7 @@
         for PACKAGE in ${FIND}; do
             COUNT=$((COUNT + 1))
             LogText "Update available: ${PACKAGE}"
-            Report "available_update[]=${J}"
+            Report "available_update[]=${PACKAGE}"
         done
 
         if [ $COUNT -eq 0 ]; then

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -440,7 +440,7 @@
 #################################################################################
 #
     # Test        : PKGS-7338
-    # Description : Query Solaris Image Packaging System (IPS)
+    # Description : Query Solaris Image Packaging System (IPS = pkg(5))
     # Note        : Restricted to Solaris 11
 
     # This test is set at this position to have all ips tests directly after each other
@@ -448,12 +448,12 @@
     if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7338 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS"
     if [ ${SKIPTEST} -eq 0 ]; then
-        Display --indent 4 --text "- Searching Image Packaging System (IPS, \"pkg\")" --result "${STATUS_FOUND}" --color GREEN
-        LogText "Result: Found Solaris Image Packaging System (IPS, \"pkg\")"
+        Display --indent 4 --text "- Searching Image Packaging System (IPS = pkg(5))" --result "${STATUS_FOUND}" --color GREEN
+        LogText "Result: Found Solaris Image Packaging System (IPS)"
         Report "package_manager[]=ips"
         PACKAGE_MGR_PKS=1
         LogText "Test: Querying IPS to get package list"
-        Display --indent 4 --text "- Querying IPS for installed packages"
+        Display --indent 4 --text "- Querying Image Packaging System (IPS) for installed packages"
         LogText "Output:"; LogText "-----"
         SPACKAGES=$(${PKG_BINARY} list | ${AWKBINARY} '{ print $1","$2 }')
         for ITEM in ${SPACKAGES}; do
@@ -482,12 +482,12 @@
         done
 
         if [ $COUNT -eq 0 ]; then
-            Display --indent 4 --text "- Checking IPS for updates" --result "${STATUS_NONE}" --color GREEN
+            Display --indent 4 --text "- Checking Image Packaging System (IPS) for updates" --result "${STATUS_NONE}" --color GREEN
             LogText "No updates available"
             AddHP 2 2
         else
-            Display --indent 4 --text "- Checking IPS for updates" --result "${STATUS_FOUND}" --color YELLOW
-            ReportSuggestion "${TEST_NO}" "Update your system with IPS"
+            Display --indent 4 --text "- Checking Image Packaging System (IPS) for updates" --result "${STATUS_FOUND}" --color YELLOW
+            ReportSuggestion "${TEST_NO}" "Update your system with pkg(5)" "pkg update" "-"
             AddHP 0 2
         fi
     fi
@@ -504,11 +504,11 @@
         LogText "Checking for Solaris support repository"
         FIND=$(${PKG_BINARY} publisher | ${GREPBINARY} https://pkg.oracle.com/solaris/support)
         if [ -n "${FIND}" ]; then
-            Display --indent 4 --text "- Checking IPS for support repository" --result "${STATUS_FOUND}" --color GREEN
+            Display --indent 4 --text "- Checking Image Packaging System (IPS) for support repository" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found solaris support repository"
             AddHP 3 3
         else
-            Display --indent 4 --text "- Checking IPS for support repository " --result "${STATUS_NOT_FOUND}" --color RED
+            Display --indent 4 --text "- Checking Image Packaging System (IPS) for support repository " --result "${STATUS_NOT_FOUND}" --color RED
             ReportWarning "${TEST_NO}" "Solaris support repository not installed" "The support repository contains important updates" "url:https://docs.oracle.com/cd/E36784_01/html/E39134/repose-1.html"
             AddHP 0 3
         fi

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -445,15 +445,18 @@
 
     # This test is set at this position to have all ips tests directly after each other
     # Future evaluation: Check if PKGS-7326 should be skipped on modern Solaris
+    IPS_TESTS_INDENT=4
+
     if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7338 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS"
     if [ ${SKIPTEST} -eq 0 ]; then
         Display --indent 4 --text "- Searching Image Packaging System (IPS = pkg(5))" --result "${STATUS_FOUND}" --color GREEN
         LogText "Result: Found Solaris Image Packaging System (IPS)"
         Report "package_manager[]=ips"
-        PACKAGE_MGR_PKS=1
+        PACKAGE_MGR_PKS=1i
+        IPS_TESTS_INDENT=6
         LogText "Test: Querying IPS to get package list"
-        Display --indent 4 --text "- Querying Image Packaging System (IPS) for installed packages"
+        Display --indent 6 --text "- Querying for installed packages"
         LogText "Output:"; LogText "-----"
         SPACKAGES=$(${PKG_BINARY} list | ${AWKBINARY} '{ print $1","$2 }')
         for ITEM in ${SPACKAGES}; do
@@ -482,11 +485,11 @@
         done
 
         if [ $COUNT -eq 0 ]; then
-            Display --indent 6 --text "- Checking for updates" --result "${STATUS_NONE}" --color GREEN
+            Display --indent ${IPS_TESTS_INDENT} --text "- Checking for updates with IPS" --result "${STATUS_NONE}" --color GREEN
             LogText "No updates available"
             AddHP 2 2
         else
-            Display --indent 6 --text "- Checking for updates" --result "${STATUS_FOUND}" --color YELLOW
+            Display --indent ${IPS_TESTS_INDENT} --text "- Checking for updates with IPS" --result "${STATUS_FOUND}" --color YELLOW
             ReportSuggestion "${TEST_NO}" "Update your system with pkg(5)" "pkg update" "-"
             AddHP 0 2
         fi
@@ -504,11 +507,11 @@
         LogText "Checking for Solaris support repository"
         FIND=$(${PKG_BINARY} publisher | ${GREPBINARY} https://pkg.oracle.com/solaris/support)
         if [ -n "${FIND}" ]; then
-            Display --indent 6 --text "- Checking for support repository" --result "${STATUS_FOUND}" --color GREEN
+            Display --indent ${IPS_TESTS_INDENT} --text "- Checking for support repository" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found solaris support repository"
             AddHP 3 3
         else
-            Display --indent 6 --text "- Checking for support repository " --result "${STATUS_NOT_FOUND}" --color RED
+            Display --indent ${IPS_TESTS_INDENT} --text "- Checking for support repository " --result "${STATUS_NOT_FOUND}" --color RED
             ReportWarning "${TEST_NO}" "Solaris support repository not installed" "The support repository contains important updates" "url:https://docs.oracle.com/cd/E36784_01/html/E39134/repose-1.html"
             AddHP 0 3
         fi
@@ -527,13 +530,13 @@
         FIND=$("${PKG_BINARY}" info solaris-11-cpu 2> /dev/null > /dev/null; echo $?)
 
         if [ "${FIND}" -eq 0 ]; then
-            Display --indent 6 --text "- Checking for patch metadata" --result "${STATUS_FOUND}" --color GREEN
+            Display --indent ${IPS_TESTS_INDENT} --text "- Checking for patch metadata" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found solaris-11-cpu"
             PACKAGE_AUDIT_TOOL_FOUND="1"
             PACKAGE_AUDIT_TOOL="IPS"
             AddHP 3 3
         else
-            Display --indent 6 --text "- Checking for patch metadata" --result "${STATUS_NOT_FOUND}" --color YELLOW
+            Display --indent ${IPS_TESTS_INDENT} --text "- Checking for patch metadata" --result "${STATUS_NOT_FOUND}" --color YELLOW
             FIND=$(pkg info -r solaris-11-cpu 2> /dev/null /dev/null; echo $?)
             LogText "Result: Not installed"
 
@@ -548,6 +551,7 @@
             AddHP 0 3
         fi
     fi
+    unset IPS_TESTS_INDENT
 #
 #################################################################################
 #

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -482,11 +482,11 @@
         done
 
         if [ $COUNT -eq 0 ]; then
-            Display --indent 4 --text "- Checking Image Packaging System (IPS) for updates" --result "${STATUS_NONE}" --color GREEN
+            Display --indent 6 --text "- Checking for updates" --result "${STATUS_NONE}" --color GREEN
             LogText "No updates available"
             AddHP 2 2
         else
-            Display --indent 4 --text "- Checking Image Packaging System (IPS) for updates" --result "${STATUS_FOUND}" --color YELLOW
+            Display --indent 6 --text "- Checking for updates" --result "${STATUS_FOUND}" --color YELLOW
             ReportSuggestion "${TEST_NO}" "Update your system with pkg(5)" "pkg update" "-"
             AddHP 0 2
         fi
@@ -504,11 +504,11 @@
         LogText "Checking for Solaris support repository"
         FIND=$(${PKG_BINARY} publisher | ${GREPBINARY} https://pkg.oracle.com/solaris/support)
         if [ -n "${FIND}" ]; then
-            Display --indent 4 --text "- Checking Image Packaging System (IPS) for support repository" --result "${STATUS_FOUND}" --color GREEN
+            Display --indent 6 --text "- Checking for support repository" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found solaris support repository"
             AddHP 3 3
         else
-            Display --indent 4 --text "- Checking Image Packaging System (IPS) for support repository " --result "${STATUS_NOT_FOUND}" --color RED
+            Display --indent 6 --text "- Checking for support repository " --result "${STATUS_NOT_FOUND}" --color RED
             ReportWarning "${TEST_NO}" "Solaris support repository not installed" "The support repository contains important updates" "url:https://docs.oracle.com/cd/E36784_01/html/E39134/repose-1.html"
             AddHP 0 3
         fi
@@ -527,13 +527,13 @@
         FIND=$("${PKG_BINARY}" info solaris-11-cpu 2> /dev/null > /dev/null; echo $?)
 
         if [ "${FIND}" -eq 0 ]; then
-            Display --indent 4 --text "- Checking for patch metadata" --result "${STATUS_FOUND}" --color GREEN
+            Display --indent 6 --text "- Checking for patch metadata" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found solaris-11-cpu"
             PACKAGE_AUDIT_TOOL_FOUND="1"
             PACKAGE_AUDIT_TOOL="IPS"
             AddHP 3 3
         else
-            Display --indent 4 --text "- Checking for patch metadata" --result "${STATUS_NOT_FOUND}" --color YELLOW
+            Display --indent 6 --text "- Checking for patch metadata" --result "${STATUS_NOT_FOUND}" --color YELLOW
             FIND=$(pkg info -r solaris-11-cpu 2> /dev/null /dev/null; echo $?)
             LogText "Result: Not installed"
 

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -473,7 +473,7 @@
     if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7339 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS for available updates"
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=$(${PKG_BINARY} list -u | tail +2 | ${AWKBINARY} '{ print $1 }')
+        FIND=$("${PKG_BINARY}" list -u | "${TAILBINARY}" +2 | "${AWKBINARY}" '{ print $1 }')
         COUNT=0
         for PACKAGE in ${FIND}; do
             COUNT=$((COUNT + 1))
@@ -524,9 +524,9 @@
     Register --test-no PKGS-7341 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check patch metadata is installed (solaris-11-cpu)"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Checking if patch metadata is installed (solaris-11-cpu)"
-        FIND=$(pkg info solaris-11-cpu 2> /dev/null > /dev/null; echo $?)
+        FIND=$("${PKG_BINARY}" info solaris-11-cpu 2> /dev/null > /dev/null; echo $?)
 
-        if [ $FIND -eq 0 ]; then
+        if [ "${FIND}" -eq 0 ]; then
             Display --indent 4 --text "- Checking for patch metadata" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found solaris-11-cpu"
             PACKAGE_AUDIT_TOOL_FOUND="1"
@@ -537,7 +537,7 @@
             FIND=$(pkg info -r solaris-11-cpu 2> /dev/null /dev/null; echo $?)
             LogText "Result: Not installed"
 
-            if [ $FIND -eq 1 ]; then
+            if [ "${FIND}" -eq 1 ]; then
                 TEXT="Package not installable, check if the support repository is enabled!"
                 LogText "Result: Not installable. Check if support repository is enabled!"
             else

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -440,7 +440,7 @@
 #################################################################################
 #
     # Test        : PKGS-7338
-    # Description : Query Solaris IPS (pkg)
+    # Description : Query Solaris Image Packaging System (IPS)
     # Note        : Restricted to Solaris 11
 
     # This test is set at this position to have all ips tests directly after each other
@@ -448,12 +448,12 @@
     if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7338 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS"
     if [ ${SKIPTEST} -eq 0 ]; then
-        Display --indent 4 --text "- Searching IPS (pkg)" --result "${STATUS_FOUND}" --color GREEN
-        LogText "Result: Found Solaris IPS (pkg)"
+        Display --indent 4 --text "- Searching Image Packaging System (IPS, \"pkg\")" --result "${STATUS_FOUND}" --color GREEN
+        LogText "Result: Found Solaris Image Packaging System (IPS, \"pkg\")"
         Report "package_manager[]=ips"
         PACKAGE_MGR_PKS=1
-        LogText "Test: Querying IPS (pkg) to get package list"
-        Display --indent 4 --text "- Querying IPS (pkg) for installed packages"
+        LogText "Test: Querying IPS to get package list"
+        Display --indent 4 --text "- Querying IPS for installed packages"
         LogText "Output:"; LogText "-----"
         SPACKAGES=$(${PKG_BINARY} list | ${AWKBINARY} '{ print $1","$2 }')
         for ITEM in ${SPACKAGES}; do

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -439,6 +439,118 @@
 #
 #################################################################################
 #
+    # Test        : PKGS-7338
+    # Description : Query Solaris IPS (pkg)
+    # Note        : Restricted to Solaris 11
+
+    # This test is set at this position to have all ips tests directly after each other
+    # Future evaluation: Check if PKGS-7326 should be skipped on modern Solaris
+    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no PKGS-7338 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        Display --indent 4 --text "- Searching IPS (pkg)" --result "${STATUS_FOUND}" --color GREEN
+        LogText "Result: Found Solaris IPS (pkg)"
+        Report "package_manager[]=ips"
+        PACKAGE_MGR_PKS=1
+        LogText "Test: Querying IPS (pkg) to get package list"
+        Display --indent 4 --text "- Querying IPS (pkg) for installed packages"
+        LogText "Output:"; LogText "-----"
+        SPACKAGES=$(${PKG_BINARY} list | ${AWKBINARY} '{ print $1","$2 }')
+        for ITEM in ${SPACKAGES}; do
+            sPKG_NAME=$(echo ${ITEM} | ${CUTBINARY} -d ',' -f1)
+            sPKG_VERSION=$(echo ${ITEM} | ${CUTBINARY} -d ',' -f2)
+            LogText "Installed package: ${sPKG_NAME} (version: ${sPKG_VERSION})"
+            INSTALLED_PACKAGES="${INSTALLED_PACKAGES}|${ITEM}"
+        done
+    fi
+#
+#################################################################################
+#
+    # Test        : PKGS-7339
+    # Description : Query Solaris IPS for available updates
+    # Note        : Restricted to Solaris 11
+
+    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no PKGS-7339 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Query Solaris IPS for available updates"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        FIND=$(${PKG_BINARY} list -u | tail +2 | ${AWKBINARY} '{ print $1 }')
+        COUNT=0
+        for PACKAGE in ${FIND}; do
+            COUNT=$((COUNT + 1))
+            LogText "Update available: ${PACKAGE}"
+            Report "available_update[]=${J}"
+        done
+
+        if [ $COUNT -eq 0 ]; then
+            Display --indent 4 --text "- Checking IPS for updates" --result "${STATUS_NONE}" --color GREEN
+            LogText "No updates available"
+            AddHP 2 2
+        else
+            Display --indent 4 --text "- Checking IPS for updates" --result "${STATUS_FOUND}" --color YELLOW
+            ReportSuggestion "${TEST_NO}" "Update your system with IPS"
+            AddHP 0 2
+        fi
+    fi
+#
+#################################################################################
+#
+    # Test        : PKGS-7340
+    # Description : Check support repository is installed
+    # Note        : Restricted to Solaris 11
+
+    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no PKGS-7340 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check support repository is installed"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        LogText "Checking for Solaris support repository"
+        FIND=$(${PKG_BINARY} publisher | ${GREPBINARY} https://pkg.oracle.com/solaris/support)
+        if [ -n "${FIND}" ]; then
+            Display --indent 4 --text "- Checking IPS for support repository" --result "${STATUS_FOUND}" --color GREEN
+            LogText "Result: Found solaris support repository"
+            AddHP 3 3
+        else
+            Display --indent 4 --text "- Checking IPS for support repository " --result "${STATUS_NOT_FOUND}" --color RED
+            ReportWarning "${TEST_NO}" "Solaris support repository not installed" "The support repository contains important updates" "url:https://docs.oracle.com/cd/E36784_01/html/E39134/repose-1.html"
+            AddHP 0 3
+        fi
+    fi
+#
+#################################################################################
+#
+    # Test        : PKGS-7341
+    # Description : Check patch metadata is installed (solaris-11-cpu)
+    # Note        : Restricted to Solaris 11
+
+    if [ -n "${PKG_BINARY}" ] && [ "${OS_VERSION}" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no PKGS-7341 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check patch metadata is installed (solaris-11-cpu)"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        LogText "Checking if patch metadata is installed (solaris-11-cpu)"
+        FIND=$(pkg info solaris-11-cpu 2> /dev/null > /dev/null; echo $?)
+
+        if [ $FIND -eq 0 ]; then
+            Display --indent 4 --text "- Checking for patch metadata" --result "${STATUS_FOUND}" --color GREEN
+            LogText "Result: Found solaris-11-cpu"
+            PACKAGE_AUDIT_TOOL_FOUND="1"
+            PACKAGE_AUDIT_TOOL="IPS"
+            AddHP 3 3
+        else
+            Display --indent 4 --text "- Checking for patch metadata" --result "${STATUS_NOT_FOUND}" --color YELLOW
+            FIND=$(pkg info -r solaris-11-cpu 2> /dev/null /dev/null; echo $?)
+            LogText "Result: Not installed"
+
+            if [ $FIND -eq 1 ]; then
+                TEXT="Package not installable, check if the support repository is enabled!"
+                LogText "Result: Not installable. Check if support repository is enabled!"
+            else
+                TEXT="pkg install solaris-11-cpu@latest"
+            fi
+
+            ReportWarning "${TEST_NO}" "Patch metadata not found" "Install solaris-11-cpu" "text:${TEXT}"
+            AddHP 0 3
+        fi
+    fi
+#
+#################################################################################
+#
     # Test        : PKGS-7345
     # Description : Debian package based systems (dpkg)
     if [ -x ${ROOTDIR}usr/bin/dpkg ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
@@ -728,7 +840,7 @@
     # Description : Check for vulnerable FreeBSD packages (with pkg)
     # Notes       : Related vulnerability file is /var/db/pkg/vuln.xml
     # TODO        : Run this in any jail
-    if [ -n "${PKG_BINARY}" ]; then PREQS_MET="YES"; SKIPREASON=""; else PREQS_MET="NO"; SKIPREASON="pkg tool not available"; fi
+    if [ -n "${PKG_BINARY}" ] && [ "${OS}" != "Solaris" ]; then PREQS_MET="YES"; SKIPREASON=""; else PREQS_MET="NO"; SKIPREASON="pkg tool not available"; fi
     Register --test-no PKGS-7381 --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Check for vulnerable FreeBSD packages with pkg"
     if [ ${SKIPTEST} -eq 0 ]; then
         COUNT=0

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -498,7 +498,7 @@
     # Description : Check support repository is installed
     # Note        : Restricted to Solaris 11
 
-    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ] && [ "${OPENSOLARIS}" = 0 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7340 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check support repository is installed"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Checking for Solaris support repository"
@@ -520,7 +520,7 @@
     # Description : Check patch metadata is installed (solaris-11-cpu)
     # Note        : Restricted to Solaris 11
 
-    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ -n "${PKG_BINARY}" ] && [ "$(uname -r)" = "5.11" ] && [ "${OPENSOLARIS}" = 0 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PKGS-7341 --os Solaris --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check patch metadata is installed (solaris-11-cpu)"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Checking if patch metadata is installed (solaris-11-cpu)"


### PR DESCRIPTION
IPS (Image Packaging System) is the new package system of Solaris 11.
This PR adds support for it.

New tests PKGS-7338 to -7341 detect this package manager, search for
updates and check if the support repository and patch metadata are
installed.

Additionally `pkg audit` is not detected wrongfully as audit tool any more.