### PR TITLE
osdetection: add PostmarketOS

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -337,6 +337,13 @@
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="Pop!_OS"
                         ;;
+                        "postmarketos")
+                            LINUX_VERSION="PostmarketOS"
+                            LINUX_VERSION_LIKE="Alpine"
+                            OS_NAME=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "pureos")
                             LINUX_VERSION="PureOS"
                             LINUX_VERSION_LIKE="Debian"


### PR DESCRIPTION
Running Lynis `master` on my Pinephone, it failed to detect the OS. Indeed, PostmarketOS was not yet included in the OS detection logic.

Here is the `/etc/os-release` for reference. 

```
PRETTY_NAME="postmarketOS v21.12.3"
NAME="postmarketOS"
VERSION_ID="v21.12.3"
VERSION="v21.12.3"
ID="postmarketos"
ID_LIKE="alpine"
HOME_URL="https://www.postmarketos.org/"
SUPPORT_URL="https://gitlab.com/postmarketOS"
BUG_REPORT_URL="https://gitlab.com/postmarketOS/pmaports/issues"
```

Let me know if I missed anything, or if more testing is required.