### PR TITLE
Added wazuh-syscheckd as a file integrity monitoring capability

### DIFF
--- a/include/tests_file_integrity
+++ b/include/tests_file_integrity
@@ -399,6 +399,25 @@
 #
 #################################################################################
 #
+    # Test        : FINT-4344
+    # Description : Check if Wazuh system integrity tool is running
+    Register --test-no FINT-4328 --weight L --network NO --category security --description "Wazuh syscheck daemon running"
+    if [ ${SKIPTEST} -eq 0 ]; then
+        LogText "Test: Checking if Wazuh syscheck daemon is running"
+        if IsRunning "wazuh-syscheckd"; then
+            LogText "Result: syscheck (Wazuh) active"
+            Report "file_integrity_tool[]=wazuh"
+            FILE_INT_TOOL="wazuh-syscheck"
+            FILE_INT_TOOL_FOUND=1
+            Display --indent 4 --text "- Wazuh (syscheck)" --result "${STATUS_FOUND}" --color GREEN
+        else
+            LogText "Result: syscheck (Wazuh) is not active"
+            if IsVerbose; then Display --indent 4 --text "- Wazuh" --result "${STATUS_NOT_FOUND}" --color WHITE; fi
+        fi
+    fi
+#
+#################################################################################
+#
     # Test        : FINT-4402 (was FINT-4316)
     # Description : Check if AIDE is configured to use SHA256 or SHA512 checksums
     if [ ! "${AIDEBINARY}" = "" -a -n "${AIDECONFIG}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi


### PR DESCRIPTION
As mentioned in https://github.com/CISOfy/lynis/issues/1319, Wazuh is a fork of OSSEC and is being actively maintained. Wazuh agent has capabilities to check file integrity by default. File integrity -and Registry integrity for Windows- capabilities are based on a daemon called [wazuh-syscheckd](https://documentation.wazuh.com/current/user-manual/reference/daemons/wazuh-syscheckd.html). It runs when [syscheck](https://documentation.wazuh.com/current/user-manual/reference/ossec-conf/syscheck.html#reference-ossec-syscheck) configuration is set up on the agents.

Therefore, it seems feasible to add Wazuh to the accepted logging products. Current capabilities satisfy [test FINT-4350](https://cisofy.com/lynis/controls/FINT-4350/).

https://documentation.wazuh.com/current/user-manual/capabilities/log-data-collection/
https://documentation.wazuh.com/current/pci-dss/log-analysis.html