### PR TITLE
Update osdetection - added qts for qnap

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -455,6 +455,12 @@
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="PureOS"
                         ;;
+                        "qts")
+                            LINUX_VERSION="QNAP"
+                            OS_NAME="QTS"
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                        ;;
                         "raspbian")
                             LINUX_VERSION="Raspbian"
                             LINUX_VERSION_LIKE="Debian"


### PR DESCRIPTION
Added Linux OS QTS (QNAP NAS)

```
# cat /etc/os-release
NAME="QTS"
VERSION="5.2.3 (20250108)"
ID=qts
PRETTY_NAME="QTS 5.2.3 (20250108)"
VERSION_ID="5.2.3"
```