### PR TITLE
Use 'ip' command when netstat is not found

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -275,11 +275,17 @@
     # Test        : NETW-3001
     # Description : Find default gateway (route)
     # More info   : BSD: ^default   Linux: 0.0.0.0
-    if [ -n "${NETSTATBINARY}" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
+    PREQS_MET="NO"
+    if [ -n "${IPBINARY}" ]; then PREQS_MET="YES"; fi
+    if [ -n "${NETSTATBINARY}" ]; then PREQS_MET="YES"; fi
     Register --test-no NETW-3001 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Find default gateway (route)"
     if [ $SKIPTEST -eq 0 ]; then
         LogText "Test: Searching default gateway(s)"
-        FIND=$(${NETSTATBINARY} -rn | ${GREPBINARY} -E "^0.0.0.0|default" | ${TRBINARY} -s ' ' | ${CUTBINARY} -d ' ' -f2)
+        if [ -n "${IPBINARY}" ]; then
+            FIND=$(${IPBINARY} route show default | ${TRBINARY} -s ' ' | ${CUTBINARY} -d ' ' -f3)
+        else
+            FIND=$(${NETSTATBINARY} -rn | ${GREPBINARY} -E "^0.0.0.0|default" | ${TRBINARY} -s ' ' | ${CUTBINARY} -d ' ' -f2)
+        fi
         if [ -n "${FIND}" ]; then
             for I in ${FIND}; do
                 LogText "Result: Found default gateway ${I}"


### PR DESCRIPTION
This adds the 'ip' command for retrieving the default gateway, in addition to netstat. The core logic was taken from PR #1528 by xezpeleta.

This resolves #1527.