### PR TITLE
Fixed Alpine Linux installed package detection

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2099,7 +2099,7 @@
             output=$(${XBPSBINARY} ${package} 2> /dev/null | ${GREPBINARY} "^ii")
             exit_code=$?
         elif [ -n "${APKBINARY}" ]; then
-            output=$(${APKBINARY} search ${package} 2> /dev/null | ${GREPBINARY} ${package})
+            output=$(${APKBINARY} list --installed ${package} 2> /dev/null | ${GREPBINARY} ${package})
             exit_code=$?
         else
             if [ "${package}" != "__dummy__" ]; then


### PR DESCRIPTION
`apk search` lists all packages that have `${package}` on the name and that aren't installed

Example for rsh (not installed)

```
$ apk search rsh 2> /dev/null | grep rsh
abseil-cpp-flags-marshalling-20230802.1-r0
harsh-0.8.30-r0
powershell-7.3.9-r0
starship-1.16.0-r0
starship-bash-completion-1.16.0-r0
starship-fish-completion-1.16.0-r0
starship-zsh-completion-1.16.0-r0
starship-zsh-plugin-1.16.0-r0
$
```
```
$ apk list --installed rsh 2> /dev/null | grep rsh
$
```

Example for busybox (installed)
```
$ apk search busybox 2> /dev/null | grep busybox
busybox-1.36.1-r15
busybox-binsh-1.36.1-r15
busybox-doc-1.36.1-r15
busybox-extras-1.36.1-r15
busybox-extras-openrc-1.36.1-r15
busybox-ifupdown-1.36.1-r15
busybox-mdev-openrc-1.36.1-r15
busybox-openrc-1.36.1-r15
busybox-static-1.36.1-r15
busybox-suid-1.36.1-r15
$
```
```
$ apk list --installed busybox 2> /dev/null | grep busybox
busybox-1.36.1-r15 x86_64 {busybox} (GPL-2.0-only) [installed]
$
```

grep is still needed since `apk list` always returns 0