### PR TITLE
Adding support for Alpine Package Keeper

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -134,6 +134,7 @@
                             aide)                   AIDEBINARY=${BINARY};              LogText "  Found known binary: aide (file integrity checker) - ${BINARY}" ;;
                             apache2)                HTTPDBINARY=${BINARY};             LogText "  Found known binary: apache2 (web server) - ${BINARY}" ;;
                             apt)                    APTBINARY=${BINARY};               LogText "  Found known binary: apt (package manager) - ${BINARY}" ;;
+                            apk)                    APKBINARY=${BINARY};               LogText "  Found known binary: apk (package manager) - ${BINARY}" ;;
                             arch-audit)             ARCH_AUDIT_BINARY="${BINARY}";     LogText "  Found known binary: arch-audit (auditing utility to test for vulnerable packages) - ${BINARY}" ;;
                             auditd)                 AUDITDBINARY=${BINARY};            LogText "  Found known binary: auditd (audit framework) - ${BINARY}" ;;
                             awk)                    AWKBINARY=${BINARY};               LogText "  Found known binary: awk (string tool) - ${BINARY}" ;;

--- a/include/consts
+++ b/include/consts
@@ -43,6 +43,7 @@ ETC_PATHS="/etc /usr/local/etc"
 # == Variable initializing ==
 #
     APTBINARY=""
+    APKBINARY=""
     ARCH_AUDIT_BINARY=""
     AUDITORNAME=""
     AUDITCTLBINARY=""

--- a/include/functions
+++ b/include/functions
@@ -2090,6 +2090,9 @@
         elif [ -n "${XBPSBINARY}" ]; then
             output=$(${XBPSBINARY} ${package} 2> /dev/null | ${GREPBINARY} "^ii")
             exit_code=$?
+        elif [ -n "${APKBINARY}" ]; then
+            output=$(${APKBINARY} search ${package} 2> /dev/null | ${GREPBINARY} ${package})
+            exit_code=$?
         else
             if [ "${package}" != "__dummy__" ]; then
                 ReportException "PackageIsInstalled:01 (test=${TEST_NO:-unknown})"

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -468,6 +468,34 @@
 #################################################################################
 #
     # Test        : PKGS-7346
+    # Description : Check Alpine Package Keeper (apk)
+    if [ -x ${ROOTDIR}/sbin/apk ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    Register --test-no PKGS-7346 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Querying apk"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        COUNT=0
+        Display --indent 4 --text "- Searching apk package manager" --result "${STATUS_FOUND}" --color GREEN
+        LogText "Result: Found apk binary"
+        Report "package_manager[]=apk"
+        PACKAGE_MGR_PKG=1
+        LogText "Test: Querying apk info -v to get package list"
+        Display --indent 6 --text "- Querying package manager"
+        LogText "Output:"
+        SPACKAGES=$(apk info -v | ${SEDBINARY} -r -e 's/([a-z,A-Z,0-9,_,-,.]{1,250})-([a-z,A-Z,0-9,.]+-r[a-z,A-Z,0-9]+)/\1,\2/' | sort)
+        for J in ${SPACKAGES}; do
+            COUNT=$((COUNT + 1))
+            PACKAGE_NAME=$(echo ${J} | ${CUTBINARY} -d ',' -f1)
+            PACKAGE_VERSION=$(echo ${J} | ${CUTBINARY} -d ',' -f2)
+            LogText "Found package: ${PACKAGE_NAME} (version: ${PACKAGE_VERSION})"
+            INSTALLED_PACKAGES="${INSTALLED_PACKAGES}|${PACKAGE_NAME},${PACKAGE_VERSION}"
+        done
+        Report "installed_packages=${COUNT}"
+    else
+        LogText "Result: apk "${STATUS_NOT_FOUND}", test skipped"
+    fi
+#
+#################################################################################
+#
+    # Test        : PKGS-7346
     # Description : Check packages which are removed, but still own configuration files, cron jobs etc
     # Notes       : Cleanup: for pkg in $(dpkg -l | ${GREPBINARY} "^rc" | ${CUTBINARY} -d' ' -f3); do aptitude purge ${pkg}; done
     if [ -x ${ROOTDIR}usr/bin/dpkg ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
@@ -1233,6 +1261,41 @@
         fi
     fi
 
+#
+#################################################################################
+#
+    # Test        : PKGS-7395
+    # Description : Check Alpine upgradeable packages
+    if [ "${LINUX_VERSION}" = "Alpine Linux" ]  && [ -x "${ROOTDIR}sbin/apk" ]; then
+        PREQS_MET="YES"
+    else
+        PREQS_MET="NO"
+    fi
+
+    Register --test-no PKGS-7395 --os Linux --preqs-met ${PREQS_MET} --weight L --network YES --category security --description "Check for Alpine updates"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        if [ ${REFRESH_REPOSITORIES} -eq 1 ]; then
+            LogText "Action: updating package repository with apk"
+            ${ROOTDIR}sbin/apk update
+            LogText "Result: apk finished"
+        else
+            LogText "Result: using a possibly outdated repository, as updating is disabled via configuration"
+        fi
+        LogText "Test: Checking packages which can be upgraded via apk version -l '<'"
+        FIND=$(${ROOTDIR}sbin/apk version -l '<' | ${GREPBINARY} '<' | ${SEDBINARY} 's/\s\+<\s/</g')
+        if [ -z "${FIND}" ]; then
+            LogText "Result: no packages found which can be upgraded"
+            Display --indent 2 --text "- Checking upgradeable packages" --result "${STATUS_NONE}" --color GREEN
+            AddHP 3 3
+        else
+            LogText "Result: found one or more packages which can be upgraded"
+            Display --indent 2 --text "- Checking upgradeable packages" --result "${STATUS_FOUND}" --color YELLOW
+            for ITEM in ${FIND}; do
+                ITEM=$(echo ${ITEM} | ${SEDBINARY}  -r -e 's/([a-z,A-Z,0-9,_,-,.]{1,250})-([a-z,A-Z,0-9,.]+-r[a-z,A-Z,0-9]+)<([a-z,A-Z,0-9,-,.]+)/\1 from \2 to \3/')
+                LogText "${ITEM}"
+            done
+        fi
+    fi
 #
 #################################################################################
 #


### PR DESCRIPTION
- Added known binary apk
- Updated function 'PackageIsInstalled' to use apk when available
- Added two tests to tests_ports_packages
  - PKGS-7346 - Check apk and log/report installed packages
  - PKGS-7395 - Check apk for packages that can be upgraded

