### PR TITLE
Added Arch Linux 32

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -168,6 +168,11 @@
                             OS_FULLNAME="Arch Linux"
                             OS_VERSION="Rolling release"
                         ;;
+                        "arch32")
+                            LINUX_VERSION="Arch Linux 32"
+                            OS_FULLNAME="Arch Linux 32"
+                            OS_VERSION="Rolling release"
+                        ;;
                         "centos")
                             LINUX_VERSION="CentOS"
                             OS_NAME="CentOS Linux"


### PR DESCRIPTION
There is an `i686` fork of Arch Linux called [Arch Linux 32](https://archlinux32.org/). It's `/etc/os-release` reads as follows:

````
NAME="Arch Linux 32"
PRETTY_NAME="Arch Linux 32"
ID=arch32
ID_LIKE=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://www.archlinux32.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux32.org/"
BUG_REPORT_URL="https://bugs.archlinux32.org/"
LOGO=archlinux
````