### PR TITLE
Update AUTH-9252

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -586,7 +586,7 @@
             FIND2=$(${LSBINARY} -lnd ${SUDOERS_D} | ${AWKBINARY} '{print $3$4}')
             LogText "Result: Found directory permissions: ${FIND} and owner UID GID: ${FIND2}"
             case "${FIND}" in
-                rwx[r-][w-][x-]--- )
+                rw[x-][r-][w-][x-]--- )
                     LogText "Result: directory ${SUDOERS_D} permissions OK"
                     if [ "${FIND2}" = "00" ]; then
                         LogText "Result: directory ${SUDOERS_D} ownership OK"


### PR DESCRIPTION
Changes AUTH-9252 to allow files in sudoers.d to not have execute permissions..

Before the change a file with permissions of RW- --- --- would be marked unsafe, but changing it to be RWX --- --- would be marked as safe.

I have verified that a file with minimal permissions still works prior to submission.