### PR TITLE
Update tests_database: Redis configuration file

### DIFF
--- a/include/tests_databases
+++ b/include/tests_databases
@@ -311,7 +311,7 @@
     if [ ${REDIS_RUNNING} -eq 1 ]; then PREQS_METS="YES"; else PREQS_MET="NO"; SKIPREASON="Redis not running"; fi
     Register --test-no DBS-1882 --weight L --network NO --preqs-met "${PREQS_MET}" --skip-reason "${SKIPREASON}" --category security --description "Redis configuration file"
     if [ ${SKIPTEST} -eq 0 ]; then
-        PATHS="${ROOTDIR}etc/redis ${ROOTDIR}usr/local/etc/redis ${ROOTDIR}usr/local/redis/etc"
+        PATHS="${ROOTDIR}etc/redis ${ROOTDIR}usr/local/etc ${ROOTDIR}usr/local/etc/redis ${ROOTDIR}usr/local/redis/etc"
         if [ ${QNAP_DEVICE} -eq 1 ]; then
             PATHS="${PATHS} ${ROOTDIR}share/CACHEDEV1_DATA/.qpkg/QKVM/usr/etc/redis.conf"
         fi


### PR DESCRIPTION
On FreeBSD, the Redis configuration file is typically stored as /usr/local/etc/redis.conf.