### PR TITLE
Added Wazuh as a malware scanner/antivirus and rootkit detection tool

### DIFF
--- a/include/tests_malware
+++ b/include/tests_malware
@@ -43,6 +43,7 @@
     SYMANTEC_SCANNER_RUNNING=0
     SYNOLOGY_DAEMON_RUNNING=0
     TRENDMICRO_DSA_DAEMON_RUNNING=0
+    WAZUH_DAEMON_RUNNING=0
 #
 #################################################################################
 #
@@ -314,8 +315,10 @@
             if IsVerbose; then Display --indent 2 --text "- ${GEN_CHECKING} Wazuh agent" --result "${STATUS_FOUND}" --color GREEN; fi
             LogText "Result: found Wazuh component"
             FOUND=1
+            WAZUH_DAEMON_RUNNING=1
             MALWARE_DAEMON_RUNNING=1
             MALWARE_SCANNER_INSTALLED=1
+            ROOTKIT_SCANNER_FOUND=1
             Report "malware_scanner[]=wazuh"
         fi
 

--- a/include/tests_malware
+++ b/include/tests_malware
@@ -308,6 +308,17 @@
             Report "malware_scanner[]=trend-micro-av"
         fi
 
+        # Wazuh agent
+        LogText "Test: checking process wazuh-agent to test for Wazuh agent"
+        if IsRunning "wazuh-agent"; then
+            if IsVerbose; then Display --indent 2 --text "- ${GEN_CHECKING} Wazuh agent" --result "${STATUS_FOUND}" --color GREEN; fi
+            LogText "Result: found Wazuh component"
+            FOUND=1
+            MALWARE_DAEMON_RUNNING=1
+            MALWARE_SCANNER_INSTALLED=1
+            Report "malware_scanner[]=wazuh"
+        fi
+
         if [ ${FOUND} -eq 0 ]; then
             LogText "Result: no commercial anti-virus tools found"
             AddHP 0 3


### PR DESCRIPTION
As mentioned in https://github.com/CISOfy/lynis/issues/1304, Wazuh is a fork of OSSEC and is being actively maintained. Wazuh agent has capabilities to detect and prevent malware and rootkits acting as an EDR. Therefore, it seems feasible to add wazuh-agent to the accepted antivirus and rootkit detection products. Current capabilities satisfy [test HRDN-7230](https://cisofy.com/lynis/controls/HRDN-7230/).

https://documentation.wazuh.com/current/user-manual/capabilities/anomalies-detection/index.html
https://documentation.wazuh.com/current/pci-dss/rootkit-detection.html