### PR TITLE
nftables empy ruleset test fix by reorder --stateless

### DIFF
--- a/include/tests_firewalls
+++ b/include/tests_firewalls
@@ -506,7 +506,7 @@
     Register --test-no FIRE-4540 --os Linux --preqs-met ${PREQS_MET} --weight L --network NO --root-only YES --category security --description "Check for empty nftables configuration"
     if [ ${SKIPTEST} -eq 0 ]; then
         # Check for empty ruleset
-        NFT_RULES_LENGTH=$(${NFTBINARY} list ruleset --stateless 2> /dev/null | ${EGREPBINARY} -v "table|chain|;$|}$|^$" | ${WCBINARY} -l)
+        NFT_RULES_LENGTH=$(${NFTBINARY} --stateless list ruleset 2> /dev/null | ${EGREPBINARY} -v "table|chain|;$|}$|^$" | ${WCBINARY} -l)
         if [ ${NFT_RULES_LENGTH} -le 3 ]; then
             FIREWALL_EMPTY_RULESET=1
             LogText "Result: this firewall set has 3 rules or less and is considered to be empty"


### PR DESCRIPTION
```
$ nft -v
nftables v0.9.8 (E.D.S.)
$ sudo nft list ruleset --stateless 
Error: syntax error, options must be specified before commands
```