### PR TITLE
Use first e1000 interface and break after match (for hostid generation on Solaris)

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1089,12 +1089,13 @@
                 ;;
 
                 "Solaris")
-                    INTERFACES_TO_TEST="e1000g1 net0"
+                    INTERFACES_TO_TEST="net0 e1000g1 e1000g0"
                     FOUND=0
                     for I in ${INTERFACES_TO_TEST}; do
                          FIND=$(${IFCONFIGBINARY} -a | grep "^${I}")
                          if [ ! "${FIND}" = "" ]; then
                              FOUND=1; LogText "Found interface ${I} on Solaris"
+                             break
                          fi
                     done
                     if [ ${FOUND} -eq 1 ]; then
@@ -1107,7 +1108,7 @@
                             ReportException "GetHostID" "Can not find sha1/sha1sum or openssl"
                         fi
                     else
-                        ReportException "GetHostID" "No interface found op Solaris to create HostID"
+                        ReportException "GetHostID" "No interface found on Solaris to create HostID"
                     fi
                 ;;
 


### PR DESCRIPTION
Fixes CISOfy/lynis#1075.

Before this commit, the interfaces "e1000g1" and "net0" were allowed. The name "e1000g0" is appended to the list. After finding an interface, the loop is interrupted now. As previously "net0" was always used, even if another interface was available, the list is reordered to "net0 e1000g1 e1000g0" to not break previous generations.

A typo is also fixed ("No interface found op Solaris ..." -> "No interface found on Solaris ...").

Signed-off-by: Simon Biewald <simon@fam-biewald.de>