### PR TITLE
Add Garuda Linux to audit package test tool

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -296,7 +296,7 @@
 #
     # Test        : PKGS-7320
     # Description : Check available of arch-audit
-    if [ "${OS_FULLNAME}" = "Arch Linux" ] || [ "${OS_FULLNAME}" = "Arch Linux 32" ]; then PREQS_MET="YES"; SKIPREASON=""; else PREQS_MET="NO"; SKIPREASON="Test only applies to Arch Linux"; fi
+    if [ "${OS_FULLNAME}" = "Arch Linux" ] || [ "${OS_FULLNAME}" = "Arch Linux 32" ] || [ "${OS_FULLNAME}" = "Garuda Linux" ]; then PREQS_MET="YES"; SKIPREASON=""; else PREQS_MET="NO"; SKIPREASON="Test only applies to Arch Linux and Garuda Linux"; fi
     Register --test-no PKGS-7320 --os "Linux" --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Checking for arch-audit tooling"
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ -z "${ARCH_AUDIT_BINARY}" ]; then


### PR DESCRIPTION
This fixes the bug I've encountered #1230, by adding `Garuda Linux` to the valid `$OS_FULLNAME` to be tested.

If any other changes are needed, feel free to tell me @mboelen or any other maintainer of this repo.