### PR TITLE
Test PKGS-7320 extended to "Arch Linux 32"

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -296,7 +296,7 @@
 #
     # Test        : PKGS-7320
     # Description : Check available of arch-audit
-    if [ "${OS_FULLNAME}" = "Arch Linux" ]; then PREQS_MET="YES"; SKIPREASON=""; else PREQS_MET="NO"; SKIPREASON="Test only applies to Arch Linux"; fi
+    if [ "${OS_FULLNAME}" = "Arch Linux" ] || [ "${OS_FULLNAME}" = "Arch Linux 32" ]; then PREQS_MET="YES"; SKIPREASON=""; else PREQS_MET="NO"; SKIPREASON="Test only applies to Arch Linux"; fi
     Register --test-no PKGS-7320 --os "Linux" --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Checking for arch-audit tooling"
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ -z "${ARCH_AUDIT_BINARY}" ]; then


### PR DESCRIPTION
`PKGS-7320` checks whether package `arch-audit` is installed. This test has been extended to test `${OS_FULLNAME}` for both "Arch Linux" as well as "Arch Linux 32".