### PR TITLE
Adding Artix Linux to osdetection

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -173,6 +173,11 @@
                             OS_FULLNAME="Arch Linux 32"
                             OS_VERSION="Rolling release"
                         ;;
+                        artix")
+                            LINUX_VERSION="Artix Linux"
+                            OS_FULLNAME="Artix Linux"
+                            OS_VERSION="Rolling release"
+                        ;;
                         "bunsenlabs")
                             LINUX_VERSION="BunsenLabs"
                             OS_NAME="BunsenLabs"


### PR DESCRIPTION
By request of #1179, in order to add Artix Linux to lynis.