### PR TITLE
Change in suggestion message. Issue 1354

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -717,7 +717,7 @@
         if [ ${FOUND} -eq 0 ]; then
             Display --indent 2 --text "- PAM password strength tools" --result "${STATUS_SUGGESTION}" --color YELLOW
             LogText "Result: no PAM modules for password strength testing found"
-            ReportSuggestion "${TEST_NO}" "Install a PAM module for password strength testing like pam_cracklib or pam_passwdqc"
+            ReportSuggestion "${TEST_NO}" "Install a PAM module for password strength testing like pam_cracklib or pam_passwdqc or libpam-passwdqc"
             AddHP 0 3
         else
             Display --indent 2 --text "- PAM password strength tools" --result "${STATUS_OK}" --color GREEN


### PR DESCRIPTION
This pull request just adds the name of the latest package (libpam-passwdqc) for checking password strength used in Debian and Ubuntu distributions. Solves issue https://github.com/CISOfy/lynis/issues/1354

Run test AUTH-9262 with and without the package just to make sure the behaviour was as expected. Debian 12.
