### PR TITLE
OpenSolaris distribution detection

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -237,4 +237,20 @@ os:Ubuntu 18.10:2019-07-18:1563400800:
 os:Ubuntu 19.04:2020-01-01:1577833200:
 os:Ubuntu 20.04:2025-04-01:1743458400:
 #
+# OmniosCE - https://omniosce.org/releasenotes.html
+#
+os:OmniOS Community Edition v11 r151022:2020-05-11:1589148000:
+os:OmniOS Community Edition v11 r151024:2018-11-04:1541286000:
+os:OmniOS Community Edition v11 r151026:2019-05-05:1557007200:
+os:OmniOS Community Edition v11 r151028:2019-11-04:1572822000:
+os:OmniOS Community Edition v11 r151030::-1:
+os:OmniOS Community Edition v11 r151032:2020-11-03:1604358000:
+os:OmniOS Community Edition v11 r151034::-1:
+#
+## Oracle Solaris - https://www.oracle.com/us/support/library/lifetime-support-hardware-301321.pdf (p. 34)
+#                   The list below contains Premier Support End only
+#
+os:Oracle Solaris 11.3:2021-01-01:1609455600:
+os:Oracle Solaris 11.4:2031-11-01:1951254000:
+#
 # EOF

--- a/include/osdetection
+++ b/include/osdetection
@@ -556,12 +556,89 @@
             SYSCTL_READKEY=""
         ;;
 
-        # Solaris / OpenSolaris
+        # Solaris / OpenSolaris / Ilumos ...
         SunOS)
             OS="Solaris"
-            OS_NAME="Sun Solaris"
-            OS_FULLNAME=$(uname -s -r)
-            OS_VERSION=$(uname -r)
+            OS_KERNELVERSION=$(uname -v)
+            OPENSOLARIS=0
+
+            if [ -f /etc/os-release ]; then
+                OS_ID=$(grep "^ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                OS_VERSION=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                OS_FULLNAME=$(awk -F= '/^PRETTY_NAME=/ {print substr($2,2,length($2)-2)}' /etc/os-release)
+                case "${OS_ID}" in
+                    "solaris")
+                        OS_NAME="Oracle Solaris"
+                        ;;
+                    "omnios")
+                        OS_NAME="OmniOS"
+                        OPENSOLARIS=1
+                        ;;
+                    "tribblix")
+                        OS_NAME="Tribblix"
+                        OS_FULLNAME="Tribblix ${OS_VERSION}"
+                        OPENSOLARIS=1 
+                        ;;
+                    "*")
+                        ReportException "OS Detection" "Unknown OS found in /etc/os-release - Please create issue on GitHub project page: ${PROGRAM_SOURCE}"
+                        ;;
+                esac
+            elif [ "$(uname -o 2> /dev/null)" == "illumos" ]; then
+                OPENSOLARIS=1
+        
+                # Solaris has a free form text file with release information
+                if grep "OpenIndiana" /etc/release > /dev/null; then
+                    OS_NAME="OpenIndiana"
+                    if grep "Hipster" /etc/release > /dev/null; then
+                        OS_VERSION="$(tr ' ' '\n' < /etc/release  | grep '[[:digit:]]\.[[:digit:]]')"
+                        OS_FULLNAME="OpenIndiana Hipster $OS_VERSION"
+                    else
+                        OS_VERSION="Unknown"
+                        OS_FULLNAME="OpenIndiana (unknown edition)"
+                    fi
+                elif grep "OmniOS" /etc/release > /dev/null; then
+                    OS_NAME="OmniOS"
+                    OS_VERSION="$(tr ' ' '\n' < /etc/release  | grep 'r[[:digit:]]')"
+                    if grep "Community Edition" /etc/release > /dev/null; then
+                        OS_FULLNAME="OmniOS Community Edition v11 $OS_VERSION"
+                    fi
+                elif grep "SmartOS" /etc/release > /dev/null; then
+                    OS_NAME="SmartOS"
+                    OS_VERSION="-"
+                    OS_FULLNAME="SmartOS"
+                else
+                    OS_NAME="Unknown Illumos"
+                fi
+            elif grep "SchilliX" /etc/release > /dev/null; then
+                OS_NAME="SchilliX"
+                OS_FULLNAME="$(head -n 1 /etc/release | xargs)"
+                OS_VERSION="$(echo "$OS_FULLNAME" | cut -d '-' -f 2)"
+
+                OPENSOLARIS=1
+            elif head -n 1 < /etc/release | grep "Oracle Solaris" > /dev/null; then
+                OS_NAME="Oracle Solaris"
+                OS_FULLNAME="$(head -n 1 /etc/release | xargs)"
+                OS_VERSION="$(head -n 1 < /etc/release | xargs | cut -d ' ' -f 3)"
+            elif head -n 1 < /etc/release | xargs | grep "^Solaris " > /dev/null; then
+                OS_NAME="Sun Solaris"
+                # Example of /etc/release:
+                #   Solaris 10 5/08
+                #   ...
+                #   Solaris 10 10/09 (Update 8)
+                # The first line does not contain the "Update" number,
+                # only if present.
+                if tail -1 < /etc/release | xargs | grep "^Solaris " > /dev/null; then
+                    OS_FULLNAME=$(tail -1 < /etc/release | xargs)
+                else
+                    OS_FULLNAME=$(head -1 < /etc/release | xargs)
+                fi
+                OS_VERSION=$(echo "$OS_FULLNAME" | cut -d ' ' -f 2,3)
+            else  # Old behaviour
+                OS_NAME="Sun Solaris"
+                OS_FULLNAME=$(uname -s -r)
+                OS_VERSION=$(uname -r)
+            fi
+
             HARDWARE=$(uname -m)
             if [ -x /usr/bin/isainfo ]; then
                 # Returns 32, 64


### PR DESCRIPTION
This PR adds detection of OpenSolaris distributions. The variable OPENSOLARIS is introduced to distringuish between the closed  source Solaris or OpenSolaris based ones. The edge case of OpenSolaris itself is not yet solved, but OpenSolaris itself should be very rare these days. Solaris Express is not detected yet as well.

Lynis will try to read the `/etc/os-release` if possible and will fall back to parsing the free form `/etc/release` file.
Currently detected and distinguished (Open)Solaris variants with correct version number are:
 - Solaris >= 11 (exluding Solaris Express and OpenSolaris) as "Oracle Solaris" with EOL dates for 11.3 and .4
 - Solaris < 11 as "Sun Solaris" 
 - OmniosCE (but not old Omnios) with EOL dates
 - OpenIndiana (Hipster and Legacy)
 - Shillix
 - SmartOS
 - Tribblix
 - "Unknown Illumos" for unknown distributions based on Illumos

Lynis will fall back to "Sun Solaris" with "SunOS 5.X" as full name for unknown distributions (this is the current behaviour), if both parsing the `os-release` and `release` files do not return meaningful results.