### PR TITLE
Update software-eol.db

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -112,7 +112,7 @@ os:Fedora release 39:2024-11-26:1732575600:
 os:Fedora release 40:2025-05-28:1748383200:
 os:Fedora release 41:2025-11-19:1763506800:
 os:Fedora release 42:2026-05-13:1778623200:
-os:Fedora release 43:2026-12-09:1796774400:
+os:Fedora release 43:2026-12-02:1761865200:
 #
 # FreeBSD - https://www.freebsd.org/security/unsupported.html
 #


### PR DESCRIPTION
Add Fedora 43 EOL Date Details:

Operating System: Fedora 43

EOL Date: 2026-12-02

Epoch Timestamp: 1761865200

Source: /etc/os-release file, field SUPPORT_END