### PR TITLE
osdetection: add macOS Ventura and Sonoma

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -64,6 +64,7 @@
                     10.15 | 10.15.[0-9]*) OS_FULLNAME="macOS Catalina (${OS_VERSION})" ;;
                     11 | 11.[0-9]*) OS_FULLNAME="macOS Big Sur (${OS_VERSION})" ;;
                     12 | 12.[0-9]*) OS_FULLNAME="macOS Monterey (${OS_VERSION})" ;;
+                    13 | 13.[0-9]*) OS_FULLNAME="macOS Ventura (${OS_VERSION})" ;;
                     *) echo "Unknown macOS version. Do you know what version it is? Create an issue at ${PROGRAM_SOURCE}" ;;
                 esac
             else

--- a/include/osdetection
+++ b/include/osdetection
@@ -65,6 +65,7 @@
                     11 | 11.[0-9]*) OS_FULLNAME="macOS Big Sur (${OS_VERSION})" ;;
                     12 | 12.[0-9]*) OS_FULLNAME="macOS Monterey (${OS_VERSION})" ;;
                     13 | 13.[0-9]*) OS_FULLNAME="macOS Ventura (${OS_VERSION})" ;;
+                    14 | 14.[0-9]*) OS_FULLNAME="macOS Sonoma (${OS_VERSION})" ;;
                     *) echo "Unknown macOS version. Do you know what version it is? Create an issue at ${PROGRAM_SOURCE}" ;;
                 esac
             else


### PR DESCRIPTION
Adds support for macOS Ventura (13.x) and Sonoma (14.x)

Fixes #1370