### PR TITLE
only fail AUTH-9230 if both SHA_CRYPT_{MIN,MAX}_ROUNDS are undefined

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -352,50 +352,49 @@
 #################################################################################
 #
     # Test        : AUTH-9230
-    # Description : Check group password hashing rounds in login.defs
+    # Description : Check password hashing rounds in login.defs
     # Notes       : Applicable to all Unix-like OS
     PREQS_MET="NO"
     if [ -f ${ROOTDIR}etc/login.defs ]; then
         PREQS_MET="YES"
     fi
-    Register --test-no AUTH-9230 --preqs-met ${PREQS_MET} --root-only NO --weight L --network NO --category security --description "Check group password hashing rounds"
+
+    Register --test-no AUTH-9230 --preqs-met ${PREQS_MET} --root-only NO --weight L --network NO --category security --description "Check password hashing rounds"
     if [ ${SKIPTEST} -eq 0 ]; then
         SHA_CRYPT_MIN_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MIN_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MIN_ROUNDS") { print $2 } }')
         SHA_CRYPT_MAX_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MAX_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MAX_ROUNDS") { print $2 } }')
+        SHA_CRYPT_ROUNDS=0
 
-        if [ -z "${SHA_CRYPT_MIN_ROUNDS_FIND}" -o "${SHA_CRYPT_MIN_ROUNDS_FIND}" = "0" ] && [ -z "${SHA_CRYPT_MAX_ROUNDS_FIND}" -o "${SHA_CRYPT_MAX_ROUNDS_FIND}" = "0" ]; then
-            LogText "Result: number of rounds used by the encryption algorithm is not configured"
-            Display --indent 2 --text "- Checking group password hashing rounds" --result "${STATUS_DISABLED}" --color YELLOW
-            ReportSuggestion "${TEST_NO}" "Configure encryption algorithm rounds in /etc/login.defs"
+        if [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
+            if [ ${SHA_CRYPT_MIN_ROUNDS_FIND} -lt ${SHA_CRYPT_MAX_ROUNDS_FIND} ]; then
+                SHA_CRYPT_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
+            else
+              SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
+            fi
+        elif [ -z "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
+            SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
+        elif [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -z "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
+            SHA_CRYPT_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
+        else
+            SHA_CRYPT_ROUNDS=0
+        fi
+
+        LogText "Test: Checking SHA_CRYPT_{MIN,MAX}_ROUNDS option in ${ROOTDIR}etc/login.defs"
+        if [ ${SHA_CRYPT_ROUNDS} -eq 0 ]; then
+            LogText "Result: number of password hashing rounds is not configured"
+            Display --indent 2 --text "- Checking password hashing rounds" --result "${STATUS_DISABLED}" --color YELLOW
+            ReportSuggestion "${TEST_NO}" "Configure password hashing rounds in /etc/login.defs"
             AddHP 0 2
         fi
 
-        if [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" ]; then
-            LogText "Test: Checking SHA_CRYPT_MIN_ROUNDS option in ${ROOTDIR}etc/login.defs"
-            if [ "${SHA_CRYPT_MIN_ROUNDS_FIND}" -lt 5000 ]; then
-                LogText "Result: low number of minimum encryption algorithm rounds found: ${SHA_CRYPT_MIN_ROUNDS_FIND}"
-                PASSWORD_MINIMUM_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
-                Display --indent 2 --text "- Group password hashing rounds (minimum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
+        if [ -n "${SHA_CRYPT_ROUNDS}" ] && [ ${SHA_CRYPT_ROUNDS} -gt 0 ]; then
+            if [ ${SHA_CRYPT_ROUNDS} -lt 5000 ]; then
+                LogText "Result: low number of password hashing rounds found: ${SHA_CRYPT_ROUNDS}"
+                Display --indent 2 --text "- Password hashing rounds (minimum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
                 AddHP 1 2
             else
-                LogText "Result: number of encryption algorithm rounds is ${SHA_CRYPT_MIN_ROUNDS_FIND}"
-                PASSWORD_MINIMUM_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
-                Display --indent 2 --text "- Group password hashing rounds (minimum)" --result CONFIGURED --color GREEN
-                AddHP 2 2
-            fi
-        fi
-
-        if [ -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
-            LogText "Test: Checking SHA_CRYPT_MAX_ROUNDS option in ${ROOTDIR}etc/login.defs"
-            if [ "${SHA_CRYPT_MAX_ROUNDS_FIND}" -lt 10000 ]; then
-                LogText "Result: low number of maximum encryption algorithm rounds found: ${SHA_CRYPT_MAX_ROUNDS_FIND}"
-                PASSWORD_MAXIMUM_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
-                Display --indent 2 --text "- Group password hashing rounds (maximum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
-                AddHP 1 2
-            else
-                LogText "Result: number of encryption algorithm rounds is ${SHA_CRYPT_MAX_ROUNDS_FIND}"
-                PASSWORD_MAXIMUM_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
-                Display --indent 2 --text "- Group password hashing rounds (maximum)" --result CONFIGURED --color GREEN
+                LogText "Result: number of password hashing rounds is ${SHA_CRYPT_ROUNDS}"
+                Display --indent 2 --text "- Password hashing rounds (minimum)" --result CONFIGURED --color GREEN
                 AddHP 2 2
             fi
         fi

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -368,7 +368,7 @@
             if [ ${SHA_CRYPT_MIN_ROUNDS_FIND} -lt ${SHA_CRYPT_MAX_ROUNDS_FIND} ]; then
                 SHA_CRYPT_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
             else
-              SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
+                SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
             fi
         elif [ -z "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
             SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -358,7 +358,6 @@
     if [ -f ${ROOTDIR}etc/login.defs ]; then
         PREQS_MET="YES"
     fi
-
     Register --test-no AUTH-9230 --preqs-met ${PREQS_MET} --root-only NO --weight L --network NO --category security --description "Check password hashing rounds"
     if [ ${SKIPTEST} -eq 0 ]; then
         SHA_CRYPT_MIN_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MIN_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MIN_ROUNDS") { print $2 } }')

--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -360,42 +360,44 @@
     fi
     Register --test-no AUTH-9230 --preqs-met ${PREQS_MET} --root-only NO --weight L --network NO --category security --description "Check group password hashing rounds"
     if [ ${SKIPTEST} -eq 0 ]; then
-        LogText "Test: Checking SHA_CRYPT_MIN_ROUNDS option in ${ROOTDIR}etc/login.defs"
-        FIND=$(${GREPBINARY} "^SHA_CRYPT_MIN_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MIN_ROUNDS") { print $2 } }')
-        if [ -z "${FIND}" -o "${FIND}" = "0" ]; then
-            LogText "Result: number of minimum rounds used by the encryption algorithm is not configured"
-            Display --indent 2 --text "- Checking minimum group password hashing rounds" --result "${STATUS_DISABLED}" --color YELLOW
-            ReportSuggestion "${TEST_NO}" "Configure minimum encryption algorithm rounds in /etc/login.defs"
+        SHA_CRYPT_MIN_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MIN_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MIN_ROUNDS") { print $2 } }')
+        SHA_CRYPT_MAX_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MAX_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MAX_ROUNDS") { print $2 } }')
+
+        if [ -z "${SHA_CRYPT_MIN_ROUNDS_FIND}" -o "${SHA_CRYPT_MIN_ROUNDS_FIND}" = "0" ] && [ -z "${SHA_CRYPT_MAX_ROUNDS_FIND}" -o "${SHA_CRYPT_MAX_ROUNDS_FIND}" = "0" ]; then
+            LogText "Result: number of rounds used by the encryption algorithm is not configured"
+            Display --indent 2 --text "- Checking group password hashing rounds" --result "${STATUS_DISABLED}" --color YELLOW
+            ReportSuggestion "${TEST_NO}" "Configure encryption algorithm rounds in /etc/login.defs"
             AddHP 0 2
-        elif [ "${FIND}" -lt 5000 ]; then
-            LogText "Result: low number of minimum encryption algorithm rounds found: ${FIND}"
-            PASSWORD_MINIMUM_ROUNDS=${FIND}
-            Display --indent 2 --text "- Group password hashing rounds (minimum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
-            AddHP 1 2
-        else
-            LogText "Result: number of encryption algorithm rounds is ${FIND}"
-            PASSWORD_MINIMUM_ROUNDS=${FIND}
-            Display --indent 2 --text "- Group password hashing rounds (minimum)" --result CONFIGURED --color GREEN
-            AddHP 2 2
         fi
 
-        LogText "Test: Checking SHA_CRYPT_MAX_ROUNDS option in ${ROOTDIR}etc/login.defs"
-        FIND=$(${GREPBINARY} "^SHA_CRYPT_MAX_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MAX_ROUNDS") { print $2 } }')
-        if [ -z "${FIND}" -o "${FIND}" = "0" ]; then
-            LogText "Result: number of maximum rounds used by the encryption algorithm is not configured"
-            Display --indent 2 --text "- Checking maximum group password hashing rounds" --result "${STATUS_DISABLED}" --color YELLOW
-            ReportSuggestion "${TEST_NO}" "Configure maximum encryption algorithm rounds in /etc/login.defs"
-            AddHP 0 2
-        elif [ "${FIND}" -lt 10000 ]; then
-            LogText "Result: low number of maximum encryption algorithm rounds found: ${FIND}"
-            PASSWORD_MINIMUM_ROUNDS=${FIND}
-            Display --indent 2 --text "- Group password hashing rounds (maximum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
-            AddHP 1 2
-        else
-            LogText "Result: number of encryption algorithm rounds is ${FIND}"
-            PASSWORD_MINIMUM_ROUNDS=${FIND}
-            Display --indent 2 --text "- Group password hashing rounds (maximum)" --result CONFIGURED --color GREEN
-            AddHP 2 2
+        if [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" ]; then
+            LogText "Test: Checking SHA_CRYPT_MIN_ROUNDS option in ${ROOTDIR}etc/login.defs"
+            if [ "${SHA_CRYPT_MIN_ROUNDS_FIND}" -lt 5000 ]; then
+                LogText "Result: low number of minimum encryption algorithm rounds found: ${SHA_CRYPT_MIN_ROUNDS_FIND}"
+                PASSWORD_MINIMUM_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
+                Display --indent 2 --text "- Group password hashing rounds (minimum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
+                AddHP 1 2
+            else
+                LogText "Result: number of encryption algorithm rounds is ${SHA_CRYPT_MIN_ROUNDS_FIND}"
+                PASSWORD_MINIMUM_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
+                Display --indent 2 --text "- Group password hashing rounds (minimum)" --result CONFIGURED --color GREEN
+                AddHP 2 2
+            fi
+        fi
+
+        if [ -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
+            LogText "Test: Checking SHA_CRYPT_MAX_ROUNDS option in ${ROOTDIR}etc/login.defs"
+            if [ "${SHA_CRYPT_MAX_ROUNDS_FIND}" -lt 10000 ]; then
+                LogText "Result: low number of maximum encryption algorithm rounds found: ${SHA_CRYPT_MAX_ROUNDS_FIND}"
+                PASSWORD_MAXIMUM_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
+                Display --indent 2 --text "- Group password hashing rounds (maximum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
+                AddHP 1 2
+            else
+                LogText "Result: number of encryption algorithm rounds is ${SHA_CRYPT_MAX_ROUNDS_FIND}"
+                PASSWORD_MAXIMUM_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
+                Display --indent 2 --text "- Group password hashing rounds (maximum)" --result CONFIGURED --color GREEN
+                AddHP 2 2
+            fi
         fi
     fi
 #


### PR DESCRIPTION
Since if only one of the MIN or MAX values is set, and then this value will be used, we only have to fail AUTH-9230 if both SHA_CRYPT_{MIN,MAX}_ROUNDS are undefined.

Closes #1085 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>