### PR TITLE
[HRDN-7231] When calling wc, use the short -l flag instead of --lines…

### DIFF
--- a/include/tests_hardening
+++ b/include/tests_hardening
@@ -114,7 +114,7 @@
         LogText "Test: Check for registered non-native binary formats"
         NFORMATS=0
         if [ -d /proc/sys/fs/binfmt_misc ]; then
-            NFORMATS=$(${FINDBINARY} /proc/sys/fs/binfmt_misc -type f -not -name register -not -name status | ${WCBINARY} --lines)
+            NFORMATS=$(${FINDBINARY} /proc/sys/fs/binfmt_misc -type f -not -name register -not -name status | ${WCBINARY} -l)
         fi
         if [ ${NFORMATS} -eq 0 ]; then
             LogText "Result: no non-native binary formats found"


### PR DESCRIPTION
… to make it work with busybox's wc implementation as well.

On Alpine Linux with Busybox when using the long ``--lines`` argument the test fails with ``/usr/bin/wc: unrecognized option: lines``.