### PR TITLE
Fix NETW-2706: Update DNSSEC detection logic for modern resolvectl

### DIFF
--- a/include/tests_networking
+++ b/include/tests_networking
@@ -244,7 +244,7 @@
     if [ -n "${RESOLVECTLBINARY}" ]; then
         PREQS_MET="YES"
         RESOLVE_CMD="${RESOLVECTLBINARY}"
-        RESOLVE_CMD_PARAM="statistics"
+        RESOLVE_CMD_PARAM="status"
     elif [ -n "$(command -v systemd-resolve 2> /dev/null)" ]; then
         PREQS_MET="YES"
         RESOLVE_CMD="$(command -v systemd-resolve 2> /dev/null)"
@@ -255,7 +255,8 @@
     Register --test-no NETW-2706 --preqs-met "${PREQS_MET}" --weight L --network YES --category security --description "Check systemd-resolved and upstream DNSSEC status"
     if [ ${SKIPTEST} -eq 0 ]; then
         SKIP=0
-        DNSSEC_STATUS=$(${RESOLVE_CMD} ${RESOLVE_CMD_PARAM} 2> /dev/null | ${AWKBINARY} -F ":" '/DNSSEC supported/ { print $2 }' | ${TRBINARY} -d ' ')
+        DNSSEC_STATUS=$(${RESOLVE_CMD} ${RESOLVE_CMD_PARAM} 2> /dev/null | ${GREPBINARY} -o 'DNSSEC=[^ ]*' | ${CUTBINARY} -d'=' -f2 | ${CUTBINARY} -d'/' -f1 | head -n 1)
+LogText ${DNSSEC_STATUS}
         if [ "${DNSSEC_STATUS}" = "yes" ]; then
             Display --indent 4 --text "- DNSSEC supported (systemd-resolved)" --result "${STATUS_YES}" --color GREEN
             LogText "Result: DNSSEC supported by systemd-resolved and upstream DNS servers"


### PR DESCRIPTION
<section>
  <h2>summary</h2>
  <p>this pr improves the dnssec detection logic in the `netw-2706` test to support newer versions of `systemd-resolved` (systemd 250 and later).</p>
</section>
<section>
  <h2>problem</h2>
  <p>the current implementation relies on `resolvectl --statistics`, which only provides statistical counters and does not reliably indicate whether dnssec is active for the current network interfaces. furthermore, the previous `awk` parsing logic fails on newer output formats like `dnssec=yes/supported`.</p>
</section>
<section>
  <h2>changes</h2>
  <ul>
    <li>changed `resolve_cmd_param` from `--statistics` to `status` to get the actual operational status.</li>
    <li>updated the parsing logic using `grep` and `cut` to correctly extract the status even when the output includes additional info (e.g., `yes/supported`).</li>
    <li>added `head -n 1` to ensure a consistent single-line result when multiple interfaces are active.</li>
  </ul>
</section>
<section>
  <h2>note for maintainers</h2>
  <p>i am a japanese user and am using a machine translator to write this. i apologize for any unnatural phrasing. i have verified this fix on my local environment, and it now correctly returns `yes`.</p>
</section>
<section>
  <h2>verified result</h2>
  <dl>
    <dt><b>command:</b></dt>&nbsp;<dd><pre><code>resolvectl status | grep -o 'DNSSEC=[^ ]*' | cut -d'=' -f2 | cut -d'/' -f1 | head -n 1</code></pre></dd>
    <dt><b>Output:</b></dt>&nbsp;<dd>yes</dd>
  </dl>
</section>
<aside>
  <p>miikun95, miikun95@miikun95.net</p>
</aside>