### PR TITLE
Update parameters, spelling nit

### DIFF
--- a/include/parameters
+++ b/include/parameters
@@ -336,7 +336,7 @@
             ;;
 
             # Strip the colors which aren't clearly visible on light backgrounds
-            --reverse-colors | --reverse-colour)
+            --reverse-colors | --reverse-colours)
                 BLUE="${NORMAL}";
                 SECTION="${NORMAL}";
                 NOTICE="${NORMAL}";


### PR DESCRIPTION
The option in the --help output is named "--reverse-colours" with an s at the end, like the american spelling "--reverse-colors", but the parameters file had it without the trailing s, meaning the parser would not allow the option listed in the --help output.