### PR TITLE
Fix OS detection for CachyOS (ID=cachyos)

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -223,7 +223,7 @@
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
-                        "CachyOS")
+                        "cachyos")
                             LINUX_VERSION="CachyOS"
                             OS_FULLNAME="CachyOS"
                             OS_VERSION="Rolling release"


### PR DESCRIPTION
Lynis currently throws "Unknown OS found in /etc/os-release" on CachyOS.

Cause:
`/etc/os-release` defines `ID=cachyos` (all lowercase), but the osdetection
case block uses `"CachyOS")`, which does not match due to case sensitivity.

Fix:
Adjusted the case label to `"cachyos")` to correctly match the ID value.
Verified locally with:

    sudo ./lynis audit system --usecwd

Resulting output includes:
    Operating system name:     CachyOS
    Operating system version:  Rolling release

This resolves the OS detection exception.
<img width="381" height="137" alt="Screenshot_20251116_193048" src="https://github.com/user-attachments/assets/4f878b5b-8244-4776-b3a3-9bf99171a922" />
