### PR TITLE
Only test Compression if sshd version < 7.4

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -135,7 +135,6 @@
         SSHOPS="AllowTcpForwarding:NO,LOCAL,YES:=\
                 ClientAliveCountMax:2,4,16:<\
                 ClientAliveInterval:300,600,900:<\
-                Compression:NO,,YES:=\
                 FingerprintHash:SHA256,MD5,:=\
                 GatewayPorts:NO,,YES:=\
                 IgnoreRhosts:YES,,NO:=\
@@ -158,12 +157,12 @@
         # OpenSSH had some options removed over time. Based on the version we add some additional options to check
         if [ ${OPENSSHD_VERSION_MAJOR} -lt 7 ]; then
             LogText "Result: added additional options for OpenSSH 6.x and lower"
-            SSHOPS="${SSHOPS} UsePrivilegeSeparation:SANDBOX,YES,NO:=  Protocol:2,,1:="
+            SSHOPS="${SSHOPS} Compression:(DELAYED|NO),,YES:= UsePrivilegeSeparation:SANDBOX,YES,NO:=  Protocol:2,,1:="
         elif [ ${OPENSSHD_VERSION_MAJOR} -eq 7 ]; then
             # Protocol 1 support removed (OpenSSH 7.4 and later)
             if [ ${OPENSSHD_VERSION_MINOR} -lt 4 ]; then
                 LogText "Result: added additional options for OpenSSH < 7.4"
-                SSHOPS="${SSHOPS} Protocol:2,,1:="
+                SSHOPS="${SSHOPS} Compression:(DELAYED|NO),,YES:= Protocol:2,,1:="
             fi
             # UsePrivilegedSeparation removed (OpenSSH 7.5 and later)
             if [ ${OPENSSHD_VERSION_MINOR} -lt 5 ]; then


### PR DESCRIPTION
This PR:
- Removes the Compression test for `sshd` versions > 7.4
- Closes #1291

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>