### PR TITLE
Support Arch Linux ARM detection

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -169,6 +169,11 @@
                             OS_FULLNAME="Arch Linux"
                             OS_VERSION="Rolling release"
                         ;;
+                        "archarm")
+                            LINUX_VERSION="Arch Linux ARM"
+                            OS_FULLNAME="Arch Linux ARM"
+                            OS_VERSION="Rolling release"
+                        ;;
                         "arch32")
                             LINUX_VERSION="Arch Linux 32"
                             OS_FULLNAME="Arch Linux 32"


### PR DESCRIPTION
Contents of `/etc/os-release`:
```bash
NAME="Arch Linux ARM"
PRETTY_NAME="Arch Linux ARM"
ID=archarm
ID_LIKE=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinuxarm.org/"
DOCUMENTATION_URL="https://archlinuxarm.org/wiki"
SUPPORT_URL="https://archlinuxarm.org/forum"
BUG_REPORT_URL="https://github.com/archlinuxarm/PKGBUILDs/issues"
LOGO=archlinux-logo
```