### PR TITLE
osdetection: add OpenEmbedded and Poky

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -308,6 +308,12 @@
                             OS_REDHAT_OR_CLONE=1
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
+                        "nodistro")
+                            LINUX_VERSION="openembedded"
+                            OS_NAME="OpenEmbedded"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "opensuse-tumbleweed")
                             LINUX_VERSION="openSUSE Tumbleweed"
                             # It's rolling release but has a snapshot version (the date of the snapshot)
@@ -329,6 +335,14 @@
                             OS_NAME="Parrot GNU/Linux"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
+                        "poky")
+                            LINUX_VERSION="Poky"
+                            OS_NAME="openembedded"
+                            LINUX_VERSION_LIKE="openembedded"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+
                         ;;
                         "pop")
                             LINUX_VERSION="Pop!_OS"


### PR DESCRIPTION
This allows detection the OpenEmbedded "nodistro" and The Yocto Projects distro "Poky"