### PR TITLE
Add Rocky Linux to EOL DB

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -289,6 +289,12 @@ os:Red Hat Enterprise Linux Server release 6:2020-11-30:1606690800:
 os:Red Hat Enterprise Linux 7:2024-06-30:1719698400:
 os:Red Hat Enterprise Linux 8:2029-05-07:1872799200:
 #
+# Rocky Linux - https://wiki.rockylinux.org/rocky/version/
+#
+os:Rocky Linux 8:2029-05-31:1874872800:
+os:Rocky Linux 9:2032-05-31:1969567200:
+os:Rocky Linux 10:2035-05-31:2064175200:
+#
 # Slackware - https://en.wikipedia.org/wiki/Slackware#Releases
 #
 os:Slackware Linux 8.1:2012-08-01:1343768400:


### PR DESCRIPTION
This PR adds Rocky Linux version 8, 9 and 10 to the EOL DB. 

Information gathered from https://wiki.rockylinux.org/rocky/version/