### PR TITLE
Add Debian 13 EOL

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -78,6 +78,7 @@ os:Debian 9:2022-06-30:1656547200:
 os:Debian 10:2022-09-10:1665266400:
 os:Debian 11:2024-07-01:1719784800:
 os:Debian 12:2028-06-30:1845936000:
+os:Debian 13:2030-06-30:1909008000:
 #
 # Fedora - https://fedoraproject.org/wiki/End_of_life
 #


### PR DESCRIPTION
Hello,
Debian 13 was release on August 9th 2025, submitting this PR to add Debian 13 EOL to the software-eol.db
Debian 13 EOL info available on https://wiki.debian.org/LTS
Cheers,
Skorium