### PR TITLE
Add .editorconfig and detection for Google's Container-Optimized OS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# See: https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4

--- a/include/osdetection
+++ b/include/osdetection
@@ -208,6 +208,11 @@
                             OS_NAME="CoreOS Linux"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
+                        "cos")
+                            LINUX_VERSION="Container-Optimized OS"
+                            OS_NAME="Container-Optimized OS from Google"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "debian")
                             LINUX_VERSION="Debian"
                             OS_NAME="Debian"


### PR DESCRIPTION
The `.editorconfig` file works for most modern editors. It ensures the indentation standards for the repository are consistent with what's in `CONTRIBUTING.md`. See [here](https://editorconfig.org/) for more settings.

Updated `include/osdetection` so it recognizes Google's Container-Optimized OS.

Running this on a COS instance in Google Cloud I get:

```
[+] Initializing program
------------------------------------
  - Detecting OS...                                           [ DONE ]
  - Checking profiles...                                      [ DONE ]

  ---------------------------------------------------
  Program version:           3.0.8
  Operating system:          Linux
  Operating system name:     Container-Optimized OS from Google
  Operating system version:  101
  Kernel version:            5.15.107+
  Hardware platform:         x86_64
  Hostname:                  ian-cos-cis-compliance-testing
```

Lovely!