### PR TITLE
Add macOS Sequoia and update EOL

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -133,14 +133,14 @@ os:macOS High Sierra \(10.13.2\):2018-01-23:1516662000:
 os:macOS High Sierra \(10.13.3\):2018-03-29:1522274400:
 os:macOS High Sierra \(10.13.4\):2018-06-01:1527804000:
 os:macOS High Sierra \(10.13.5\):2018-07-09:1531087200:
-os:macOS High Sierra \(10.13.6\)::-1:
+os:macOS High Sierra \(10.13.6\)::2020-12-01:1606780800:
 os:macOS Mojave \(10.14\):2018-10-30:1540854000:
 os:macOS Mojave \(10.14.1\):2018-12-05:1543964400:
 os:macOS Mojave \(10.14.2\):2019-01-22:1548111600:
 os:macOS Mojave \(10.14.3\):2019-03-25:1553468400:
 os:macOS Mojave \(10.14.4\):2019-05-13:1557698400:
 os:macOS Mojave \(10.14.5\):2019-07-22:1563746400:
-os:macOS Mojave \(10.14.6\)::-1:
+os:macOS Mojave \(10.14.6\)::2021-10-25:1635120000:
 os:macOS Catalina \(10.15\):2019-10-29:1572303600:
 os:macOS Catalina \(10.15.1\):2019-12-10:1575932400:
 os:macOS Catalina \(10.15.2\):2020-01-28:1580166000:
@@ -148,7 +148,12 @@ os:macOS Catalina \(10.15.3\):2020-03-24:1585004400:
 os:macOS Catalina \(10.15.4\):2020-05-26:1590444000:
 os:macOS Catalina \(10.15.5\):2020-07-15:1594764000:
 os:macOS Catalina \(10.15.6\):2020-09-24:1600898400:
-os:macOS Catalina \(10.15.7\)::-1:
+os:macOS Catalina \(10.15.7\)::2022-09-12:1662940800:
+os:macOS Big Sur \(11.7.10\):2023-09-26:1695686400:
+os:macOS Monterey \(12.7.6\):2024-09-16:1726444800:
+os:macOS Ventura \(13.7.2\)::-1:
+os:macOS Sonoma \(14.7.2\)::-1:
+os:macOS Sequoia \(15.2\)::-1:
 #
 # Mageia - https://www.mageia.org/en/support/
 #

--- a/include/osdetection
+++ b/include/osdetection
@@ -66,6 +66,7 @@
                     12 | 12.[0-9]*) OS_FULLNAME="macOS Monterey (${OS_VERSION})" ;;
                     13 | 13.[0-9]*) OS_FULLNAME="macOS Ventura (${OS_VERSION})" ;;
                     14 | 14.[0-9]*) OS_FULLNAME="macOS Sonoma (${OS_VERSION})" ;;
+                    15 | 15.[0-9]*) OS_FULLNAME="macOS Sequoia (${OS_VERSION})" ;;
                     *) echo "Unknown macOS version. Do you know what version it is? Create an issue at ${PROGRAM_SOURCE}" ;;
                 esac
             else


### PR DESCRIPTION
This adds the latest macOS release and updates the EOL for macOS versions. I did not all all versions of macOS, would it make sense to add every small update @mboelen? 

Fixes #1565