### PR TITLE
Change xargs -i to xargs -I

### DIFF
--- a/include/tests_databases
+++ b/include/tests_databases
@@ -85,7 +85,7 @@
         LogText "Test: Trying to login to local MySQL server without password"
 
         # "-u root --password=" avoids ~/.my.cnf authentication settings
-        # "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used 
+        # "plugin = 'mysql_native_password' AND authentication_string = ''" avoids false positives when secure plugins are used
         FIND=$(${MYSQLCLIENTBINARY} --default-auth=mysql_native_password  --no-defaults -u root --password= --silent --batch --execute="SELECT count(*) FROM mysql.user WHERE user = 'root' AND plugin = 'mysql_native_password' AND authentication_string = ''" mysql > /dev/null 2>&1; echo $?)
         if [ "${FIND}" = "0" ]; then
            LogText "Result: Login succeeded, no MySQL root password set!"
@@ -204,7 +204,7 @@
     Register --test-no DBS-1828 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Test PostgreSQL configuration"
     if [ ${SKIPTEST} -eq 0 ]; then
         FIND_PATHS="${ROOTDIR}etc/postgres ${ROOTDIR}var/lib/postgres/data ${ROOTDIR}usr/local/pgsql/data"
-        CONFIG_FILES=$(${FINDBINARY} -L ${FIND_PATHS} -type f -name "*.conf" -print0 2> /dev/null | ${TRBINARY} -cd '[:print:]\0' | ${TRBINARY} -d '\n' | ${TRBINARY} '\0' '\n' | xargs -i sh -c 'test -r "{}" && echo "{}"' | ${SEDBINARY} "s/ /:space:/g")
+        CONFIG_FILES=$(${FINDBINARY} -L ${FIND_PATHS} -type f -name "*.conf" -print0 2> /dev/null | ${TRBINARY} -cd '[:print:]\0' | ${TRBINARY} -d '\n' | ${TRBINARY} '\0' '\n' | xargs -I sh -c 'test -r "{}" && echo "{}"' | ${SEDBINARY} "s/ /:space:/g")
         for CF in ${CONFIG_FILES}; do
             Report "postgresql_config_file[]=${CF}"
             LogText "Found configuration file (${CF})"
@@ -213,7 +213,7 @@
                 ReportWarning "${TEST_NO}" "PostgreSQL configuration file ${CF} is world readable and might leak sensitive details" "${CF}" "Use chmod 600 to change file permissions"
             else
                 LogText "Result: great, configuration file ${CF} is not world readable"
-            fi            
+            fi
         done
     fi
 #


### PR DESCRIPTION
From the man page:

-i[replace-str], --replace[=replace-str]
        This option is a synonym for -Ireplace-str if replace-str
        is specified.  If the replace-str argument is missing, the
        effect is the same as -I{}.  This option is deprecated;
        use -I instead.

The -i flag is not present on BSD xargs and is deprecated in GNU xargs.