### PR TITLE
Update RHEL 8 EOL and add RHEL 9 and 10 dates to software-eol.db

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -301,7 +301,9 @@ os:OpenBSD 7.6:2025-10-31:1761865200:
 #
 os:Red Hat Enterprise Linux Server release 6:2020-11-30:1606690800:
 os:Red Hat Enterprise Linux 7:2024-06-30:1719698400:
-os:Red Hat Enterprise Linux 8:2029-05-07:1872799200:
+os:Red Hat Enterprise Linux 8:2029-05-31:1874872800:
+os:Red Hat Enterprise Linux 9:2032-05-31:1969567200:
+os:Red Hat Enterprise Linux 10:2035-05-31:2064175200:
 #
 # Rocky Linux - https://wiki.rockylinux.org/rocky/version/
 #


### PR DESCRIPTION
While running lynis on my RHEL 10.1 laptop recently and noticed the following message: 

"Notice: No OS entry was found in the end-of-life database"

After inspecting software-eol.db, I found that RHEL 9 and 10 entries were missing entirely, so this PR adds their corresponding EOL dates. While adding the entries for RHEL 9 and 10, I also noticed that the entry for RHEL 8 did not match the Red Hat offical policy already listed for AlmaLinux/Rocky Linux 8. So, I have changed it to match.