### PR TITLE
[OpenWrt] Fix BusyBox ps unsupported flags

### DIFF
--- a/include/tests_databases
+++ b/include/tests_databases
@@ -44,8 +44,7 @@
     # Description : Check if MySQL is being used
     Register --test-no DBS-1804 --weight L --network NO --category security --description "Checking active MySQL process"
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} -E "mariadb|mysqld|mysqld_safe" | ${GREPBINARY} -v "grep")
-        if [ -z "${FIND}" ]; then
+        if ! IsRunning 'mariadb' && ! IsRunning 'mysqld' && ! IsRunning 'mysqld_safe'; then
             if [ ${DEBUG} -eq 1 ]; then Display --indent 2 --text "- MySQL process status" --result "${STATUS_NOT_FOUND}" --color WHITE --debug; fi
             LogText "Result: MySQL process not active"
         else
@@ -248,8 +247,7 @@
     #               reco: recovery (optional)
     Register --test-no DBS-1840 --weight L --network NO --category security --description "Checking active Oracle processes"
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} -E "ora_pmon|ora_smon|tnslsnr" | ${GREPBINARY} -v "grep")
-        if [ -z "${FIND}" ]; then
+        if ! IsRunning 'ora_pmon' && ! IsRunning 'ora_smon' && ! IsRunning 'tnslsnr'; then
             if [ ${DEBUG} -eq 1 ]; then Display --indent 2 --text "- Oracle processes status" --result "${STATUS_NOT_FOUND}" --color WHITE --debug; fi
             LogText "Result: Oracle process(es) not active"
         else

--- a/include/tests_logging
+++ b/include/tests_logging
@@ -45,8 +45,7 @@
     Register --test-no LOGG-2130 --weight L --network NO --category security --description "Check for running syslog daemon"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Searching for a logging daemon"
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} -E "syslogd|syslog-ng|metalog|systemd-journal" | ${GREPBINARY} -v "grep")
-        if [ -z "${FIND}" ]; then
+        if ! IsRunning 'syslogd' && ! IsRunning 'syslog-ng' && ! IsRunning 'metalog' && ! IsRunning 'systemd-journal'; then
             Display --indent 2 --text "- Checking for a running log daemon" --result "${STATUS_WARNING}" --color RED
             LogText "Result: Could not find a syslog daemon like syslog, syslog-ng, rsyslog, metalog, systemd-journal"
             ReportSuggestion "${TEST_NO}" "Check if any syslog daemon is running and correctly configured."

--- a/include/tests_mail_messaging
+++ b/include/tests_mail_messaging
@@ -244,8 +244,12 @@
     Register --test-no MAIL-8814 --weight L --network NO --category security --description "Check postfix process status"
     if [ ${SKIPTEST} -eq 0  ]; then
         LogText "Test: check Postfix status"
+        PSOPTIONS="ax"
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            PSOPTIONS="-w"
+        fi
         # Some other processes also use master, therefore it should include both master and postfix
-        FIND1=$(${PSBINARY} ax | ${GREPBINARY} "master" | ${GREPBINARY} "postfix" | ${GREPBINARY} -v "grep")
+        FIND1=$(${PSBINARY} ${PSOPTIONS} | ${GREPBINARY} "master" | ${GREPBINARY} "postfix" | ${GREPBINARY} -v "grep")
         if [ -n "${FIND1}" ]; then
             LogText "Result: found running Postfix process"
             Display --indent 2 --text "- Postfix status" --result "${STATUS_RUNNING}" --color GREEN
@@ -414,7 +418,11 @@
     Register --test-no MAIL-8920 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check OpenSMTPD status"
     if [ ${SKIPTEST} -eq 0  ]; then
         LogText "Test: check smtpd status"
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} -E "(/smtpd|smtpd: \[priv\]|smtpd: smtp)" | ${GREPBINARY} -v "grep")
+        PSOPTIONS="ax"
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            PSOPTIONS="-w"
+        fi
+        FIND=$(${PSBINARY} ${PSOPTIONS} | ${GREPBINARY} -E "(/smtpd|smtpd: \[priv\]|smtpd: smtp)" | ${GREPBINARY} -v "grep")
         if [ ! "${FIND}" = "" ]; then
             LogText "Result: found running smtpd process"
             Display --indent 2 --text "- OpenSMTPD status" --result "${STATUS_RUNNING}" --color GREEN

