### PR TITLE
Checking for errors, not only warning in docker info output

### DIFF
--- a/include/tests_containers
+++ b/include/tests_containers
@@ -107,7 +107,7 @@
             LogText "Result: disabling further Docker tests as docker version gave exit code other than zero (0)"
             RUN_DOCKER_TESTS=0
         fi
-        FIND=$(${DOCKERBINARY} info 2>&1 | ${GREPBINARY} "^WARNING:" | ${CUTBINARY} -d " " -f 2- | ${SEDBINARY} 's/ /:space:/g')
+        FIND=$(${DOCKERBINARY} info 2>&1 | ${GREPBINARY} -E "^WARNING:|^ERROR:" | ${CUTBINARY} -d " " -f 2- | ${SEDBINARY} 's/ /:space:/g')
         if [ ! "${FIND}" = "" ]; then
             LogText "Result: found warning(s) in output"
             for I in ${FIND}; do


### PR DESCRIPTION
When running lynis audit system as a non-privileged user, and assuming dockerd running as root, lynis will report an ERROR por Docker status but will report NONE for "Docker info output (warnings)", not reporting the error ("Docker daemon socket") that docker info reported. 

This pull request makes sure that error is reported and the hardening points are consistent with that error.