### PR TITLE
nginx parser fails on commented lines

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -2247,7 +2247,7 @@
         FIND=$(sed 's/ /:space:/g' ${TMP_NGINX_FILE})
         DEPTH=0
         for I in ${FIND}; do
-            I=$(echo ${I} | sed 's/:space:/ /g' | sed 's/;$//' | sed 's/ #.*$//')
+            I=$(echo ${I} | sed 's/:space:/ /g' | sed 's/ #.*$//' | sed 's/;$//')
             OPTION=$(echo ${I} | awk '{ print $1 }')
             # Use quotes here to prevent wildcard expansion
             VALUE=$(echo "${I}"| cut -d' ' -f2-)


### PR DESCRIPTION
on lines like

	ssl_prefer_server_ciphers on; # Force server cipher order.

the result of the parser would keep the ';', returning 'on;' which in turn would lead to a mismatch of

"on" != "on;"

This was caused by an incorrect order of the sed statements. Now first the comment is removed and afterwards the trailing ; gets removed.