### PR TITLE
Fixing test on kernel major and minor version (FILE-6344). Issue 1367

### DIFF
--- a/include/tests_filesystems
+++ b/include/tests_filesystems
@@ -346,7 +346,13 @@
         LINUX_KERNEL_MAJOR=$(echo $OS_KERNELVERSION | ${AWKBINARY} -F. '{print $1}')
         LINUX_KERNEL_MINOR=$(echo $OS_KERNELVERSION | ${AWKBINARY} -F. '{print $2}')
         if [ -n "${LINUX_KERNEL_MAJOR}" -a -n "${LINUX_KERNEL_MINOR}" ]; then
-            if [ ${LINUX_KERNEL_MAJOR} -ge 3 -a ${LINUX_KERNEL_MINOR} -ge 3 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+            if [ ${LINUX_KERNEL_MAJOR} -ge 3 -a ${LINUX_KERNEL_MINOR} -ge 3 ]; then
+                PREQS_MET="YES";
+            elif [ ${LINUX_KERNEL_MAJOR} -ge 4 ]; then
+                PREQS_MET="YES";
+            else
+                PREQS_MET="NO";
+            fi
         else
             PREQS_MET="NO";
         fi


### PR DESCRIPTION
This pull request fixes issue 1367: https://github.com/CISOfy/lynis/issues/1367

Tested on:
- Debian 11, kernel 5.10.0. Failure and success.
- Ubuntu 19.04, kernel 5.0, which skipped the test because on minor version 0. Failure and success.
