### PR TITLE
McAfee antivirus has been deprecated

### DIFF
--- a/include/tests_malware
+++ b/include/tests_malware
@@ -46,23 +46,18 @@
     TRENDMICRO_DSA_DAEMON_RUNNING=0
 #
 #################################################################################
-#
-    # Test        : MALW-3274
-    # Description : Check for installed tool (McAfee VirusScan for Command Line)
-    Register --test-no MALW-3274 --weight L --network NO --category security --description "Check for McAfee VirusScan Command Line"
-    if [ ${SKIPTEST} -eq 0 ]; then
-        LogText "Test: checking presence McAfee VirusScan for Command Line"
-        if [ -x /usr/local/uvscan/uvscan ]; then
-            Display --indent 2 --text "- ${GEN_CHECKING} McAfee VirusScan for Command Line" --result "${STATUS_FOUND}" --color GREEN
-            LogText "Result: Found ${MCAFEECLBINARY}"
-            MALWARE_SCANNER_INSTALLED=1
-            AddHP 2 2
-            Report "malware_scanner[]=mcafeecl"
-        else
-            LogText "Result: McAfee VirusScan for Command Line not found"
-        fi
-    fi
-#
+# Test        : MALW-3274
+# Description : Check for installed tool (McAfee VirusScan for Command Line)
+Register --test-no MALW-3274 --weight L --network NO --category security --description "Check for McAfee VirusScan Command Line"
+if [ ${SKIPTEST} -eq 0 ]; then
+    LogText "Test: checking presence McAfee VirusScan for Command Line"
+    if [ -x /usr/local/uvscan/uvscan ]; then
+        Display --indent 2 --text "- ${GEN_CHECKING} McAfee VirusScan for Command Line" --result "${STATUS_FOUND}" --color RED
+        LogText "Result: Found ${MCAFEECLBINARY}"
+        MALWARE_SCANNER_INSTALLED=0
+        AddHP 0 2
+        LogText "Result: McAfee Antivirus for Linux has been deprecated as of 1 Oct 2023 and will not receive updates. Please use another antivirus instead."
+fi
 #################################################################################
 #
     # Test        : MALW-3275


### PR DESCRIPTION
As of 1 Oct 2023, McAfee antivirus for Linux has been deprecated https://www.mcafee.com/support/?locale=no-NO&articleId=TS103384&page=shell&shell=article-view