### PR TITLE
Add Alpine 3.23 EOL date

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -40,6 +40,7 @@ os:AlmaLinux release 10:2035-05-31:2064175200:
 #
 # Alpine - https://alpinelinux.org/releases/
 #
+os:Alpine 3.23:2027-11-01:1825027200:
 os:Alpine 3.22:2027-05-01:1809144000:
 os:Alpine 3.21:2026-11-01:1793487600:
 os:Alpine 3.20:2026-04-01:1774994400:


### PR DESCRIPTION
<img width="1913" height="380" alt="image" src="https://github.com/user-attachments/assets/7ec7922d-ed02-4798-aa25-a7a05928f708" />
I have noticed that there is no EOL date for new Alpine Linux release.