### PR TITLE
add check for ESET oaeventd

### DIFF
--- a/include/tests_malware
+++ b/include/tests_malware
@@ -186,8 +186,8 @@
         fi
 
         # ESET security products
-        LogText "Test: checking process esets_daemon"
-        if IsRunning "esets_daemon"; then
+        LogText "Test: checking process esets_daemon or oaeventd (ESET)"
+        if IsRunning "esets_daemon" || IsRunning "oaeventd"; then
             FOUND=1
             ESET_DAEMON_RUNNING=1
             MALWARE_DAEMON_RUNNING=1


### PR DESCRIPTION
This PR:
- adds a check for the ESET Endpoint Antivirus `oaeventd` process
- closes #1285 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>