### PR TITLE
fix #1582 suspicious history test is not checking the user folder [HOME-9310]

### DIFF
--- a/include/tests_homedirs
+++ b/include/tests_homedirs
@@ -131,7 +131,7 @@ EOF
                 # Solaris doesn't support -maxdepth
                 FIND=$(${FINDBINARY} ${HOMEDIRS} -name ".*history" ! -type f -print)
             else
-                FIND=$(${FINDBINARY} ${HOMEDIRS} -maxdepth 1 -name ".*history" ! -type f -print)
+                FIND=$(${FINDBINARY} ${HOMEDIRS} -maxdepth 2 -name ".*history" ! -type f -print)
             fi
             if [ -z "${FIND}" ]; then
                 Display --indent 2 --text "- Checking shell history files" --result "${STATUS_OK}" --color GREEN


### PR DESCRIPTION
Fix #1582. Thanks @nawe1321

Changed maxdepth value to 2 from 1.

> Old Result
```
> find /home -maxdepth 1 -name ".*history" ! -type f -print
<no output>
```
> New Result
```
$ find /home -maxdepth 2 -name ".*history" ! -type f -print
/home/me/.test_history     <--- detects symbolic link file.
```
