### PR TITLE
use grep -E instead of egrep if possible

### DIFF
--- a/include/binaries
+++ b/include/binaries
@@ -337,6 +337,15 @@
         Report "binaries_sgid_count=${SGID_BINARIES}"
         Report "binary_paths=${BINARY_PATHS_FOUND}"
 
+	# If grep is capable of extended regexp, use that instead of egrep to avoid annoying warning
+	if [ "${GREPBINARY:-}" ] ; then
+		${GREPBINARY} --help | ${GREPBINARY} -e "extended-regexp" > /dev/null
+		if [ $? -eq 0 ] ; then
+			EGREPBINARY="${GREPBINARY} -E"
+		fi
+	fi
+	
+
         # Test if the basic system tools are defined. These will be used during the audit.
         [ "${AWKBINARY:-}" ] || ExitFatal "awk binary not found"
         [ "${CAT_BINARY:-}" ] || ExitFatal "cat binary not found"

--- a/include/tests_time
+++ b/include/tests_time
@@ -164,7 +164,7 @@
                 FIND=$(echo "${J}" | ${EGREPBINARY} '/.placeholder$')
                 if [ -f "${J}" ] && [ -r "${J}" ] && [ -z "${FIND}" ]; then
                     LogText "Test: checking for ntpdate, rdate, sntp or ntpdig in ${J}"
-                    FIND=$("${EGREPBINARY}" "${CRONTAB_REGEX}" "${J}" | "${GREPBINARY}" -v "^#")
+                    FIND=$(${EGREPBINARY} "${CRONTAB_REGEX}" "${J}" | "${GREPBINARY}" -v "^#")
                     if [ -n "${FIND}" ]; then
                         FOUND=1; FOUND_IN_CRON=1; NTP_CONFIG_TYPE_SCHEDULED=1
                         LogText "Result: found ntpdate, rdate, sntp or ntpdig in ${J}"

--- a/lynis
+++ b/lynis
@@ -217,10 +217,10 @@
 
     # Extract the short notation of the language (first two characters).
     if [ -x "$(command -v locale 2> /dev/null)" ]; then
-        LANGUAGE=$(locale | egrep "^LANG=" | cut -d= -f2 | cut -d_ -f1 | tr -d '"' | egrep "^[a-z]{2}$")
+        LANGUAGE=$(locale | grep -e "^LANG=" | cut -d= -f2 | cut -d_ -f1 | tr -d '"' | grep -E -e "^[a-z]{2}$")
         # Try locale command if shell variable had no value
         if [ -z "${DISPLAY_LANG}" ]; then
-            DISPLAY_LANG=$(locale | egrep "^LANG=" | cut -d= -f2)
+            DISPLAY_LANG=$(locale | grep -e "^LANG=" | cut -d= -f2)
         fi
     else
         LANGUAGE="en"


### PR DESCRIPTION
Hello,
recent /usr/bin/egrep on Linux systems is throwing annoying warning that egrep is obsolete and that grep -E is used instead. 
To avoid this warning the EGREPBINARY is set to "${GREPBINARY} -E" if it has extended regexp in the "--help"
Best regards
Michal Ambroz