### PR TITLE
Ignore Debian kernel packages with rc status

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -1378,7 +1378,7 @@ EOF
         if [ "${DPKGBINARY}" ]; then
             TESTED=1
             KERNEL_PKG_NAMES="linux-image-[0-9]|raspberrypi-kernel|pve-kernel-[0-9]|linux-odroid-5422"
-            KERNELS=$(${DPKGBINARY} -l 2> /dev/null | ${GREPBINARY} -E "${KERNEL_PKG_NAMES}" | ${WCBINARY} -l)
+            KERNELS=$(${DPKGBINARY} -l 2> /dev/null | ${GREPBINARY} -E "${KERNEL_PKG_NAMES}" | ${GREPBINARY} -v ^rc | ${WCBINARY} -l)
             if [ ${KERNELS} -eq 0 ]; then
                 LogText "Result: found no kernels from dpkg -l output, which is unexpected"
             elif [ ${KERNELS} -gt 5 ]; then


### PR DESCRIPTION
When 'apt autoremove' is used with kernel packages, they're set to rc which is Remove, leave Conf-files. Ignose those.