### PR TITLE
Update Amazon Linux 2 and 2023 EOL

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -49,7 +49,7 @@ os:Alpine 3.8:2020-05-01:1588305600
 # Amazon Linux
 #
 # Note: shortest entry is listed at end due to regular expression matching being used
-os:Amazon Linux 2023:2028-03-15:1836691200:
+os:Amazon Linux 2023:2029-06-30:1877558399000:
 os:Amazon Linux 2:2026-06-30:1782863999:
 os:Amazon Linux:2023-12-31:1703980800:
 #

--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -50,7 +50,7 @@ os:Alpine 3.8:2020-05-01:1588305600
 #
 # Note: shortest entry is listed at end due to regular expression matching being used
 os:Amazon Linux 2023:2028-03-15:1836691200:
-os:Amazon Linux 2:2025-06-30:1751241600:
+os:Amazon Linux 2:2026-06-30:1782863999:
 os:Amazon Linux:2023-12-31:1703980800:
 #
 # Arch Linux

--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -49,7 +49,7 @@ os:Alpine 3.8:2020-05-01:1588305600
 # Amazon Linux
 #
 # Note: shortest entry is listed at end due to regular expression matching being used
-os:Amazon Linux 2023:2029-06-30:1877558399000:
+os:Amazon Linux 2023:2029-06-30:1877464800:
 os:Amazon Linux 2:2026-06-30:1782863999:
 os:Amazon Linux:2023-12-31:1703980800:
 #


### PR DESCRIPTION
AL2:
As per https://aws.amazon.com/amazon-linux-2/faqs/:
> Amazon Linux 2 end of support date (End of Life, or EOL) will be on 2026-06-30.

AL23:
As per https://docs.aws.amazon.com/linux/al2023/ug/release-cadence.html:
> The maintenance phase ends June 30, 2029.