### PR TITLE
Add end-of-life date for Ubuntu 26.04

### DIFF
--- a/db/software-eol.db
+++ b/db/software-eol.db
@@ -374,6 +374,7 @@ os:Ubuntu 24.04:2029-06-01:1874959200:
 os:Ubuntu 24.10:2025-07-01:1751320800:
 os:Ubuntu 25.04:2026-01-01:1767222000:
 os:Ubuntu 25.10:2026-07-01:1782838800:
+os:Ubuntu 26.04:2031-04-01:1932760800:
 #
 # OmniosCE - https://omniosce.org/releasenotes.html
 #


### PR DESCRIPTION
This pull request adds a new entry to the software end-of-life database for a new Ubuntu LTS release.

Operating system database update:

* Added `Ubuntu 26.04` with its end-of-life date (`2031-04-01`) to the `db/software-eol.db` file.