### PR TITLE
Update osdetection - Peppermint OS

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -406,6 +406,13 @@
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
+                        "peppermint")
+                            LINUX_VERSION="Peppermint OS"
+                            LINUX_VERSION_LIKE="Debian"
+                            OS_NAME="Peppermint OS"
+                            OS_VERSION=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION_CODENAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "poky")
                             LINUX_VERSION="Poky"
                             OS_NAME="openembedded"


### PR DESCRIPTION
Added Peppermint OS to the list (version codename returns "Bookworm", think it counts as the detailed version name)

PS: If you need it, the output of ``cat /etc/os-release``

````
PRETTY_NAME="PeppermintOS"
NAME="Peppermint"
ID=peppermint
VERSION_CODENAME="bookworm"
HOME_URL="https://peppermintos.com"
SUPPORT_URL="https://sourceforge.net/p/peppermintos/pepos/"
BUG_REPORT_URL="https://sourceforge.net/p/peppermintos/pepos/"
````
