### PR TITLE
Add CachyOS to OS end-of-life database

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -67,6 +67,10 @@ os:Amazon Linux:2023-12-31:1703980800:
 #
 os:Arch Linux::-1:
 #
+# CachyOS - https://cachyos.org/
+#
+os:CachyOS::-1:
+#
 # CentOS
 #
 os:CentOS release 5:2017-03-31:1490911200:


### PR DESCRIPTION
CachyOS is an Arch-based rolling-release distribution (ID=cachyos, ID_LIKE=arch).

Arch Linux is already represented in db/software-eol.db with a -1 EOL marker:

    os:Arch Linux::-1:

This patch adds a similar entry for CachyOS:

    os:CachyOS::-1:

Because CachyOS is rolling, there is no fixed EOL date. Using -1 follows the
existing pattern for Arch and avoids the Lynis notice:

    "No OS entry was found in the end-of-life database"

Tested locally with:

    sudo ./lynis audit system --usecwd

and the notice is resolved.
<img width="387" height="165" alt="Screenshot_20251116_195430" src="https://github.com/user-attachments/assets/6eb9f4ab-b111-482a-85e0-66835e535f65" />
