### PR TITLE
Adds openSUSE Tumbleweed-Slowroll to the list of recognisable os

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -397,6 +397,12 @@
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_NAME="openSUSE"
                         ;;
+                        "opensuse-slowroll")
+                            LINUX_VERSION="openSUSE Tumbleweed-Slowroll"
+                            # It's rolling release but has a snapshot version (the date of the snapshot)
+                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                            OS_NAME="openSUSE"
+                        ;;
                         "opensuse-leap")
                             LINUX_VERSION="openSUSE Leap"
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')


### PR DESCRIPTION
This pull request aim to solve the issue of openSUSE Tumbleweed-Slowroll not being recognisable as an os.

[openSUSE Tumbleweed-Slowroll ](https://github.com/CISOfy/lynis/issues/1517)