### PR TITLE
Fixing missing or erroneous test number comments

### DIFF
--- a/db/tests.db
+++ b/db/tests.db
@@ -204,7 +204,7 @@ INSE-8200:test:security:insecure_services::Usage of TCP wrappers:
 INSE-8300:test:security:insecure_services::Presence of rsh client:
 INSE-8302:test:security:insecure_services::Presence of rsh server:
 INSE-8310:test:security:insecure_services::Presence of telnet client:
-INSE-8312:test:security:insecure_services::Presence of telnet server:
+INSE-8322:test:security:insecure_services::Presence of telnet server:
 INSE-8314:test:security:insecure_services::Presence of NIS client:
 INSE-8316:test:security:insecure_services::Presence of NIS server:
 INSE-8318:test:security:insecure_services::Presence of TFTP client:
@@ -438,7 +438,7 @@ TOOL-5104:test:security:tooling::Enabled tests for Fail2ban:
 TOOL-5120:test:security:tooling::Presence of Snort IDS:
 TOOL-5122:test:security:tooling::Snort IDS configuration file:
 TOOL-5130:test:security:tooling::Check for active Suricata daemon:
-TOOL-5160:test:security:tooling::Check for active OSSEC daemon:
+TOOL-5126:test:security:tooling::Check for active OSSEC daemon:
 TOOL-5190:test:security:tooling::Check presence of available IDS/IPS tooling:
 USB-1000:test:security:storage:Linux:Check if USB storage is disabled:
 USB-2000:test:security:storage:Linux:Check USB authorizations:

--- a/include/tests_insecure_services
+++ b/include/tests_insecure_services
@@ -371,7 +371,7 @@
 #
 #################################################################################
 #
-    # Test        : INSE-8312
+    # Test        : INSE-8322
     # Description : Check if telnet server is installed
     Register --test-no INSE-8322 --package-manager-required --weight L --network NO --category security --description "Check if telnet server is installed"
     if [ ${SKIPTEST} -eq 0 ]; then
@@ -492,6 +492,8 @@
 #
 #################################################################################
 #
+    # Test        : INSE-8050
+    # Description : Check for insecure services on macOS
     if [ -n "${LAUNCHCTL_BINARY}" ]; then PREQS_MET="YES"; SKIPREASON=""; else PREQS_MET="NO"; SKIPREASON="No launchctl binary on this system"; fi
     Register --test-no INSE-8050 --os "macOS" --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight M --network NO --category security --description "Check for insecure services on macOS"
     if [ ${SKIPTEST} -eq 0 ]; then

--- a/include/tests_system_integrity
+++ b/include/tests_system_integrity
@@ -30,6 +30,8 @@
 #
 #################################################################################
 #
+    # Test        : SINT-7010
+    # Description : System Integrity Status
     if [ -x ${ROOTDIR}/usr/bin/csrutil ]; then PREQS_MET="YES"; else PREQS_MET="NO"; SKIPREASON="No CSrutil binary found"; fi
     Register --test-no SINT-7010 --os MacOS --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight H --network NO --category security --description "System Integrity Status"
     if [ ${SKIPTEST} -eq 0 ]; then

--- a/include/tests_tooling
+++ b/include/tests_tooling
@@ -400,7 +400,7 @@
 #
 #################################################################################
 #
-    # Test        : TOOL-5160
+    # Test        : TOOL-5126
     # Description : Check for OSSEC
     Register --test-no TOOL-5126 --weight L --network NO --category security --description "Check for active OSSEC daemon"
     if [ ${SKIPTEST} -eq 0 ]; then


### PR DESCRIPTION
- This pull request fixes a few missing or erroneous test number comments. i.e.:
    _# Test        : INSE-8322
    # Description : Check if telnet server is installed
    Register --test-no INSE-8322 --package-manager-required --weight L --network NO --category security --description "Check if telnet server is installed"_

- Also fixes a couple of test numbers in tests.db that were wrong according to the actual test definitions in include/tests_*