### PR TITLE
KRB-1010: Silence output when SKIPTEST != 0

### DIFF
--- a/include/tests_kerberos
+++ b/include/tests_kerberos
@@ -31,8 +31,8 @@ InsertSection "${SECTION_KERBEROS}"
     # Test        : KRB-1010
     # Description : Check that Kerberos principals have passwords that expire
     Register --test-no KRB-1010 --preqs-met ${PREQS_MET} --weight L --network NO --description "Check that Kerberos principals have passwords that expire"
-    FOUND=0
     if [ ${SKIPTEST} -eq 0 ]; then
+        FOUND=0
         for I in ${PRINCS}
         do
             FIND="$(${KADMINLOCALBINARY} getprinc "${I}" | ${GREPBINARY} '^Password expiration date:')"
@@ -42,12 +42,12 @@ InsertSection "${SECTION_KERBEROS}"
                 FOUND=1
             fi
         done
-    fi
-    if [ ${FOUND} -eq 1 ]; then
-        Display --indent 4 --text "- Principals without expiring password" --result "${STATUS_WARNING}" --color RED
-        ReportSuggestion "${TEST_NO}" "Make sure all your Kerberos principals have expiring passwords"
-    else
-        Display --indent 4 --text "- Principals without expiring password" --result "${STATUS_OK}" --color GREEN
+        if [ ${FOUND} -eq 1 ]; then
+            Display --indent 4 --text "- Principals without expiring password" --result "${STATUS_WARNING}" --color RED
+            ReportSuggestion "${TEST_NO}" "Make sure all your Kerberos principals have expiring passwords"
+        else
+            Display --indent 4 --text "- Principals without expiring password" --result "${STATUS_OK}" --color GREEN
+        fi
     fi
 #
 #################################################################################


### PR DESCRIPTION
Fixes https://github.com/CISOfy/lynis/pull/1456#issuecomment-2113390171