--- a/include/tests_memory_processes
+++ b/include/tests_memory_processes
@@ -72,7 +72,9 @@
     if [ ! "${OS}" = "Solaris" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PROC-3612 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check dead or zombie processes"
     if [ ${SKIPTEST} -eq 0 ]; then
-        if [ "${OS}" = "AIX" ]; then
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            FIND=$(${PSBINARY} -w | ${AWKBINARY} '{ if ($4 ~ /Z|X/) print $1 }' | ${XARGSBINARY})
+        elif [ "${OS}" = "AIX" ]; then
             FIND=$(${PSBINARY} -Ae -o pid,stat,comm | ${AWKBINARY} '{ if ($2 ~ /Z|X/) print $1 }' | ${XARGSBINARY})
         else
             FIND=$(${PSBINARY} x -o pid,stat,comm | ${AWKBINARY} '{ if ($2 ~ /Z|X/) print $1 }' | ${XARGSBINARY})
@@ -96,7 +98,9 @@
     if [ ! "${OS}" = "Solaris" ]; then PREQS_MET="YES"; else PREQS_MET="NO"; fi
     Register --test-no PROC-3614 --preqs-met ${PREQS_MET} --weight L --network NO --category security --description "Check heavy IO waiting based processes"
     if [ ${SKIPTEST} -eq 0 ]; then
-        if [ "${OS}" = "AIX" ]; then
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            FIND=$(${PSBINARY} -w | ${AWKBINARY} '{ if ($4 ~ /D/) print $1 }' | ${XARGSBINARY})
+        elif [ "${OS}" = "AIX" ]; then
             FIND=$(${PSBINARY} -Ae -o pid,stat,comm | ${AWKBINARY} '{ if ($2=="D") print $1 }' | ${XARGSBINARY})
         else
             FIND=$(${PSBINARY} x -o pid,stat,comm | ${AWKBINARY} '{ if ($2=="D") print $1 }' | ${XARGSBINARY})

--- a/include/tests_scheduling
+++ b/include/tests_scheduling
@@ -34,7 +34,11 @@
     # Description : Check cron daemon
     Register --test-no SCHD-7702 --weight L --network NO --category security --description "Check status of cron daemon"
     if [ ${SKIPTEST} -eq 0 ]; then
-        FIND=$(${PSBINARY} aux | ${GREPBINARY} -E "( cron$|/cron(d)? )")
+        PSOPTIONS="aux"
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            PSOPTIONS="-w"
+        fi
+        FIND=$(${PSBINARY} ${PSOPTIONS} | ${GREPBINARY} -E "( cron$|/cron(d)? )")
         if IsEmpty "${FIND}"; then
             LogText "Result: no cron daemon found"
         else
@@ -199,7 +203,11 @@
     Register --test-no SCHD-7718 --weight L --network NO --category security --description "Check at users"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Checking atd status"
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} "/atd" | ${GREPBINARY} -v "grep")
+        PSOPTIONS="ax"
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            PSOPTIONS="-w"
+        fi
+        FIND=$(${PSBINARY} ${PSOPTIONS} | ${GREPBINARY} "/atd" | ${GREPBINARY} -v "grep")
         if [ -n "${FIND}" ]; then
             LogText "Result: at daemon active"
             Display --indent 2 --text "- Checking atd status" --result "${STATUS_RUNNING}" --color GREEN

--- a/include/tests_squid
+++ b/include/tests_squid
@@ -41,8 +41,7 @@
         LogText "Test: Searching for a Squid daemon"
         FOUND=0
         # Check running processes
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} -E "(squid|squid3) " | ${GREPBINARY} -v "grep")
-        if [ -n "${FIND}" ]; then
+        if IsRunning 'squid' || IsRunning 'squid3'; then
             SQUID_DAEMON_RUNNING=1
             LogText "Result: Squid daemon is running"
             Display --indent 2 --text "- Checking running Squid daemon" --result "${STATUS_FOUND}" --color GREEN

--- a/include/tests_storage_nfs
+++ b/include/tests_storage_nfs
@@ -93,8 +93,7 @@
     Register --test-no STRG-1920 --weight L --network NO --category security --description "Checking NFS daemon"
     if [ ${SKIPTEST} -eq 0 ]; then
         LogText "Test: Checking running NFS daemon"
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} "nfsd" | ${GREPBINARY} -v "grep")
-        if [ -z "${FIND}" ]; then
+        if ! IsRunning 'nfsd'; then
             LogText "Output: NFS daemon is not running"
             Display --indent 2 --text "- Check running NFS daemon" --result "${STATUS_NOT_FOUND}" --color WHITE
         else

