### PR TITLE
changed wording of the output AllowUsers to AllowGroups in test SSH-7440

### DIFF
--- a/include/tests_ssh
+++ b/include/tests_ssh
@@ -312,7 +312,7 @@
         # AllowGroups
         FIND=$(${GREPBINARY} -E -i "^AllowGroups" ${SSH_DAEMON_OPTIONS_FILE} | ${AWKBINARY} '{ print $2 }')
         if [ -n "${FIND}" ]; then
-            LogText "Result: AllowUsers set ${FIND}"
+            LogText "Result: AllowGroups set ${FIND}"
             Display --indent 4 --text "- OpenSSH option: AllowGroups" --result "${STATUS_FOUND}" --color GREEN
             FOUND=1
         else


### PR DESCRIPTION
In the evaluation of AllowGroups, AllowUsers was in the output text.  I have corrected this