### PR TITLE
Extend HasCorrectCheckPermissions logging

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1320,9 +1320,8 @@
                 CHECK_PERMISSION=$(echo "${CHECK_PERMISSION}" | ${AWKBINARY} '{printf "%03d",$1}')
 
                 # First try stat command
-                LogText "Test: checking if file ${CHECKFILE} has the permissions set to ${CHECK_PERMISSION} or more restrictive"
+                LogText "Test: checking if file ${CHECKFILE} has the permissions set to ${CHECK_PERMISSION} (${CHECKPERMISSION_FULL}) or more restrictive"
                 if [ -n "${STATBINARY}" ]; then
-
                     case ${OS} in
                         *BSD | "macOS")
                             # BSD and macOS have no --format, only short notation
@@ -1388,7 +1387,7 @@
                 fi
             done
 
-            LogText "Outcome: permissions of file ${CHECKFILE} are not matching expected value (${DATA} != ${CHECKPERMISSION_FULL})"
+            LogText "Outcome: permissions of file ${CHECKFILE} are not matching expected value (${DATA} != ${CHECK_PERMISSION})"
             # No match, return exit code 1
             return 1
         fi


### PR DESCRIPTION
This PR:
- Adds human readable output to permission check log text
- Present expected permission value in octal for easier comparison
- Closes #1220 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>