### PR TITLE
Verify the linux OS supports nanoseconds

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2562,15 +2562,17 @@
 
     GetTimestamp() {
         ts=0
-        case "${OS}" in
-            "Linux")
-                ts=$(date "+%s%N")
-            ;;
-            *)
-                ts=$(date "+%s")
-            ;;
-        esac
-        echo $ts
+		# Detect if the implementation of date supports nanoseconds,
+	    if [ "${OS}" = "Linux" ]; then
+		    current_nanoseconds=$(date "+%N")
+		    # Verify if the result of the command is a number
+            if [ -n "$current_nanoseconds" ] && [ "$current_nanoseconds" -eq "$current_nanoseconds" ] 2>/dev/null; then
+               ts=$(date "+%s%N")
+            else
+		       ts=$(date "+%s")
+		    fi
+        fi
+		echo $ts
     }
 
     Register() {

--- a/include/functions
+++ b/include/functions
@@ -2562,17 +2562,19 @@
 
     GetTimestamp() {
         ts=0
-		# Detect if the implementation of date supports nanoseconds,
-	    if [ "${OS}" = "Linux" ]; then
-		    current_nanoseconds=$(date "+%N")
-		    # Verify if the result of the command is a number
+        # Detect if the implementation of date supports nanoseconds,
+        if [ "${OS}" = "Linux" ]; then
+            current_nanoseconds=$(date "+%N")
+            # Verify if the result of the command is a number
             if [ -n "$current_nanoseconds" ] && [ "$current_nanoseconds" -eq "$current_nanoseconds" ] 2>/dev/null; then
                ts=$(date "+%s%N")
             else
-		       ts=$(date "+%s")
-		    fi
+                ts=$(date "+%s")
+            fi
+        else
+            ts=$(date "+%s")
         fi
-		echo $ts
+        echo $ts
     }
 
     Register() {

--- a/include/functions
+++ b/include/functions
@@ -2567,7 +2567,7 @@
             current_nanoseconds=$(date "+%N")
             # Verify if the result of the command is a number
             if [ -n "$current_nanoseconds" ] && [ "$current_nanoseconds" -eq "$current_nanoseconds" ] 2>/dev/null; then
-               ts=$(date "+%s%N")
+                ts=$(date "+%s%N")
             else
                 ts=$(date "+%s")
             fi


### PR DESCRIPTION
Add extra check to verify the linux OS supports nanoseconds. This might not be the case with certain busybox implementations.