### PR TITLE
Add openSUSE Leap to EOL DB

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -325,10 +325,21 @@ os:Slackware Linux 14.1:2024-01-01:1704063600:
 os:Slackware Linux 14.2:2024-01-01:1704063600:
 os:Slackware Linux 15.0::-1:
 #
-# SuSE - https://www.suse.com/lifecycle/
+# SUSE - https://www.suse.com/lifecycle/
 #
 os:SUSE Linux Enterprise Server 12:2024-10-31:1730329200:
 os:SUSE Linux Enterprise Server 15:2028-07-31:1848607200:
+#
+# openSUSE - https://en.opensuse.org/Lifetime
+#
+os:openSUSE Leap 15.0:2019-12-03:1575327600:
+os:openSUSE Leap 15.1:2021-02-02:1612220400:
+os:openSUSE Leap 15.2:2022-01-04:1641250800:
+os:openSUSE Leap 15.3:2022-12-31:1672441200:
+os:openSUSE Leap 15.4:2023-12-31:1703977200:
+os:openSUSE Leap 15.5:2024-12-31:1735599600:
+os:openSUSE Leap 15.6:2026-04-30:1777500000:
+os:openSUSE Leap 16.0:2027-10-31:1824933600:
 #
 # Ubuntu - https://wiki.ubuntu.com/Kernel/LTSEnablementStack and
 #          https://wiki.ubuntu.com/Releases


### PR DESCRIPTION
This PR adds openSUSE Leap version 15 and 16 to the EOL DB.

Information gathered from https://en.opensuse.org/Lifetime