### PR TITLE
Fix(README): Clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The very latest developments can be obtained via git.
 
 1. Clone or download the project files (**no compilation nor installation** is required) ;
 
-        git clone https://github.com/CISOfy/lynis
+        git clone https://github.com/CISOfy/lynis.git
 
 2. Execute:
 


### PR DESCRIPTION
Add `.git` to clone URL, so users without authenticating to github can clone the repo on their servers.