### PR TITLE
1103: FILE-6430 reports suggestion only when at least one kernel module is not in the blacklist

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -820,11 +820,11 @@
                         LogText "Result: module ${FS} is currently not loaded in the kernel."
                         AddHP 2 3
                         if IsDebug; then Display --indent 6 --text "- Module ${FS} not loaded (lsmod)" --result OK --color GREEN; fi
-                        FOUND=1
-                        AVAILABLE_MODPROBE_FS="${AVAILABLE_MODPROBE_FS}${FS} "
                     else
                         LogText "Result: module ${FS} is loaded in the kernel"
                         Display --indent 4 --text "- Module $FS loaded in the kernel (lsmod)" --result "FOUND" --color WHITE
+                        FOUND=1
+                        AVAILABLE_MODPROBE_FS="${AVAILABLE_MODPROBE_FS}${FS} "
                     fi
                 else
                     AddHP 3 3


### PR DESCRIPTION
fixes #1103 