### PR TITLE
Fix #1562

### DIFF
--- a/include/tests_kerberos
+++ b/include/tests_kerberos
@@ -14,7 +14,7 @@ InsertSection "${SECTION_KERBEROS}"
         PREQS_MET="YES"
         # Make sure krb5 debugging doesn't mess up the output
         unset KRB5_TRACE
-        PRINCS="$(${KADMINLOCALBINARY} listprincs | ${TRBINARY:-tr} '\n' ' ')"
+        PRINCS="$(${KADMINLOCALBINARY} listprincs 2>/dev/null | ${TRBINARY:-tr} '\n' ' ')"
         if [ -z "${PRINCS}" ]
         then
             PREQS_MET="NO"


### PR DESCRIPTION
kadmin.local binary might exist, even though Kerberos is not configured and /etc/krb5.conf does not exist.