### PR TITLE
[PKGS-7322] Amend the arch-audit command to fetch the list of vulnerable packages

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -347,14 +347,14 @@
     Register --test-no PKGS-7322 --os "Linux" --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Discover vulnerable packages with arch-audit"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: checking arch-audit output for vulnerable packages"
-        FIND=$(${ARCH_AUDIT_BINARY} | ${SEDBINARY} 's/\.\..*$//' | ${SEDBINARY} 's/, //g' | ${SEDBINARY} 's/\(\["\|"\]\)//g' | ${SEDBINARY} 's/""/,/g' | ${AWKBINARY} '{ if($1=="Package") { print $2"|"$6"|"}}' | ${AWKBINARY} -F'|' 'NF>1{a[$1] = a[$1]","$2}END{for(i in a){print i""a[i]"|"}}' | ${SEDBINARY} 's/,/|cve=/' | ${SORTBINARY})
+        FIND=$(${ARCH_AUDIT_BINARY} -f "%n|%c" | ${SEDBINARY} 's/\.\..*$//' | ${SEDBINARY} 's/, /,/g' | ${SORTBINARY})
         if [ -z "${FIND}" ]; then
             LogText "Result: no vulnerable packages found with arch-audit"
             AddHP 10 10
         else
             LogText "Result: found one or more vulnerable packages"
             for ITEM in ${FIND}; do
-                LogText "Found line: ${ITEM}"
+                LogText "Found vunerable package: ${ITEM}"
                 Report "vulnerable_package[]=${ITEM}"
                 AddHP 1 2
             done


### PR DESCRIPTION
Updated the arch-audit command to list out the vulnerable packages.
https://security.archlinux.org/

 Fix Issue #1277