### PR TITLE
Report a warning if no logrotate configuration is found

### DIFF
--- a/include/tests_logging
+++ b/include/tests_logging
@@ -265,7 +265,7 @@
             Display --indent 2 --text "- Checking logrotate presence" --result "${STATUS_OK}" --color GREEN
             LogText "Result: logrotate configuration found"
         else
-            Display --indent 2 --text "- Checking logrotate presence" --result "${STATUS_WARNING}" --color RED
+            Display --indent 2 --text "- Checking logrotate presence" --result "${STATUS_NOT_FOUND}" --color WHITE
             LogText "Result: No logrotate configuration found"
             ReportSuggestion "${TEST_NO}" "Check if log files are properly rotated"
         fi


### PR DESCRIPTION
Previously the text of the report would suggest a warning but report it as a suggestions. This was an inconsistency in the reporting as a warning was displayed in the report, but the summary showed

    Great, no warnings

in case no other warning was reported.