### PR TITLE
Strip quotes from CRON_CHECK in debsums test (PKGS-7370)

### DIFF
--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -700,7 +700,7 @@ EOF
             if [ ${COUNT} -gt 0 ]; then
                 CRON_CHECK=""
                 if [ -f ${ROOTDIR}etc/default/debsums ]; then
-                    CRON_CHECK=$(${GREPBINARY} CRON_CHECK /etc/default/debsums|${AWKBINARY} -F "=" '{print $2}')
+                    CRON_CHECK=$(${GREPBINARY} CRON_CHECK /etc/default/debsums|${AWKBINARY} -F "=" '{print $2}'|tr -d '"'\''')
                 fi
                 if [ "${CRON_CHECK}" = "daily" ] || [ "${CRON_CHECK}" = "weekly" ] || [ "${CRON_CHECK}" = "monthly" ]; then
                     LogText "Result: Cron job is configured for debsums utility."

--- a/include/tests_ports_packages
+++ b/include/tests_ports_packages
@@ -700,7 +700,7 @@ EOF
             if [ ${COUNT} -gt 0 ]; then
                 CRON_CHECK=""
                 if [ -f ${ROOTDIR}etc/default/debsums ]; then
-                    CRON_CHECK=$(${GREPBINARY} CRON_CHECK /etc/default/debsums|${AWKBINARY} -F "=" '{print $2}'|tr -d '"'\''')
+                    CRON_CHECK=$(${GREPBINARY} CRON_CHECK /etc/default/debsums | ${AWKBINARY} -F "=" '{print $2}' | ${TRBINARY} -d '"'\''')
                 fi
                 if [ "${CRON_CHECK}" = "daily" ] || [ "${CRON_CHECK}" = "weekly" ] || [ "${CRON_CHECK}" = "monthly" ]; then
                     LogText "Result: Cron job is configured for debsums utility."


### PR DESCRIPTION
<section>
  <h2>Description</h2>
  <p>Fixes a false positive in the `PKGS-7370` test for `debsums`. </p>
  <br>
  <p>Currently, if `CRON_CHECK="daily"` (or with single quotes) is defined in `/etc/default/debsums`, Lynis fails to parse the value correctly due to the quotes and falsely reports that the cron job is not configured.</p>
  <br>
</section>
<section>
  <h2>Changes</h2>
  <p>Added `tr -d '"'\''` to strip single and double quotes from the parsed `CRON_CHECK` value, aligning with standard shell configuration styles.</p>
</section>
<aside>miikun95, miikun95@miikun95.net</aside>