### PR TITLE
Add EOL entry for macOS Tahoe (26.2)

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -205,6 +205,7 @@ os:macOS Monterey \(12.7.6\):2024-09-16:1726444800:
 os:macOS Ventura \(13.7.2\)::-1:
 os:macOS Sonoma \(14.7.2\)::-1:
 os:macOS Sequoia \(15.2\)::-1:
+os:macOS Tahoe \(26.2\)::-1:
 #
 # Mageia - https://www.mageia.org/en/support/
 #


### PR DESCRIPTION
Following Apple's new versioning scheme introduced in 2025, macOS Tahoe is identified as version 26.

My system scan reports version 26.2 with Darwin Kernel 25.2.0. 

This PR adds the corresponding entry to `software-eol.db` to fix the missing EOL warning.

**Note:** *The version number skips from 15 to 26 to align with the release year 2026.*

```
  ---------------------------------------------------
  Program version:           3.1.6
  Operating system:          macOS
  Operating system name:     macOS
  Operating system version:  26.2
  End-of-life:               INCONNU
  Kernel version:            25.2.0
  Hardware platform:         arm64
  Hostname:                  ***
  ---------------------------------------------------
```