### PR TITLE
Add Fedora 43 EOL date

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -79,7 +79,8 @@ os:Debian 10:2022-09-10:1665266400:
 os:Debian 11:2024-07-01:1719784800:
 os:Debian 12:2028-06-30:1845936000:
 #
-# Fedora - https://fedoraproject.org/wiki/End_of_life
+# Fedora - https://fedoraproject.org/wiki/End_of_life and
+#          https://fedorapeople.org/groups/schedule/
 #
 os:Fedora release 25:2017-12-12:1513033200:
 os:Fedora release 26:2018-05-29:1527544800:
@@ -99,6 +100,7 @@ os:Fedora release 39:2024-11-26:1732575600:
 os:Fedora release 40:2025-05-28:1748383200:
 os:Fedora release 41:2025-11-19:1763506800:
 os:Fedora release 42:2026-05-13:1778623200:
+os:Fedora release 43:2026-12-09:1796774400:
 #
 # FreeBSD - https://www.freebsd.org/security/unsupported.html
 #


### PR DESCRIPTION
Fedora 43 recently hit public release last month, and as such I've added it's EOL date to the database. I've also added a link to the Fedora project schedule information site, which lists EOLs for upcoming and currently supported releases (although these are subject to change until the N+2 release is completed).

Thanks,
Elliott