### PR TITLE
Accept NFLOG as a logging target for iptables.

### DIFF
--- a/include/tests_firewalls
+++ b/include/tests_firewalls
@@ -557,7 +557,7 @@
     if [ ${SKIPTEST} -eq 0 ]; then
         if [ ${IPTABLES_ACTIVE} -eq 1 ]; then
             if [ -n "${IPTABLESSAVEBINARY}" ]; then
-                HAS_LOGGING=$(${IPTABLESSAVEBINARY} | ${GREPBINARY} "\-j LOG")
+                HAS_LOGGING=$(${IPTABLESSAVEBINARY} | ${EGREPBINARY} "\-j (NF)?LOG")
                 if [ -z "${HAS_LOGGING}" ]; then
                     Report "firewall_no_logging[]=iptables"
                 fi


### PR DESCRIPTION
NFLOG allows for more flexible handling of logging from iptables.