### PR TITLE
More support for busybox devices

### DIFF
--- a/extras/build-lynis.sh
+++ b/extras/build-lynis.sh
@@ -238,7 +238,7 @@
 
     echo "[*] Starting with DEB building process"
 
-        DEBCHANGELOGFULLVERSION=$(head -1 ../debian/changelog | awk '{ print $2 }' | sed 's/(//' | sed 's/)//')
+        DEBCHANGELOGFULLVERSION=$(head -n 1 ../debian/changelog | awk '{ print $2 }' | sed 's/(//' | sed 's/)//')
         DEBCHANGELOGVERSION=$(echo ${DEBCHANGELOGFULLVERSION} | awk -F- '{ print $1 }')
         DEBCHANGELOGVERSIONREV=$(echo ${DEBCHANGELOGFULLVERSION} | awk -F- '{ print $2 }')
         if [ "${LYNIS_VERSION}" = "${DEBCHANGELOGVERSION}" ]; then
@@ -251,7 +251,7 @@
 #    BZRSTATUS=$(${BZRBINARY} status . 2>&1 > /dev/null; echo $?)
 #    if [ "${BZRSTATUS}" = "0" ]; then
 #        echo "[V] bzr has proper directory tree"
-#        DEBCHANGELOGFULLVERSION=$(head -1 debian/changelog | awk '{ print $2 }' | sed 's/(//' | sed 's/)//')
+#        DEBCHANGELOGFULLVERSION=$(head -n 1 debian/changelog | awk '{ print $2 }' | sed 's/(//' | sed 's/)//')
 #        DEBCHANGELOGVERSION=$(echo ${DEBCHANGELOGFULLVERSION} | awk -F- '{ print $1 }')
 #        DEBCHANGELOGVERSIONREV=$(echo ${DEBCHANGELOGFULLVERSION} | awk -F- '{ print $2 }')
 #        echo "[=] Version in Debian changelog: ${DEBCHANGELOGVERSION} (revision: ${DEBCHANGELOGVERSIONREV})"

--- a/include/functions
+++ b/include/functions
@@ -968,7 +968,7 @@
                 ;;
 
                 "DragonFly" | "FreeBSD")
