### PR TITLE
osdetection: add Arcolinux

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -174,6 +174,11 @@
                             OS_FULLNAME="Arch Linux 32"
                             OS_VERSION="Rolling release"
                         ;;
+                        "arcolinux")
+                            LINUX_VERSION="ArcoLinux"
+                            OS_FULLNAME="ArcoLinux"
+                            OS_VERSION="Rolling release"
+                        ;;
                         "artix")
                             LINUX_VERSION="Artix Linux"
                             OS_FULLNAME="Artix Linux"


### PR DESCRIPTION
Adds ArcoLinux to osdetection. Formly known as ArchMerge, and similar to Garuda or EndeavourOS.
If the formatting is incorrect please let me know and I will correct it quickly.
This should close issue #1267 
Output of `/etc/os-release`:
```
NAME=ArcoLinux
ID=arcolinux
ID_LIKE=arch
BUILD_ID=rolling
ANSI_COLOR="0;36"
HOME_URL="https://arcolinux.info/"
SUPPORT_URL="https://arcolinuxforum.com/"
BUG_REPORT_URL="https://github.com/arcolinux"
LOGO=arcolinux-hello
```