### PR TITLE
Update osdetection (ALT Linux)

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -160,6 +160,11 @@
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
+                        "altlinux")
+                            LINUX_VERSION="ALT Linux"
+                            OS_NAME="altlinux"
+                            OS_VERSION=$(grep "^ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "amzn")
                             LINUX_VERSION="Amazon Linux"
                             OS_NAME="Amazon Linux"


### PR DESCRIPTION
Consider to update osdetection script to detect ALT Linux distro in issue #1465 (https://github.com/CISOfy/lynis/issues/1465)