### PR TITLE
Feat: added deb822 support for Debian 12,13, Ubuntu 24 support onward

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -1080,8 +1080,17 @@ EOF
                 fi
             fi
             if [ -d /etc/apt/sources.list.d ]; then
-                LogText "Searching for security.debian.org/security.ubuntu.com or security repositories in /etc/apt/sources.list.d directory"
-                FIND=$(${GREPBINARY} -E -r "security.debian.org|security.ubuntu.com|security/? " /etc/apt/sources.list.d | ${GREPBINARY} -v '#' | ${SEDBINARY} 's/ /!space!/g')
+                LogText "Searching for Sources List format : deb822 (newer) or older"
+                FORMATLIST=$(${GREPBINARY} -E -r -- "^Types: deb" /etc/apt/sources.list.d/*.sources | ${GREPBINARY} -v '#' | ${SEDBINARY} 's/ /!space!/g')
+                if [ -n "$FORMATLIST" ]; then
+                    LogText "Sources is written in deb822"
+                    LogText "Searching for debian-security/security.ubuntu.com or security repositories in /etc/apt/sources.list.d directory"
+                    FIND=$(${GREPBINARY} -E -r "debian-security|security.ubuntu.com|security/? " /etc/apt/sources.list.d | ${GREPBINARY} -v '#' | ${SEDBINARY} 's/ /!space!/g')
+                else
+                    LogText "Searching for security.debian.org/security.ubuntu.com or security repositories in /etc/apt/sources.list.d directory"
+                    FIND=$(${GREPBINARY} -E -r "security.debian.org|security.ubuntu.com|security/? " /etc/apt/sources.list.d | ${GREPBINARY} -v '#' | ${SEDBINARY} 's/ /!space!/g')
+                fi
+
                 if [ -n "${FIND}" ]; then
                     FOUND=1
                     Display --indent 2 --text "- Checking security repository in sources.list.d directory" --result "${STATUS_OK}" --color GREEN


### PR DESCRIPTION
Fix #1636
PKGS-7388 issue on detecting security repository for APT.

Added deb822 format support in APT sources list.
Used on Debian 12,13, Ubuntu 24 and onward.

Now search for "^Types: deb" in /etc/apt/sources.list.d/*.sources. It's the declaration model for deb packages repository, so should be present in every declaration of repo.
Could look for "*.sources" files vs "*.list" files also (newer format vs older format).

Ubuntu did not change the security url ("security.ubuntu.com"), the search was still working (Ubuntu 24.04 clo
ud image).
Debian did ("security.debian.org" -> "debian-security"). Tested KO on Debian 12 and Debian 13.

Log before change (failing on Debian 12):

<img width="1284" height="118" alt="2025-12-19_10-59" src="https://github.com/user-attachments/assets/8abf4e9e-aa69-4615-a7f0-4c1557ac352e" />

Log after change:

<img width="1091" height="191" alt="2025-12-19_11-01" src="https://github.com/user-attachments/assets/9673d475-4a9a-4637-a145-fca0bfa0cd09" />

Tested on Debian 12, 13 and Ubuntu 24.04 all cloud images.

PS: This is my first PR, hope I'm doing okay. Feel free to give feedback :)