### PR TITLE
Added regex for NETW-3200 in tests_networking

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -750,7 +750,7 @@
                         UNCOMMON_PROTOCOL_DISABLED=0
                         # First check modprobe.conf
                         if [ -f ${ROOTDIR}etc/modprobe.conf ]; then
-                            DATA=$(${GREPBINARY} "^install \+${P} \+/bin/true$" ${ROOTDIR}etc/modprobe.conf)
+                            DATA=$(${GREPBINARY} "^install \+${P} \+/bin/(true|false)$" ${ROOTDIR}etc/modprobe.conf)
                             if [ -n "${DATA}" ]; then
                                 LogText "Result: found ${P} module disabled via modprobe.conf"
                                 UNCOMMON_PROTOCOL_DISABLED=1
@@ -759,7 +759,7 @@
                         # Then additional modprobe configuration files
                         if [ -d ${ROOTDIR}etc/modprobe.d ]; then
                             # Return file names (-l) and suppress errors (-s)
-                            DATA=$(${GREPBINARY} -l -s "^install \+${P} \+/bin/true$" ${ROOTDIR}etc/modprobe.d/*)
+                            DATA=$(${GREPBINARY} -l -s "^install \+${P} \+/bin/(true|false)$" ${ROOTDIR}etc/modprobe.d/*)
                             if [ -n "${DATA}" ]; then
                                 UNCOMMON_PROTOCOL_DISABLED=1
                                 for F in ${DATA}; do


### PR DESCRIPTION
I changed the check `/bin/true` to `/bin/(true|false)` to be more inclusive and eliminate false positives for those who use `/bin/false` instead.