### PR TITLE
allow unknown number of spaces in modprobe blacklists

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -619,7 +619,6 @@
                         Display --indent 2 --text "- Mount options of ${FILESYSTEM}" --result "${STATUS_PARTIALLY_HARDENED}" --color YELLOW
                         AddHP 4 5
                     else
-                        # if 
                         if ContainsString "defaults" "${FOUND_FLAGS}"; then
                             LogText "Result: marked ${FILESYSTEM} options as default (not hardened)"
                             Display --indent 2 --text "- Mount options of ${FILESYSTEM}" --result "${STATUS_DEFAULT}" --color YELLOW
@@ -838,13 +837,13 @@
                 fi
                 FIND=$(${LSBINARY} ${ROOTDIR}etc/modprobe.d/* 2> /dev/null)
                 if [ -n "${FIND}" ]; then
-		                FIND1=$(${EGREPBINARY} "blacklist ${FS}" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
-		                FIND2=$(${EGREPBINARY} "install ${FS} /bin/true" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
-                    if [ -n "${FIND1}" ] || [ -n "${FIND2}" ]; then
-                        Display --indent 4 --text "- Module $FS is blacklisted" --result "OK" --color GREEN
-                        LogText "Result: module ${FS} is blacklisted"
-                    fi
-		            fi
+                    FIND1=$(${EGREPBINARY} "^blacklist \+${FS}$" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
+                    FIND2=$(${EGREPBINARY} "^install \+${FS} \+/bin/true$" ${ROOTDIR}etc/modprobe.d/* | ${GREPBINARY} -v "#")
+                        if [ -n "${FIND1}" ] || [ -n "${FIND2}" ]; then
+                            Display --indent 4 --text "- Module $FS is blacklisted" --result "OK" --color GREEN
+                            LogText "Result: module ${FS} is blacklisted"
+                        fi
+                fi
             done
             if [ ${FOUND} -eq 1 ]; then
                 Display --indent 4 --text "- Discovered kernel modules: ${AVAILABLE_MODPROBE_FS}"

--- a/include/tests_networking
+++ b/include/tests_networking
@@ -750,7 +750,7 @@
                         UNCOMMON_PROTOCOL_DISABLED=0
                         # First check modprobe.conf
                         if [ -f ${ROOTDIR}etc/modprobe.conf ]; then
-                            DATA=$(${GREPBINARY} "^install ${P} /bin/true" ${ROOTDIR}etc/modprobe.conf)
+                            DATA=$(${GREPBINARY} "^install \+${P} \+/bin/true$" ${ROOTDIR}etc/modprobe.conf)
                             if [ -n "${DATA}" ]; then
                                 LogText "Result: found ${P} module disabled via modprobe.conf"
                                 UNCOMMON_PROTOCOL_DISABLED=1
@@ -759,7 +759,7 @@
                         # Then additional modprobe configuration files
                         if [ -d ${ROOTDIR}etc/modprobe.d ]; then
                             # Return file names (-l) and suppress errors (-s)
-                            DATA=$(${GREPBINARY} -l -s "^install ${P} /bin/true" ${ROOTDIR}etc/modprobe.d/*)
+                            DATA=$(${GREPBINARY} -l -s "^install \+${P} \+/bin/true$" ${ROOTDIR}etc/modprobe.d/*)
                             if [ -n "${DATA}" ]; then
                                 UNCOMMON_PROTOCOL_DISABLED=1
                                 for F in ${DATA}; do


### PR DESCRIPTION
This PR:
- Allows unknown number of spaces when blacklisting kernel modules
- Closes #1219 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>