### PR TITLE
Quote binary variables during SUID/GID enumeration

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -119,11 +119,11 @@
                         COUNT=$((COUNT + 1))
                         BINARY="${SCANDIR}/${FILENAME}"
                         DISCOVERED_BINARIES="${DISCOVERED_BINARIES}${BINARY} "
-                        if [ -u ${BINARY} ]; then
+                        if [ -u "${BINARY}" ]; then
                             NSUID_BINARIES=$((NSUID_BINARIES + 1))
                             SUID_BINARIES="${SUID_BINARIES}${BINARY} "
                         fi
-                        if [ -g ${BINARY} ]; then
+                        if [ -g "${BINARY}" ]; then
                             NSGID_BINARIES=$((NSGID_BINARIES + 1))
                             SGID_BINARIES="${SGID_BINARIES}${BINARY} "
                         fi


### PR DESCRIPTION
Fixes cisofy/lynis#1078.

Signed-off-by: Simon Biewald <simon@fam-biewald.de>