### PR TITLE
Added Slackware support for PackageIsInstalled() function

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2086,6 +2086,10 @@
         elif [ -n "${PKGINFOBINARY}" ]; then
             output=$(${PKGINFOBINARY} -q -e ${package} >/dev/null 2>&1)
             exit_code=$?  # 0=package installed, 1=package not installed
+        # Slackware also has RPM for some reason and that's why this test precedes the RPMBINARY test
+        elif [ "${OS_NAME}" = "Slackware Linux" -a -d "${ROOTDIR}/var/lib/pkgtools/packages" ]; then
+            output=$( ls ${ROOTDIR}/var/lib/pkgtools/packages/ 2> /dev/null | ${GREPBINARY} "^${package}-[^-]\+-[^-]\+-[^-]\+$" )
+            exit_code=$?
         elif [ -n "${RPMBINARY}" ]; then
             output=$(${RPMBINARY} --quiet -q ${package} > /dev/null 2>&1)
             exit_code=$?


### PR DESCRIPTION
Slackware's `pkgtools` doesn't seem to have "is this package installed" functionality, but all the packages can be seen in `/var/lib/pkgtools/packages/` (though that path was introduced/changed in the recent [Slackware 15.0](https://ftp.osuosl.org/pub/slackware/slackware64-15.0/ChangeLog.txt)).

E.g. now with the `INSE-8000` test it now sees the file `inetd-1.79s-x86_64-14` (the suffix is version-arch-revision) and flags it as installed.