### PR TITLE
HTTP-6660 - Wrap quotes properly for dash and other(?) shells

### DIFF
--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -323,7 +323,7 @@
                     Display --indent 4 --text "  ${APACHE_CONFFILE}" --result "${STATUS_NOT_FOUND}" --color WHITE
                 else
                     TRACEENABLED_SETTING=$( echo ${TRACEENABLE} | tr 'A-Z' 'a-z' )
-                    if [ x${TRACEENABLED_SETTING} == x'off' ]; then
+                    if [ "x${TRACEENABLED_SETTING}" == 'xoff' ]; then
                         LogText "Result: found TraceEnable setting set to 'off' in ${APACHE_CONFFILE}"
                         Report "Apache setting: 'TraceEnable Off' in ${APACHE_CONFFILE}"
                         Display --indent 4 --text "  ${APACHE_CONFFILE}" --result "${STATUS_FOUND}" --color GREEN

--- a/include/tests_webservers
+++ b/include/tests_webservers
@@ -323,7 +323,7 @@
                     Display --indent 4 --text "  ${APACHE_CONFFILE}" --result "${STATUS_NOT_FOUND}" --color WHITE
                 else
                     TRACEENABLED_SETTING=$( echo ${TRACEENABLE} | tr 'A-Z' 'a-z' )
-                    if [ "x${TRACEENABLED_SETTING}" == 'xoff' ]; then
+                    if [ "x${TRACEENABLED_SETTING}" = 'xoff' ]; then
                         LogText "Result: found TraceEnable setting set to 'off' in ${APACHE_CONFFILE}"
                         Report "Apache setting: 'TraceEnable Off' in ${APACHE_CONFFILE}"
                         Display --indent 4 --text "  ${APACHE_CONFFILE}" --result "${STATUS_FOUND}" --color GREEN


### PR DESCRIPTION
The test for TraceEnable in Apache (HTTP-6660) has a comparison that is invalid in Dash (the default for /bin/sh in Debian-based distros). This is due to the way it does the string comparisons to try to compensate for an empty string (are there still shells around that need to do that?).