### PR TITLE
AUTH-9230: skip SHA_CRYPT rounds check when ENCRYPT_METHOD is YESCRYPT

### DIFF
--- a/include/tests_authentication
+++ b/include/tests_authentication
@@ -358,48 +358,55 @@
         PREQS_MET="YES"
     fi
     Register --test-no AUTH-9230 --preqs-met ${PREQS_MET} --root-only NO --weight L --network NO --category security --description "Check password hashing rounds"
-    if [ ${SKIPTEST} -eq 0 ]; then
-        SHA_CRYPT_MIN_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MIN_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MIN_ROUNDS") { print $2 } }')
-        SHA_CRYPT_MAX_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MAX_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MAX_ROUNDS") { print $2 } }')
-        SHA_CRYPT_ROUNDS=0
-
-        if [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
-            if [ ${SHA_CRYPT_MIN_ROUNDS_FIND} -lt ${SHA_CRYPT_MAX_ROUNDS_FIND} ]; then
-                SHA_CRYPT_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
-            else
-                SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
-            fi
-        elif [ -z "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
-            SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
-        elif [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -z "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
-            SHA_CRYPT_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
-        else
-            SHA_CRYPT_ROUNDS=0
-        fi
-
-        LogText "Test: Checking SHA_CRYPT_{MIN,MAX}_ROUNDS option in ${ROOTDIR}etc/login.defs"
-        if [ ${SHA_CRYPT_ROUNDS} -eq 0 ]; then
-            LogText "Result: number of password hashing rounds is not configured"
-            Display --indent 2 --text "- Checking password hashing rounds" --result "${STATUS_DISABLED}" --color YELLOW
-            ReportSuggestion "${TEST_NO}" "Configure password hashing rounds in /etc/login.defs"
-            AddHP 0 2
-        fi
-
-        if [ -n "${SHA_CRYPT_ROUNDS}" ] && [ ${SHA_CRYPT_ROUNDS} -gt 0 ]; then
-            if [ ${SHA_CRYPT_ROUNDS} -lt 5000 ]; then
-                LogText "Result: low number of password hashing rounds found: ${SHA_CRYPT_ROUNDS}"
-                Display --indent 2 --text "- Password hashing rounds (minimum)"  --result "${STATUS_SUGGESTION}" --color YELLOW
-                AddHP 1 2
-            else
-                LogText "Result: number of password hashing rounds is ${SHA_CRYPT_ROUNDS}"
-                Display --indent 2 --text "- Password hashing rounds (minimum)" --result CONFIGURED --color GREEN
-                AddHP 2 2
-            fi
-        fi
-    fi
+    
 #
 #################################################################################
 #
+    if [ ${SKIPTEST} -eq 0 ]; then
+        ENCRYPT_METHOD_FIND=$(${GREPBINARY} "^ENCRYPT_METHOD" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="ENCRYPT_METHOD") { print toupper($2) } }')
+        if [ "${ENCRYPT_METHOD_FIND}" = "YESCRYPT" ]; then
+            LogText "Result: ENCRYPT_METHOD is YESCRYPT, SHA_CRYPT_MIN_ROUNDS/MAX_ROUNDS do not apply, skipping test"
+        else
+            SHA_CRYPT_MIN_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MIN_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MIN_ROUNDS") { print $2 } }')
+            SHA_CRYPT_MAX_ROUNDS_FIND=$(${GREPBINARY} "^SHA_CRYPT_MAX_ROUNDS" ${ROOTDIR}etc/login.defs | ${AWKBINARY} '{ if ($1=="SHA_CRYPT_MAX_ROUNDS") { print $2 } }')
+            SHA_CRYPT_ROUNDS=0
+
+            if [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
+                if [ ${SHA_CRYPT_MIN_ROUNDS_FIND} -lt ${SHA_CRYPT_MAX_ROUNDS_FIND} ]; then
+                    SHA_CRYPT_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
+                else
+                    SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
+                fi
+            elif [ -z "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -n "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
+                SHA_CRYPT_ROUNDS=${SHA_CRYPT_MAX_ROUNDS_FIND}
+            elif [ -n "${SHA_CRYPT_MIN_ROUNDS_FIND}" -a -z "${SHA_CRYPT_MAX_ROUNDS_FIND}" ]; then
+                SHA_CRYPT_ROUNDS=${SHA_CRYPT_MIN_ROUNDS_FIND}
+            else
+                SHA_CRYPT_ROUNDS=0
+            fi
+
+            LogText "Test: Checking SHA_CRYPT_{MIN,MAX}_ROUNDS option in ${ROOTDIR}etc/login.defs"
+            if [ ${SHA_CRYPT_ROUNDS} -eq 0 ]; then
+                LogText "Result: number of password hashing rounds is not configured"
+                Display --indent 2 --text "- Checking password hashing rounds" --result "${STATUS_DISABLED}" --color YELLOW
+                ReportSuggestion "${TEST_NO}" "Configure password hashing rounds in /etc/login.defs"
+                AddHP 0 2
+            fi
+
+            if [ -n "${SHA_CRYPT_ROUNDS}" ] && [ ${SHA_CRYPT_ROUNDS} -gt 0 ]; then
+                if [ ${SHA_CRYPT_ROUNDS} -lt 5000 ]; then
+                    LogText "Result: low number of password hashing rounds found: ${SHA_CRYPT_ROUNDS}"
+                    Display --indent 2 --text "- Password hashing rounds (minimum)" --result "${STATUS_SUGGESTION}" --color YELLOW
+                    AddHP 1 2
+                else
+                    LogText "Result: number of password hashing rounds is ${SHA_CRYPT_ROUNDS}"
+                    Display --indent 2 --text "- Password hashing rounds (minimum)" --result CONFIGURED --color GREEN
+                    AddHP 2 2
+                fi
+            fi
+        fi
+    fi
+    
     # Test        : AUTH-9234
     # Description : Query user accounts
     # Notes       : AIX: 100+


### PR DESCRIPTION
Problem
AUTH-9230 checks SHA_CRYPT_MIN_ROUNDS/SHA_CRYPT_MAX_ROUNDS in
/etc/login.defs, but these settings only apply when ENCRYPT_METHOD
is SHA256 or SHA512. On systems where ENCRYPT_METHOD is set to
YESCRYPT (the default on Fedora 35+, Debian 11+, Arch Linux, and
Ubuntu 22.04+), these variables are correctly absent, but the test
still reports password hashing rounds as unconfigured and issues a
suggestion; a false positive.

Fix
Adds a check on ENCRYPT_METHOD in /etc/login.defs. When it's set to
YESCRYPT, the SHA_CRYPT rounds check is skipped entirely rather than
reporting a false "disabled" result.

Scope
This addresses the yescrypt false-positive described in https://github.com/CISOfy/lynis/issues/1352, but
not the separate question raised in that issue about whether
SHA_CRYPT_MIN_ROUNDS is actually honoured on some distros.
This PR does not check YESCRYPT_COST_FACTOR (yescrypt's tuning
parameter). Whether that needs its own check is a separate question.

Testing
Verified locally with lynis audit system --tests AUTH-9230 --debug
against a login.defs with ENCRYPT_METHOD YESCRYPT (test now skips
correctly).

Recreates #1772 