### PR TITLE
[OpenWrt] Fix unknown service manager exception (BOOT-5104)

### DIFF
--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -65,6 +65,7 @@
     # runit           - Used by Artix, Devuan, Dragora and Void
     # systemd         - Common option with more Linux distros implementing it
     # upstart         - Used by Debian/Ubuntu
+    # procd           - Used by OpenWrt
     Register --test-no BOOT-5104 --weight L --network NO --category security --description "Determine service manager"
     if [ ${SKIPTEST} -eq 0 ]; then
         BOOT_LOADER_SEARCHED=1
@@ -113,6 +114,9 @@
                                 ;;
                                 openrc-init)
                                     SERVICE_MANAGER="openrc"
+                                ;;
+                                procd)
+                                    SERVICE_MANAGER="procd"
                                 ;;
                                 *)
                                     CONTAINS_SYSTEMD=$(echo ${SHORTNAME} | ${GREPBINARY} "systemd")

--- a/include/tests_boot_services
+++ b/include/tests_boot_services
@@ -111,7 +111,7 @@
                                 runit)
                                     SERVICE_MANAGER="runit"
                                 ;;
-				openrc-init)
+                                openrc-init)
                                     SERVICE_MANAGER="openrc"
                                 ;;
                                 *)
@@ -280,7 +280,7 @@
         BOOT_LOADER_SEARCHED=1
         CURRENT_BOOT_LOADER=$(${BOOTCTLBINARY} status --no-pager 2>/dev/null | ${AWKBINARY} '/Current Boot Loader/{ getline; print $2 }')
         if [ "${CURRENT_BOOT_LOADER}" = "systemd-boot" ]; then
-	    Display --indent 2 --text "- Checking systemd-boot presence" --result "${STATUS_FOUND}" --color GREEN
+        Display --indent 2 --text "- Checking systemd-boot presence" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: found systemd-boot"
             BOOT_LOADER="systemd-boot"
             BOOT_LOADER_FOUND=1


### PR DESCRIPTION
This is a part of enabling support for OpenWrt, see: https://github.com/CISOfy/lynis/issues/1600.

(more details in commit messages)