### PR TITLE
Find default_gateway using "ip" instead of "netstat"

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -276,11 +276,11 @@
     # Test        : NETW-3001
     # Description : Find default gateway (route)
     # More info   : BSD: ^default   Linux: 0.0.0.0
-    if [ -n "${NETSTATBINARY}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    if [ -n "${IPBINARY}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no NETW-3001 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Find default gateway (route)"
     if [ $SKIPTEST -eq 0 ]; then
         LogText "Test: Searching default gateway(s)"
-        FIND=$(${NETSTATBINARY} -rn | ${GREPBINARY} -E "^0.0.0.0|default" | ${TRBINARY} -s ' ' | ${CUTBINARY} -d ' ' -f2)
+        FIND=$(${IPBINARY} route show default | ${TRBINARY} -s ' ' | ${CUTBINARY} -d ' ' -f3)
         if [ -n "${FIND}" ]; then
             for I in ${FIND}; do
                 LogText "Result: Found default gateway ${I}"


### PR DESCRIPTION
Hello,

Ubuntu 24.04 LTS does not have netstat installed so Lynis can't detect the default gateway in the system. #1527 

The "ip" command is typically pre-installed on most Linux distributions, so maybe it could be a good alternative.

What do you think?

This patch uses the `ip` command to retrieve the default gateway.

Thanks

