### PR TITLE
Add EOL date for Alpine 3.22

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -34,6 +34,7 @@ os:AIX 3:1997-12-31:883562400:
 #
 # Alpine - https://alpinelinux.org/releases/
 #
+os:Alpine 3.22:2027-05-01:1809144000:
 os:Alpine 3.21:2026-11-01:1793487600:
 os:Alpine 3.20:2026-04-01:1774994400:
 os:Alpine 3.19:2025-11-01:1761955200:


### PR DESCRIPTION
Add End of Life date for Alpine 3.22 release 2025-05-30
https://www.alpinelinux.org/posts/Alpine-3.22.0-released.html
https://alpinelinux.org/releases/