### PR TITLE
Add better NixOS detection

### DIFF
--- a/include/osdetection
+++ b/include/osdetection
@@ -382,12 +382,6 @@
                             OS_REDHAT_OR_CLONE=1
                             OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
-                        "nixos")
-                            LINUX_VERSION="NixOS"
-                            OS_NAME="NixOS"
-                            OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
-                            OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
-                        ;;
                         "ol")
                             LINUX_VERSION="Oracle Linux"
                             OS_NAME="Oracle Linux"
@@ -539,7 +533,7 @@
                             OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
                         ;;
                         *)
-                            ReportException "OS Detection" "Unknown OS found in /etc/os-release - Please create an issue on GitHub and share the contents (cat /etc/os-release): ${PROGRAM_SOURCE}"
+                            ETC_RELEASE_DETECT_FAILED=1
                         ;;
                     esac
                 fi
@@ -701,6 +695,15 @@
 
             fi
 
+            # NixOS
+            if [ -e "/run/current-system" ]; then
+                LINUX_VERSION="NixOS"
+                OS_NAME="NixOS"
+                OS_VERSION=$(grep "^VERSION_ID=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                OS_VERSION_FULL=$(grep "^VERSION=" /etc/os-release | awk -F= '{print $2}' | tr -d '"')
+                ETC_RELEASE_DETECT_FAILED=0
+            fi
+
             # PCLinuxOS
             if [ -f /etc/pclinuxos-release ]; then
                 FIND=$(grep "^PCLinuxOS" /etc/pclinuxos-release)
@@ -763,6 +766,9 @@
             # If Linux version (full name) is unknown, use uname value
             if [ "${OS_FULLNAME}" = "" ]; then OS_FULLNAME=$(uname -s -r); fi
             SYSCTL_READKEY="sysctl -n"
+            if [ "${ETC_RELEASE_DETECT_FAILED}" = "1" ]; then
+                ReportException "OS Detection" "Unknown OS found in /etc/os-release - Please create an issue on GitHub and share the contents (cat /etc/os-release): ${PROGRAM_SOURCE}"
+            fi
         ;;
 
         # NetBSD


### PR DESCRIPTION
Because it's funny, I have my /etc/os-release customized to use a `NAME` that's not `NixOS`. This is something that's easy to do by simply setting the options that control the stuff in os-release:

https://github.com/NixOS/nixpkgs/blob/527be1432109cfaf305987865bc17cc908e8e77a/nixos/modules/misc/version.nix#L121-L161

In fact, there's an entire library dedicated to making silly customizations like this: https://github.com/yunfachi/denix

This changes the NixOS detection code to look for /run/current-system, which is present on all NixOS systems regardless of configuration, and is importantly _not_ present when using Nix on non-NixOS.