--- a/include/tests_time
+++ b/include/tests_time
@@ -81,10 +81,14 @@
 
         # Check for OpenNTPD, ntpctl comes with a "regular" install
         if [ -n "${NTPCTLBINARY}" ]; then
+            PSOPTIONS="ax"
+            if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+                PSOPTIONS="-w"
+            fi
             # In contrast to timectl, "synchronised: yes" is not grepped.
             # Reason: openntpd syncs only if large time corrections are not required or -s is passed.
             #         This might be not intended by the administrator (-s is NOT the default!)
-            FIND=$(${PSBINARY} ax | ${GREPBINARY} "ntpd: ntp engine" | ${GREPBINARY} -v "grep")
+            FIND=$(${PSBINARY} ${PSOPTIONS} | ${GREPBINARY} "ntpd: ntp engine" | ${GREPBINARY} -v "grep")
             # Status code 0 is when communication over the socket is successful
             if ${NTPCTLBINARY} -s status > /dev/null 2> /dev/null; then
                 FOUND=1; NTP_DAEMON_RUNNING=1; NTP_CONFIG_TYPE_DAEMON=1; NTP_DAEMON="openntpd"
@@ -107,7 +111,11 @@
         # Check running processes (ntpd from ntp.org)
         # As checking by process name is ambiguous (openntpd has the same process name),
         # this check will be skipped if openntpd has been found.
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} "ntpd" | ${GREPBINARY} -v "dntpd" | ${GREPBINARY} -v "ntpd: " | ${GREPBINARY} -v "grep")
+        PSOPTIONS="ax"
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            PSOPTIONS="-w"
+        fi
+        FIND=$(${PSBINARY} ${PSOPTIONS} | ${GREPBINARY} "ntpd" | ${GREPBINARY} -v "dntpd" | ${GREPBINARY} -v "ntpd: " | ${GREPBINARY} -v "grep")
         if [ "${NTP_DAEMON}" != "openntpd" ] && [  -n "${FIND}" ]; then
             FOUND=1; NTPD_RUNNING=1; NTP_DAEMON_RUNNING=1; NTP_CONFIG_TYPE_DAEMON=1
             NTP_DAEMON="ntpd"
@@ -122,7 +130,12 @@
         fi
 
         # Check timedate daemon (systemd)
-        if IsRunning 'systemd-timesyncd'; then
+        PSOPTIONS="ax"
+        if [ "${SHELL_IS_BUSYBOX}" -eq 1 ]; then
+            PSOPTIONS="-w"
+        fi
+        FIND=$(${PSBINARY} ${PSOPTIONS} | ${GREPBINARY} "systemd-timesyncd" | ${GREPBINARY} -v "grep")
+        if [  -n "${FIND}" ]; then
             FOUND=1; NTP_DAEMON_RUNNING=1; NTP_CONFIG_TYPE_DAEMON=1; NTP_DAEMON="systemd-timesyncd"
             Display --indent 2 --text "- NTP daemon found: systemd (timesyncd)" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found running systemd-timesyncd in process list"

--- a/include/tests_time
+++ b/include/tests_time
@@ -122,8 +122,7 @@
         fi
 
         # Check timedate daemon (systemd)
-        FIND=$(${PSBINARY} ax | ${GREPBINARY} "systemd-timesyncd" | ${GREPBINARY} -v "grep")
-        if [  -n "${FIND}" ]; then
+        if IsRunning 'systemd-timesyncd'; then
             FOUND=1; NTP_DAEMON_RUNNING=1; NTP_CONFIG_TYPE_DAEMON=1; NTP_DAEMON="systemd-timesyncd"
             Display --indent 2 --text "- NTP daemon found: systemd (timesyncd)" --result "${STATUS_FOUND}" --color GREEN
             LogText "Result: Found running systemd-timesyncd in process list"


### PR DESCRIPTION
The error `/bin/ps: unrecognized option: a` blocks multiple tests.

This is a part of enabling support for OpenWrt, see: https://github.com/CISOfy/lynis/issues/1600.

(more details in commit messages)