### PR TITLE
osdetection: add KDE Neon

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -271,6 +271,13 @@
                             OS_NAME="Kali Linux"
                             OS_VERSION="Rolling release"
                         ;;
+                        "neon")
+                            LINUX_VERSION="KDE Neon"
+                            LINUX_VERSION_LIKE="Ubuntu"
+                            OS_NAME="KDE Neon"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "linuxmint")
                             LINUX_VERSION="Linux Mint"
                             LINUX_VERSION_LIKE="Ubuntu"


### PR DESCRIPTION
Should close issue #1232, but I have a concern to point out: 

`VERSION_ID` reports the version of the Ubuntu version that KDE Neon is based on, while `VERSION` shows the version of KDE Neon itself. From I read from the script, everyone always uses `VERSION_ID` for the `OS_VERSION`, so I didn't know which one to use here and went with the flow. I'm not sure which of the two versions matter the most.

Please let me know if this should be changed.

<details>
  <summary>Contents of `/etc/os-release`</summary>
  
```
NAME="KDE neon"
VERSION="5.24"
ID=neon
ID_LIKE="ubuntu debian"
PRETTY_NAME="KDE neon User - 5.24"
VARIANT="User Edition"
VARIANT_ID=user
VERSION_ID="20.04"
HOME_URL="https://neon.kde.org/"
SUPPORT_URL="https://neon.kde.org/"
BUG_REPORT_URL="https://bugs.kde.org/"
LOGO=start-here-kde-neon
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```
</details>