### PR TITLE
software-eol.db: Add new Debian/Ubuntu releases and update EOL dates

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -44,13 +44,16 @@ os:CentOS Linux 7:2024-06-30:1719698400:
 os:CentOS Linux 8:2029-05-31:1874872800:
 #
 # Debian - https://wiki.debian.org/DebianReleases#Production_Releases
+# https://wiki.debian.org/LTS
 #
 os:Debian 5.0:2012-02-06:1328482800:
 os:Debian 6.0:2016-02-29:1456700400:
 os:Debian 7:2018-05-31:1527717600:
 os:Debian 8:2020-06-30:1593468000:
-os:Debian 9:2022-01-01:1640991600:
-os:Debian 10:2022-01-01:1640991600:
+os:Debian 9:2022-06-30:1656547200:
+os:Debian 10:2024-06-30:1719705600:
+os:Debian 11:2026-06-30:1782777600:
+os:Debian 12:2028-06-30:1845936000:
 #
 # Fedora - https://fedoraproject.org/wiki/End_of_life
 #
@@ -240,6 +243,7 @@ os:Ubuntu 18.04:2023-05-01:1682892000:
 os:Ubuntu 18.10:2019-07-18:1563400800:
 os:Ubuntu 19.04:2020-01-01:1577833200:
 os:Ubuntu 20.04:2025-04-01:1743458400:
+os:Ubuntu 22.04:2027-04-01:1806537600:
 #
 # OmniosCE - https://omniosce.org/releasenotes.html
 #


### PR DESCRIPTION
software-eol.db: Add new Debian/Ubuntu releases and update EOL dates