### PR TITLE
add support for additional Aide db paths

### DIFF
--- a/include/tests_file_integrity
+++ b/include/tests_file_integrity
@@ -104,7 +104,7 @@
     if [ -n "${AIDEBINARY}" -a -n "${AIDECONFIG}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no FINT-4316 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Presence of AIDE database and size check"
     if [ ${SKIPTEST} -eq 0 ]; then
-        AIDE_DB=$(${GREPBINARY} ^database= ${AIDECONFIG} | ${SEDBINARY} "s/.*://")
+        AIDE_DB=$(${EGREPBINARY} '(^database|^database_in)=' ${AIDECONFIG} | ${SEDBINARY} "s/.*://")
         if case ${AIDE_DB} in @@*) ;; *) false;; esac; then
             I=$(${GREPBINARY} "@@define.*DBDIR" ${AIDECONFIG} | ${AWKBINARY} '{print $3}')
             AIDE_DB=$(echo ${AIDE_DB} | ${SEDBINARY} "s#.*}#${I}#")


### PR DESCRIPTION
When using Ubuntu 21.10 and `aide` version 0.17.3-1, the database configuration setting has changed from `database=` in previous versions to `database_in=`.

This PR catches `(^database|^database_in)=`

```sh
~$ lsb_release -d && dpkg -l | grep aide* | awk '{print $2, $3}' && grep -E '(^database|^database_in)=' /etc/aide/aide.conf
Description:    Ubuntu Impish Indri (development branch)
aide 0.17.3-1
aide-common 0.17.3-1
database_in=file:/var/lib/aide/aide.db
```
```sh
~$ lsb_release -d && dpkg -l | grep aide* | awk '{print $2, $3}' && grep -E '(^database|^database_in)=' /etc/aide/aide.conf
Description:    Ubuntu 20.04.2 LTS
aide 0.16.1-1build2
aide-common 0.16.1-1build2
database=file:/var/lib/aide/aide.db
```


Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>