### PR TITLE
Update tests_boot_services -> (E)LILO warning

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -484,6 +484,7 @@
             else
                 LogText "Result: can not read ${LILOCONFFILE} (no permission)"
             fi
+            ReportWarning "${TEST_NO}" "LILO is discontinued (unmaintained). Recommended alternatives: GRUB."
         else
             LogText "Result: LILO configuration file not found"
         fi
@@ -504,6 +505,7 @@
                 LogText "Result: found ELILO boot loader"
                 BOOT_LOADER="ELILO"
                 BOOT_LOADER_FOUND=1
+                ReportWarning "${TEST_NO}" "ELILO is discontinued (unmaintained). Recommended alternatives: GRUB, rEFInd, systemd-boot (alphabetical order)."
             fi
         done
     fi


### PR DESCRIPTION
Adding "discontinued" warning for LILO/ELILO.
As of January 2016, LILO is no longer actively developed. ELILO project is orphaned, Debian dropped it in 2014, and RH & SUSE stopped using this tree (and feeding back change) long before that so no longer interested in working on it. Apart from Slackware, which still has packages for LILO and ELILO, I don't know if anyone else uses them, and anyway, Slackware has an active and well-configured package for GRUB.