### PR TITLE
FIRE-4508 - Adding more tables in ip4tables

### DIFF
--- a/include/tests_firewalls
+++ b/include/tests_firewalls
@@ -109,7 +109,7 @@
     Register --test-no FIRE-4508 --preqs-met ${PREQS_MET} --os Linux --weight L --network NO --root-only YES --category security --description "Check used policies of iptables chains"
     if [ ${SKIPTEST} -eq 0 ]; then
         Display --indent 4 --text "- Checking iptables policies of chains" --result "${STATUS_FOUND}" --color GREEN
-        TABLES="filter"
+        TABLES="filter nat mangle raw security"
         for TABLE in ${TABLES}; do
             LogText "Test: gathering information from table ${TABLE}"
             FIND="$FIND""\n"$(${IPTABLESBINARY} -t ${TABLE} --numeric --list | ${GREPBINARY} -E  -z -o -w  '[A-Z]+' | tr -d '\0' | ${AWKBINARY} -v t=${TABLE} 'NR%2 {printf "%s %s ",t, $0 ; next;}1')


### PR DESCRIPTION
Hello, an adversary may use other than the `filter` table to manipulate the `netfilter` subsystem.

This PR adds `nat mangle raw security` tables in **FIRE-4508** control.

Please provide feedbacks!


Regards,