### PR TITLE
Fix for MariaDB test ID DBS-1816

### DIFF
--- a/include/tests_databases
+++ b/include/tests_databases
@@ -86,7 +86,7 @@
 
         # "-u root --password=" avoids ~/.my.cnf authentication settings
         # "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used 
-        FIND=$(${MYSQLCLIENTBINARY} --no-defaults -u root --password= --silent --batch --execute="SELECT count(*) FROM mysql.user WHERE user = 'root' AND plugin = 'mysql_native_password' AND authentication_string = ''" mysql > /dev/null 2>&1; echo $?)
+        FIND=$(${MYSQLCLIENTBINARY} --default-auth=mysql_native_password  --no-defaults -u root --password= --silent --batch --execute="SELECT count(*) FROM mysql.user WHERE user = 'root' AND plugin = 'mysql_native_password' AND authentication_string = ''" mysql > /dev/null 2>&1; echo $?)
         if [ "${FIND}" = "0" ]; then
            LogText "Result: Login succeeded, no MySQL root password set!"
            ReportWarning "${TEST_NO}" "No MySQL root password set"


### PR DESCRIPTION
Fix for Test: DBS-1816 - Check empty MySQL root password