### PR TITLE
Use `od` only for displaying invalid characters

### DIFF
--- a/include/profiles
+++ b/include/profiles
@@ -35,7 +35,7 @@
 
         # Show deprecation message for old config entries such as 'config:' and 'apache:'
         FOUND=0
-        DATA=$(grep -E "^[a-z-]{1,}:" ${PROFILE} | od -An -ta | sed 's/ /!space!/g')  # od -An (no file offset), -ta (named character, to be on safe side)
+        DATA=$(grep -E "^[a-z-]{1,}:" ${PROFILE})
         if ! IsEmpty "${DATA}"; then FOUND=1; fi
 
         if [ ${FOUND} -eq 1 ]; then
@@ -56,12 +56,11 @@
         fi
 
         # Security check for unexpected and possibly harmful escape characters (hyphen should be listed as first or last character)
-        DATA=$(grep -Ev '^$|^ |^#|^config:' "${PROFILE}" | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-' | od -An -ta | sed 's/ /!space!/g')
+        DATA=$(grep -Ev '^$|^ |^#|^config:' "${PROFILE}" | tr -d '[:alnum:]/\[\]\(\)_\|,\.:;= \n\r-')
         if ! IsEmpty "${DATA}"; then
             DisplayWarning "Your profile '${PROFILE}' contains unexpected characters. See the log file for more information."
             LogText "Found unexpected or possibly harmful characters in profile '${PROFILE}'. See which characters matched in the output below and compare them with your profile."
-            for I in ${DATA}; do
-                I=$(echo ${I} | sed 's/!space!/ /g')
+            for I in $(printf ${DATA} | od -An -ta); do
                 LogText "Output: ${I}"
             done
             LogText "Suggestion: comment incorrect lines with a '#' and try again. Open a GitHub issue if valid characters are blocked"


### PR DESCRIPTION
The first od is removed, the second time is moved to right before echoing
the characters. On certain OpenSolaris distributions, `od` always outputs
spaces, even if the input is empty. The spaces would have been converted
to !space!, thus Lynis detected invalid characters / old style configuration.

Resolves cisofy/lynis#1065.

Signed-off-by: Simon Biewald <simon@fam-biewald.de>