### PR TITLE
find redis.conf if /snap directory exists 

### DIFF
--- a/include/tests_databases
+++ b/include/tests_databases
@@ -302,6 +302,12 @@
         if [ ${QNAP_DEVICE} -eq 1 ]; then
             PATHS="${PATHS} ${ROOTDIR}share/CACHEDEV1_DATA/.qpkg/QKVM/usr/etc/redis.conf"
         fi
+        if [ -d "/snap" ]; then
+          for SNAP_PATH in $(${FINDBINARY} /snap -name 'redis.conf' -type f); do
+            PATHS="${PATHS} ${SNAP_PATH}"
+          done
+        fi
+
         ALLFILES=$(${LSBINARY} ${ROOTDIR}etc/redis.conf 2> /dev/null)
         FOUND=0
         for DIR in ${PATHS}; do

--- a/include/tests_databases
+++ b/include/tests_databases
@@ -85,7 +85,7 @@
         LogText "Test: Trying to login to local MySQL server without password"
 
         # "-u root --password=" avoids ~/.my.cnf authentication settings
-        # "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used 
+        # "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used
         FIND=$(${MYSQLCLIENTBINARY} --default-auth=mysql_native_password  --no-defaults -u root --password= --silent --batch --execute="SELECT count(*) FROM mysql.user WHERE user = 'root' AND plugin = 'mysql_native_password' AND authentication_string = ''" mysql > /dev/null 2>&1; echo $?)
         if [ "${FIND}" = "0" ]; then
            LogText "Result: Login succeeded, no MySQL root password set!"
@@ -213,7 +213,7 @@
                 ReportWarning "${TEST_NO}" "PostgreSQL configuration file ${CF} is world readable and might leak sensitive details" "${CF}" "Use chmod 600 to change file permissions"
             else
                 LogText "Result: great, configuration file ${CF} is not world readable"
-            fi            
+            fi
         done
     fi
 #

--- a/include/tests_databases
+++ b/include/tests_databases
@@ -303,7 +303,7 @@
             PATHS="${PATHS} ${ROOTDIR}share/CACHEDEV1_DATA/.qpkg/QKVM/usr/etc/redis.conf"
         fi
         if [ -d "/snap" ]; then
-          for SNAP_PATH in $(${FINDBINARY} /snap -name 'redis.conf' -type f); do
+          for SNAP_PATH in $(${FINDBINARY} /snap -name 'redis.conf' -type f | ${SEDBINARY} 's/redis.conf$//g'); do
             PATHS="${PATHS} ${SNAP_PATH}"
           done
         fi

--- a/include/tests_databases
+++ b/include/tests_databases
@@ -302,8 +302,8 @@
         if [ ${QNAP_DEVICE} -eq 1 ]; then
             PATHS="${PATHS} ${ROOTDIR}share/CACHEDEV1_DATA/.qpkg/QKVM/usr/etc/redis.conf"
         fi
-        if [ -d "/snap" ]; then
-          for SNAP_PATH in $(${FINDBINARY} /snap -name 'redis.conf' -type f | ${SEDBINARY} 's/redis.conf$//g'); do
+        if [ -d "${ROOTDIR}snap" ]; then
+          for SNAP_PATH in $(${FINDBINARY} ${ROOTDIR}snap -name 'redis.conf' -type f | ${SEDBINARY} 's/redis.conf$//g'); do
             PATHS="${PATHS} ${SNAP_PATH}"
           done
         fi


### PR DESCRIPTION
This PR:
- uses the`${FINDBINARY}` to locate redis.conf if  the /snap directory exists
- closes issue #1327 
- remove some end-of-line whitespaces