### PR TITLE
Updating parsing of arch-audit since arch-audit modified its output. Issue 1277

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -347,12 +347,13 @@
     Register --test-no PKGS-7322 --os "Linux" --preqs-met ${PREQS_MET} --skip-reason "${SKIPREASON}" --weight L --network NO --category security --description "Discover vulnerable packages with arch-audit"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: checking arch-audit output for vulnerable packages"
-        FIND=$(${ARCH_AUDIT_BINARY} | ${SEDBINARY} 's/\.\..*$//' | ${SEDBINARY} 's/, //g' | ${SEDBINARY} 's/\(\["\|"\]\)//g' | ${SEDBINARY} 's/""/,/g' | ${AWKBINARY} '{ if($1=="Package") { print $2"|"$6"|"}}' | ${AWKBINARY} -F'|' 'NF>1{a[$1] = a[$1]","$2}END{for(i in a){print i""a[i]"|"}}' | ${SEDBINARY} 's/,/|cve=/' | ${SORTBINARY})
+        FIND=$(${ARCH_AUDIT_BINARY} | ${SEDBINARY} 's/ High risk!//' | ${SEDBINARY} 's/ Medium risk!//' | ${SEDBINARY} 's/ Low risk!//' | ${SEDBINARY} 's/\.\..*$//' | ${SEDBINARY} 's/, /,/g' | ${SEDBINARY} 's/\(\["\|"\]\)//g' | ${SEDBINARY} 's/""/,/g' | ${AWKBINARY} '{if ($0 ~ /is affected by CVE\-/) {print $1"|"$5"|"} else {ORS=""; print $1"|"; for (i=5; i<=NF; i++)print $i; print "\n"; ORS="\n"}}'| ${AWKBINARY} -F'|' 'NF>1{a[$1] = a[$1]","$2}END{for(i in a){print i""a[i]"|"}}' | ${SEDBINARY} 's/,CVE-/|cve=CVE-/' | ${SORTBINARY})
         if [ -z "${FIND}" ]; then
             LogText "Result: no vulnerable packages found with arch-audit"
             AddHP 10 10
         else
             LogText "Result: found one or more vulnerable packages"
+            VULNERABLE_PACKAGES_FOUND=1
             for ITEM in ${FIND}; do
                 LogText "Found line: ${ITEM}"
                 Report "vulnerable_package[]=${ITEM}"


### PR DESCRIPTION
- This PR closes issue #1277 
- These were the changes that made test PKGS-7322 fail:
https://github.com/ilpianista/arch-audit/commit/d1ca0c27114db90a0e6d2ae60c8f42a76800933e
https://github.com/ilpianista/arch-audit/commit/993b5b43a86928e11c893cde9cb524b27158d10a
- Tested in Arch Linux
- This is the kind of output to expect in lynis-report.dat:
_vulnerable_package[]=openssl,arbitrarycommandexecution.|
vulnerable_package[]=perl,signatureforgery,directorytraversal.|
vulnerable_packages_found=1_  

_vulnerable_package[]=curl|cve=CVE-2016-9594,CVE-2016-9586.|
vulnerable_package[]=gst-plugins-bad|cve=CVE-2016-9447,CVE-2016-9446,CVE-2016-9445.|
vulnerable_package[]=libtiff,denialofservice.|_