### PR TITLE
Update Amazon Linux EOL dates and add Amazon Linux 2023

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -28,8 +28,9 @@ os:Alpine 3.8:2020-05-01:1588305600
 # Amazon Linux
 #
 # Note: shortest entry is listed at end due to regular expression matching being used
-os:Amazon Linux 2:2023-06-26:1687730400:
-os:Amazon Linux:2020-06-30:1593468000:
+os:Amazon Linux 2023:2028-03-15:1836691200:
+os:Amazon Linux 2:2025-06-30:1751241600:
+os:Amazon Linux:2023-12-31:1703980800:
 #
 # Arch Linux
 #


### PR DESCRIPTION
 Sources:
 AL2023 EOL: https://docs.aws.amazon.com/linux/al2023/release-notes/support-info-by-support-statement.html#support-info-by-support-statement-eol
 AL2 EOL: https://aws.amazon.com/amazon-linux-2/faqs/
 AL EOL: https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/