### PR TITLE
[PKGS-7388] Fix security repository test for new apt sources format

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -1043,7 +1043,7 @@
             fi
             if [ -d /etc/apt/sources.list.d ]; then
                 LogText "Searching for security.debian.org/security.ubuntu.com or security repositories in /etc/apt/sources.list.d directory"
-                FIND=$(${GREPBINARY} -E -r "security.debian.org|security.ubuntu.com|security/? " /etc/apt/sources.list.d | ${GREPBINARY} -v '#' | ${SEDBINARY} 's/ /!space!/g')
+                FIND=$(${GREPBINARY} -E -r "security.debian.org|security.ubuntu.com|security/?( |$)" /etc/apt/sources.list.d | ${GREPBINARY} -v '#' | ${SEDBINARY} 's/ /!space!/g')
                 if [ -n "${FIND}" ]; then
                     FOUND=1
                     Display --indent 2 --text "- Checking security repository in sources.list.d directory" --result "${STATUS_OK}" --color GREEN


### PR DESCRIPTION
In addition to the traditional one-line-per-source style, apt supports a newer sources list style with multi-line-stanzas (DEB822 style). This new style is e.g. used in Debian's latest docker images and expected to be the default in Ubuntu 23.10. The current test fails to recognize those sources.

An example of the new style would be: 
Types: deb
URIs: https://deb.debian.org/debian-security
Suites: bookworm-security
Components: main non-free-firmware
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

Change the regular expression to match the newer style as well.