### PR TITLE
[LOGG-2138] Do not check for klogd when metalog is being used

### DIFF
--- a/include/tests_logging
+++ b/include/tests_logging
@@ -177,14 +177,14 @@
 #
     # Test        : LOGG-2138
     # Description : Check for kernel log daemon (klogd) presence on Linux systems
-    # Notes       : * When using rsyslog or systemd (systemd-journal), this process is not needed.
+    # Notes       : * When using metalog, rsyslog or systemd (systemd-journal), this process is not needed.
     #               * In combination with syslog-ng, klogd is still an addition to it, since it
     #                 captures kernel related events and send them to syslog-ng.
     #               * This test should be below all other logging daemons
     Register --test-no LOGG-2138 --os Linux --weight L --network NO --category security --description "Checking kernel logger daemon on Linux"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Searching kernel logger daemon (klogd)"
-        if [ ${RSYSLOG_RUNNING} -eq 0 -a ${SYSTEMD_JOURNAL_RUNNING} -eq 0 ]; then
+        if [ ${RSYSLOG_RUNNING} -eq 0 ] && [ ${SYSTEMD_JOURNAL_RUNNING} -eq 0 ] && [ ${METALOG_RUNNING} -eq 0 ]; then
             # Search for klogd, but ignore other lines related to klogd (like dd with input/output file)
             #FIND=$(${PSBINARY} ax | ${GREPBINARY} "klogd" | ${GREPBINARY} -v "dd" | ${GREPBINARY} -v "grep")
             if IsRunning "klogd"; then


### PR DESCRIPTION
Metalog comes with its own kernel logger, so there is no need to also run klogd.