### PR TITLE
Add support for Summit Linux (ID: cm1sd) in OS detection

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -226,6 +226,12 @@
                             OS_REDHAT_OR_CLONE=1
                             OS_VERSION="Rolling release"
                         ;;
+                      "cm1sd")
+                          LINUX_VERSION="Summit Linux"
+                          OS_NAME="Summit Linux"
+                          OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                          OS_VERSION_FULL=$(grep "^PRETTY_NAME=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                      ;;
                         "cloudlinux")
                             LINUX_VERSION="CloudLinux"
                             OS_NAME="CloudLinux"


### PR DESCRIPTION
Resolves issue #1140 by adding Summit Linux detection based on ID=cm1sd from /etc/os-release.