### PR TITLE
Fix machine ID detection: inverted test kept MACHINEID always empty

### DIFF
--- a/include/functions
+++ b/include/functions
@@ -1169,7 +1169,7 @@
         sMACHINEIDFILE="/etc/machine-id"
         if [ -f ${sMACHINEIDFILE} ]; then
             FIND=$(head -n 1 ${sMACHINEIDFILE} | grep "^[a-f0-9]")
-            if [ "${FIND}" = "" ]; then
+            if [ -n "${FIND}" ]; then
                 MACHINEID="${FIND}"
             fi
         fi


### PR DESCRIPTION
The empty-check on the grep result in `GetHostID` is inverted: `MACHINEID` is assigned only when `FIND` is *empty* — assigning the empty string — so it has never been set since the code was introduced (d99dbc74, 2014).

Impact:
- the `machineid=` report field is never populated
- `lynis show hostids` always prints an empty `machineid`
- the machine-id fallback for `hostid2` generation never triggers, so a host with no SSH host keys and no usable MAC address (e.g. lynis running inside a systemd sandbox with `PrivateNetwork=yes`) ends up with **no host identifier at all**, and every run logs the `GetHostID` exceptions

That last scenario is how this surfaced: a hardened `lynis.service` produced reports with three `exception_event[]=GetHostID|...` entries and no `hostid`/`hostid2`.

Fix is a one-liner (`[ -n "${FIND}" ]`). Verified on Debian 13 with `lynis show hostids`: before → `machineid=` and `hostid2=` empty; after → both populated (hostid2 = SHA256 of the machine-id, as intended).