### PR TITLE
tests_mac_frameworks: check for existance of semanage binary

### DIFF
--- a/include/tests_mac_frameworks
+++ b/include/tests_mac_frameworks
@@ -158,10 +158,14 @@
                 Display --indent 6 --text "- Checking current mode and config file" --result "${STATUS_WARNING}" --color RED
             fi
             Display --indent 8 --text "Current SELinux mode: ${FIND}"
-            PERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${TRBINARY} '\n' ' ')
-            NPERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${WCBINARY} -l)
-            Display --indent 8 --text "Found ${NPERMISSIVE} permissive SELinux object types"
-            LogText "Permissive SELinux object types: ${PERMISSIVE}"
+            if [ -x "$SEMANAGEBINARY" ]; then
+                PERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${TRBINARY} '\n' ' ')
+                NPERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${WCBINARY} -l)
+                Display --indent 8 --text "Found ${NPERMISSIVE} permissive SELinux object types"
+                LogText "Permissive SELinux object types: ${PERMISSIVE}"
+            else
+                LogText "Result: semanage binary NOT found, can't analyse permissive domains"
+            fi
             UNCONFINED=$(${PSBINARY} -eo label,pid,command | ${GREPBINARY} '[u]nconfined_t' | ${TRBINARY} '\n' ' ')
             INITRC=$(${PSBINARY} -eo label,pid,command | ${GREPBINARY} '[i]nitrc_t' | ${TRBINARY} '\n' ' ')
             NUNCONFINED=$(${PSBINARY} -eo label | ${GREPBINARY} '[u]nconfined_t' | ${WCBINARY} -l)

--- a/include/tests_mac_frameworks
+++ b/include/tests_mac_frameworks
@@ -158,7 +158,7 @@
                 Display --indent 6 --text "- Checking current mode and config file" --result "${STATUS_WARNING}" --color RED
             fi
             Display --indent 8 --text "Current SELinux mode: ${FIND}"
-            if [ -x "$SEMANAGEBINARY" ]; then
+            if [ -n "${SEMANAGEBINARY}" ]; then
                 PERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${TRBINARY} '\n' ' ')
                 NPERMISSIVE=$(${SEMANAGEBINARY} permissive --list --noheading | ${WCBINARY} -l)
                 Display --indent 8 --text "Found ${NPERMISSIVE} permissive SELinux object types"


### PR DESCRIPTION
It's not installed everywhere, causing this error message:
/usr/share/lynis/include/tests_mac_frameworks: line 161: permissive: command not found
/usr/share/lynis/include/tests_mac_frameworks: line 162: permissive: command not found