-                    FIND=$(${IFCONFIGBINARY} | grep ether | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                    FIND=$(${IFCONFIGBINARY} | grep ether | head -n 1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                     if HasData "${FIND}"; then
                         HOSTID=$(echo ${FIND} | sha1)
                     else
@@ -996,7 +996,7 @@
                         for INTERFACE in ${NET_INTERFACES}; do
                             if grep -q -s 'up' "/sys/class/net/${INTERFACE}/operstate"; then
                                 LogText "Interface '${INTERFACE}' is up, fetching MAC address"
-                                FIND=$(head -1 "/sys/class/net/${INTERFACE}/address" | tr '[:upper:]' '[:lower:]')
+                                FIND=$(head -n 1 "/sys/class/net/${INTERFACE}/address" | tr '[:upper:]' '[:lower:]')
                                 if HasData "${FIND}"; then
                                     HOSTID_GEN="linux-sys-interface-up"
                                     break
@@ -1010,7 +1010,7 @@
                         LogText "Info: trying output from 'ip' to generate HostID"
                         # Determine if we have the common available eth0 interface. If so, give that priority.
                         # Note: apply sorting in case there would be multiple MAC addresses linked to increase predictable end result
-                        FIND=$(${IPBINARY} addr show eth0 2> /dev/null | grep -E "link/ether " | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]' | sort | head -1)
+                        FIND=$(${IPBINARY} addr show eth0 2> /dev/null | grep -E "link/ether " | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]' | sort | head -n 1)
                         if HasData "${FIND}"; then
                             HOSTID_GEN="linux-ip-interface-eth0"
                         else
@@ -1020,7 +1020,7 @@
                             # 3) Convert everything to lowercase
                             # 4) Sort the entries, so that the output is more predictable between runs when the same interfaces are available
                             # 5) Select first entry
-                            FIND=$(${IPBINARY} -family link addr show up 2> /dev/null | awk '{if($1=="link/ether" && $2 !~ "^02:42:"){print $2}}' | tr '[:upper:]' '[:lower:]' | sort | head -1)
+                            FIND=$(${IPBINARY} -family link addr show up 2> /dev/null | awk '{if($1=="link/ether" && $2 !~ "^02:42:"){print $2}}' | tr '[:upper:]' '[:lower:]' | sort | head -n 1)
                             if HasData "${FIND}"; then
                                 HOSTID_GEN="linux-ip-interface-up-other"
                             else
@@ -1049,7 +1049,7 @@
                                         HOSTID_GEN="linux-ifconfig-interface-eth0-ether"
                                     fi
                                 else
-                                    FIND=$(${IFCONFIGBINARY} 2> /dev/null | grep "ether " | awk '{ print $2 }' | head -1 | tr '[:upper:]' '[:lower:]')
+                                    FIND=$(${IFCONFIGBINARY} 2> /dev/null | grep "ether " | awk '{ print $2 }' | head -n 1 | tr '[:upper:]' '[:lower:]')
                                     if IsEmpty "${FIND}"; then
                                         ReportException "GetHostID" "No eth0 found (and no ether was found with ifconfig)"
                                     else
@@ -1058,7 +1058,7 @@
                                     fi
                                 fi
                             else
-                                FIND=$(${IFCONFIGBINARY} 2> /dev/null | grep HWaddr | head -1 | awk '{ print $5 }' | tr '[:upper:]' '[:lower:]')
+                                FIND=$(${IFCONFIGBINARY} 2> /dev/null | grep HWaddr | head -n 1 | awk '{ print $5 }' | tr '[:upper:]' '[:lower:]')
                                 HOSTID_GEN="linux-ifconfig-interface-first-hwaddr"
                             fi
                         else
@@ -1077,7 +1077,7 @@
                 ;;
 
                 "macOS")
-                    FIND=$(${IFCONFIGBINARY} en0 | grep ether | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                    FIND=$(${IFCONFIGBINARY} en0 | grep ether | head -n 1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                     if [ ! "${FIND}" = "" ]; then
                         HOSTID=$(echo ${FIND} | shasum | awk '{ print $1 }')
                     else
@@ -1099,7 +1099,7 @@
                 ;;
 
                 "NetBSD")
-                    FIND=$(${IFCONFIGBINARY} -a | grep "address:" | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                    FIND=$(${IFCONFIGBINARY} -a | grep "address:" | head -n 1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                     if HasData "${FIND}"; then
                         HOSTID=$(echo ${FIND} | sha1)
                     else
@@ -1108,7 +1108,7 @@
                 ;;
 
                 "OpenBSD")
-                    FIND=$(${IFCONFIGBINARY} | grep "lladdr " | head -1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
+                    FIND=$(${IFCONFIGBINARY} | grep "lladdr " | head -n 1 | awk '{ print $2 }' | tr '[:upper:]' '[:lower:]')
                     if HasData "${FIND}"; then
                         HOSTID=$(echo ${FIND} | sha1)
                     else
@@ -1164,7 +1164,7 @@
         # Optional: DBUS creates ID as well with dbus-uuidgen and is stored in /var/lib/dbus-machine-id (might be symlinked to /etc/machine-id)
         sMACHINEIDFILE="/etc/machine-id"
         if [ -f ${sMACHINEIDFILE} ]; then
-            FIND=$(head -1 ${sMACHINEIDFILE} | grep "^[a-f0-9]")
+            FIND=$(head -n 1 ${sMACHINEIDFILE} | grep "^[a-f0-9]")
             if [ "${FIND}" = "" ]; then
                 MACHINEID="${FIND}"
             fi
@@ -1336,6 +1336,8 @@
                             # busybox does not support format
                             if [ ${SHELL_IS_BUSYBOX} -eq 0 ]; then
                                 DATA=$(${STATBINARY} --format=%a ${CHECKFILE})
+                            else
+                                DATA=$(${STATBINARY} -c %a ${CHECKFILE})
                             fi
                         ;;
                     esac
@@ -1349,12 +1351,16 @@
                         ;;
                         *)
                             # Only use find when OS is NOT AIX and binaries are NOT busybox
+                            if [ -d "${CHECKFILE}" ]; then
+                                MAXDEPTH="-maxdepth 0"
+                            else
+                                MAXDEPTH=""
+                            fi
+
                             if [ ${SHELL_IS_BUSYBOX} -eq 0 ]; then
-                                if [ -d ${CHECKFILE} ]; then
-                                    DATA=$(${FINDBINARY} ${CHECKFILE} -maxdepth 0 -printf "%m")
-                                else
-                                    DATA=$(${FINDBINARY} ${CHECKFILE} -printf "%m")
-                                fi
+                                DATA=$(${FINDBINARY} "${CHECKFILE}" ${MAXDEPTH} -printf "%m")
+                            else
+                                DATA=$(${FINDBINARY} "${CHECKFILE}" ${MAXDEPTH} -exec stat -c %a {} \;)
                             fi
                         ;;
                     esac
@@ -1872,7 +1878,7 @@
             # FreeBSD: hw.hv_vendor (remains empty for VirtualBox)
             # NetBSD: machdep.dmi.system-product
             # OpenBSD: hw.product
-            FIND=$(sysctl -a 2> /dev/null | grep -E "(hw.product|machdep.dmi.system-product)" | head -1 | sed 's/ = /=/' | awk -F= '{ print $2 }')
+            FIND=$(sysctl -a 2> /dev/null | grep -E "(hw.product|machdep.dmi.system-product)" | head -n 1 | sed 's/ = /=/' | awk -F= '{ print $2 }')
             if [ ! "${FIND}" = "" ]; then
                 SHORT="${FIND}"
             fi
@@ -3049,7 +3055,8 @@
         # By default remove only control characters
         if [ $# -eq 1 ]; then
             input="$1"
-            cleaned=$(echo ${input} | tr -d '[:cntrl:]')
+            # cleaned=$(echo ${input} | tr -d '[:cntrl:]')
+            cleaned=$(echo "$input" | sed 's/[^a-zA-Z0-9_-]//g')
         # If know what to test against, then see if input matches the specified class
         elif [ $# -eq 2 ]; then
             input="$1"

--- a/include/osdetection
+++ b/include/osdetection
@@ -836,7 +836,7 @@
                 if tail -1 < /etc/release | xargs | grep "^Solaris " > /dev/null; then
                     OS_FULLNAME=$(tail -1 < /etc/release | xargs)
                 else
-                    OS_FULLNAME=$(head -1 < /etc/release | xargs)
+                    OS_FULLNAME=$(head -n 1 < /etc/release | xargs)
                 fi
                 OS_VERSION=$(echo "$OS_FULLNAME" | cut -d ' ' -f 2,3)
             else  # Old behaviour
@@ -929,6 +929,9 @@
             ShowSymlinkPath /bin/ps
             if [ "${SYMLINK}" = "/bin/busybox" ]; then
                 SHELL_IS_BUSYBOX=1
+                LogText "Result: The device is using Busybox."
+            else
+                LogText "Result: The device is NOT using Busybox."
             fi
         fi
     fi

--- a/plugins/plugin_systemd_phase1
+++ b/plugins/plugin_systemd_phase1
@@ -47,13 +47,13 @@
     if [ -n "${SYSTEMCTLBINARY}" -a ${SYSTEMD_RUNNING} -eq 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PLGN-3802 --preqs-met ${PREQS_MET} --weight L --network NO --description "Query systemd version and options" --progress
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=$(${SYSTEMCTLBINARY} --version 2> /dev/null | ${AWKBINARY} '{ if ($1=="systemd") { print $2 } }' | grep "^[1-9][0-9][0-9]$" | head -1)
+        FIND=$(${SYSTEMCTLBINARY} --version 2> /dev/null | ${AWKBINARY} '{ if ($1=="systemd") { print $2 } }' | grep "^[1-9][0-9][0-9]$" | head -n 1)
         if [ -n "${FIND}" ]; then
             SYSTEMD_VERSION=${FIND}
             Report "systemd_version=${FIND}"
             LogText "Result: found systemd version ${FIND}"
         fi
-        FIND=$(${SYSTEMCTLBINARY} --version 2> /dev/null | grep "^[-+]" | sed 's/[[:space:]]/,/g' | head -1)
+        FIND=$(${SYSTEMCTLBINARY} --version 2> /dev/null | grep "^[-+]" | sed 's/[[:space:]]/,/g' | head -n 1)
         if [ -n "${FIND}" ]; then
             Report "systemd_builtin_components=${FIND}"
             LogText "Result: found builtin components list"
@@ -101,7 +101,7 @@
     if [ -f ${ROOTDIR}etc/machine-id -a ${SYSTEMD_RUNNING} -eq 1 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PLGN-3808 --preqs-met ${PREQS_MET} --weight L --network NO --description "Gather systemd machine ID" --progress
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=$(cat ${ROOTDIR}etc/machine-id | head -1)
+        FIND=$(cat ${ROOTDIR}etc/machine-id | head -n 1)
         if [ -n "${FIND}" ]; then
             SYSTEMD_MACHINEID="${FIND}"
             LogText "Result: found machine ID: ${SYSTEMD_MACHINEID}"
@@ -134,7 +134,7 @@
         FIND=$(${JOURNALCTLBINARY} --list-boots | wc -l)
         LogText "Output: number of boots listed in journal is ${FIND}"
         if [ -n "${FIND}" ]; then Report "journal_bootlogs=${FIND}"; fi
-        FIND=$(${JOURNALCTLBINARY} --list-boots | head -1 | awk '{ print $4 }')
+        FIND=$(${JOURNALCTLBINARY} --list-boots | head -n 1 | awk '{ print $4 }')
         LogText "Output: oldest boot date in journal is ${FIND}"
         if [ -n "${FIND}" ]; then Report "journal_oldest_bootdate=${FIND}"; fi
     fi
@@ -204,7 +204,7 @@
     if [ -n "${SYSTEMCTLBINARY}" -a ${SYSTEMD_RUNNING} -eq 1 -a ${SYSTEMD_VERSION} -ge 215 ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PLGN-3830 --preqs-met ${PREQS_MET} --weight L --network NO --description "Query systemd status" --progress
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=$(${SYSTEMCTLBINARY} is-system-running 2> /dev/null | head -1)
+        FIND=$(${SYSTEMCTLBINARY} is-system-running 2> /dev/null | head -n 1)
         if [ -n "${FIND}" ]; then
             Report "systemd_status=${FIND}"
             LogText "Result: found systemd status = ${FIND}"


### PR DESCRIPTION
1. Replaced "head -1" with "head -n 1"
> busybox devices don't recognize the option *-1*, anyway *head -n 1* works also in other distributions (e.g. Debian, macOS, ...)

2. Fixed Stat format error in busybox
> stat binary doesn't have the option *--format*, it was added a line to use this command also in busybox devices

3. Fixed find -printf error in busybox
> The command find in busybox doesn't have -printf option, to solve this it was used added *-exec stat -c %a {} \;*

4. SafeInput accept only alphanumeric values, underscore and hyphens
> in certain devices with busybox, *echo "$input" | sed 's/[^a-zA-Z0-9_-]//g'* is removing letters from the parameters (e.g. when executing *./lynis show profiles*)