### PR TITLE
Fix Big Sur Detection and add macOS Monterey

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -62,7 +62,8 @@
                     10.13 | 10.13.[0-9]*) OS_FULLNAME="macOS High Sierra (${OS_VERSION})" ;;
                     10.14 | 10.14.[0-9]*) OS_FULLNAME="macOS Mojave (${OS_VERSION})" ;;
                     10.15 | 10.15.[0-9]*) OS_FULLNAME="macOS Catalina (${OS_VERSION})" ;;
-                    11.0 | 11.0[0-9]*) OS_FULLNAME="macOS Big Sur (${OS_VERSION})" ;;
+                    11 | 11.[0-9]*) OS_FULLNAME="macOS Big Sur (${OS_VERSION})" ;;
+                    12 | 12.[0-9]*) OS_FULLNAME="macOS Monterey (${OS_VERSION})" ;;
                     *) echo "Unknown macOS version. Do you know what version it is? Create an issue at ${PROGRAM_SOURCE}" ;;
                 esac
             else


### PR DESCRIPTION
Fixed the macOS Big Sur (Version 11) detection and added support for macOS Monterey (Version 12)