### PR TITLE
Krnl 5677

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2670,7 +2670,15 @@
         fi
 
         # Check for correct hardware platform
-        if [ ${SKIPTEST} -eq 0 -a -n "${TEST_NEED_PLATFORM}" -a ! "${HARDWARE}" = "${TEST_NEED_PLATFORM}" ]; then SKIPTEST=1; SKIPREASON="Incorrect hardware platform"; fi
+        if [ ${SKIPTEST} -eq 0 -a -n "${TEST_NEED_PLATFORM}" ]; then
+            HASMATCH=0
+            for I in ${TEST_NEED_PLATFORM}; do
+                if [ "${I}" = "${HARDWARE}" ]; then HASMATCH=1; fi
+            done
+            if [ ${HASMATCH} -eq 0 ]; then
+                SKIPTEST=1; SKIPREASON="Incorrect hardware platform (${TEST_NEED_PLATFORM} only)"
+            fi
+        fi
 
         # Check for required (and discovered) package manager
         if [ ${SKIPTEST} -eq 0 -a ${TEST_NEED_PKG_MGR} -eq 1 -a ${HAS_PACKAGE_MANAGER} -eq 0 ]; then SKIPTEST=1; SKIPREASON="Requires a known package manager to test presence of a particular package"; fi

--- a/include/tests_kernel
+++ b/include/tests_kernel
@@ -103,7 +103,7 @@
     # Description : Check CPU options and support (PAE, No eXecute, eXecute Disable)
     # More info   : pae and nx bit are both visible on AMD and Intel CPU's if supported
 
-    Register --test-no KRNL-5677 --platform x86_64 --os Linux --weight L --network NO --category security --description "Check CPU options and support"
+    Register --test-no KRNL-5677 --platform "x86_64 amd64" --os "Linux NetBSD" --weight L --network NO --category security --description "Check CPU options and support"
     if [ ${SKIPTEST} -eq 0 ]; then
         Display --indent 2 --text "- Checking CPU support (NX/PAE)"
         LogText "Test: Checking /proc/cpuinfo"


### PR DESCRIPTION
Allow for multiple hardware names in Register. Primarily added to support *BSD systems that use amd64 as the hardware name rather than the Linux (and Intel) x86_64. Additionally this allows for a test to possibly support multiple hardware types.

Open to discussing alternatives rather than just letting this PR timeout this time.